### PR TITLE
Fix installation on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ From your local copy directory, use the following comands.
 LICENSE
 =======================
 
-“pynwb” Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+"pynwb" Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
  
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
  
@@ -52,7 +52,7 @@ You are under no obligation whatsoever to provide any bug fixes, patches, or upg
 COPYRIGHT
 =======================
 
-“pynwb” Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+"pynwb" Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
  
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships ce at  IPO@lbl.gov.
  

--- a/license.txt
+++ b/license.txt
@@ -1,4 +1,4 @@
-“pynwb” Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
+"pynwb" Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
  
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
  


### PR DESCRIPTION
The installation on a german windows x64 currently fails with

```
(C:\ProgramData\Anaconda3) E:\projekte\pynwb>python setup.py install
Traceback (most recent call last):
  File "setup.py", line 11, in <module>
    readme = f.read()
  File "C:\ProgramData\Anaconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 958: char
acter maps to <undefined>
```

with Python 3.6.1 :: Anaconda 4.4.0 (64-bit).

Replace the fancy typographical quotes with ASCII ones to allow
installation.

Signed-off-by: Thomas Braun <thomas.braun@byte-physics.de>