### PR TITLE
Build source distribution and wheels with CIs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,3 +36,11 @@ jobs:
              pip3 install -e .
              coverage run --source src test.py
              codecov
+       - run:
+           name: Test installation from a wheel for Python 2.7
+           command: |
+             tox -e py27 recreate --installpkg dist/pynwb-0.1-py2-none-any.whl
+       - run:
+           name: Test installation from a wheel for Python 3.6
+           command: |
+             tox -e py36 recreate --installpkg dist/pynwb-0.1-py3-none-any.whl

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ python:
   - '3.6'
 
 before_install:
+  - brew update
   - brew outdated pyenv || brew upgrade pyenv
   - pyenv install 3.6.2
   - pyenv global 3.6.2
@@ -23,6 +24,8 @@ install:
 script:
   - tox -e py27
   - tox -e py36
+  - tox -e py27 recreate --installpkg dist/pynwb-0.1-py2-none-any.whl
+  - tox -e py36 recreate --installpkg dist/pynwb-0.1-py3-none-any.whl
 
 after_success:
   - pip install -r requirements.txt

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,10 @@ environment:
   matrix:
     - PYTHON_VERSION: 2.7
       MINICONDA: C:\Miniconda-x64
+      WHEEL: pynwb-0.1-py2-none-any.whl
     - PYTHON_VERSION: 3.6
       MINICONDA: C:\Miniconda36-x64
+      WHEEL: pynwb-0.1-py3-none-any.whl
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
@@ -23,6 +25,8 @@ install:
   - activate test-environment
   - pip install -r %APPVEYOR_BUILD_FOLDER%\requirements.txt
   - pip install -r %APPVEYOR_BUILD_FOLDER%\requirements-dev.txt
+  - python %APPVEYOR_BUILD_FOLDER%\setup.py sdist
+  - python %APPVEYOR_BUILD_FOLDER%\setup.py bdist_wheel
   - pip install %APPVEYOR_BUILD_FOLDER%\
 
 test_script:
@@ -31,3 +35,7 @@ test_script:
 after_test:
   - coverage run --source %APPVEYOR_BUILD_FOLDER%\src %APPVEYOR_BUILD_FOLDER%\test.py
   - codecov
+  - pip install -U %APPVEYOR_BUILD_FOLDER%\dist\%WHEEL%
+  - python %APPVEYOR_BUILD_FOLDER%\test.py
+  - pip install -U %APPVEYOR_BUILD_FOLDER%\dist\pynwb-0.1.tar.gz
+  - python %APPVEYOR_BUILD_FOLDER%\test.py

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,4 @@ deps =
 
 commands =
     python test.py
+    python setup.py bdist_wheel


### PR DESCRIPTION
Fixes #133.

Note that tox is creating an sdist in the .tox/dist/pynwb-0.1.zip directory already and installs the package from that zip file by default. Thus, we don't need to explicitly test installation from sdist. We are building the wheels, reinstalling pynwb from the wheels and running the tests with the wheel installation.

@jcfr PTAL