### PR TITLE
__is_float: Make np.float128 optional

### DIFF
--- a/src/form/utils.py
+++ b/src/form/utils.py
@@ -49,7 +49,10 @@ def __is_int(value):
     return any(isinstance(value, i) for i in (int, np.int8, np.int16, np.int32, np.int64))
 
 def __is_float(value):
-    return any(isinstance(value, i) for i in (float, np.float16, np.float32, np.float64, np.float128))
+    if hasattr(np, 'float128'):
+        return any(isinstance(value, i) for i in (float, np.float16, np.float32, np.float64, np.float128))
+    else:
+        return any(isinstance(value, i) for i in (float, np.float16, np.float32, np.float64))
 
 def __format_type(argtype):
     if isinstance(argtype, str):


### PR DESCRIPTION
It is not available on Python 3.6.1 :: Anaconda 4.4.0 (64-bit) (Windows 7 x64).