### PR TITLE
Update README.rst to fix installation on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,8 +44,7 @@ From your local copy directory, use the following comands.
 LICENSE
 =======================
 
-“pynwb” Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
-
+"pynwb" Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
 
 (1) Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
@@ -61,8 +60,7 @@ You are under no obligation whatsoever to provide any bug fixes, patches, or upg
 COPYRIGHT
 =======================
 
-“pynwb” Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
-
+"pynwb" Copyright (c) 2017, The Regents of the University of California, through Lawrence Berkeley National Laboratory (subject to receipt of any required approvals from the U.S. Dept. of Energy).  All rights reserved.
 If you have questions about your rights to use or distribute this software, please contact Berkeley Lab's Innovation & Partnerships ce at  IPO@lbl.gov.
 
 NOTICE.  This Software was developed under funding from the U.S. Department of Energy and the U.S. Government consequently retains certain rights. As such, the U.S. Government has been granted for itself and others acting on its behalf a paid-up, nonexclusive, irrevocable, worldwide license in the Software to reproduce, distribute copies to the public, prepare derivative works, and perform publicly and display publicly, and to permit other to do so.


### PR DESCRIPTION
The installation on a german windows x64 currently fails with

```
(C:\ProgramData\Anaconda3) E:\projekte\pynwb>python setup.py install
Traceback (most recent call last):
  File "setup.py", line 11, in <module>
    readme = f.read()
  File "C:\ProgramData\Anaconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 958: char
acter maps to <undefined>
```

with Python 3.6.1 :: Anaconda 4.4.0 (64-bit).

Replace the fancy typographical quotes with ASCII ones to allow
installation.

Signed-off-by: Thomas Braun <thomas.braun@byte-physics.de>