### PR TITLE
Remove scipy from dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ jobs:
            command: |
              apt-get update
              apt-get install -y software-properties-common python-software-properties
-             apt-get install -y libblas-dev liblapack-dev
        - run:
            name: Install python3.6 and pip
            command: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,12 +18,10 @@ environment:
       PYTHON: C:\\Python27-x64
       EXPECTED_WHEEL: pynwb-0.1-py2-none-any.whl
       ENV: python
-      SCIPY: https://pypi.python.org/packages/f0/5c/bc1e0c17b1fbf6e21827e9da97f2f584d8dc51993717479adff778ba718a/scipy-1.0.0rc2-cp27-none-win_amd64.whl
     - PYTHON_VERSION: 3.6
       PYTHON: C:\\Python36-x64
       EXPECTED_WHEEL: pynwb-0.1-py3-none-any.whl
       ENV: python
-      SCIPY: https://pypi.python.org/packages/ed/23/cc831da308cf4f7e319c73e32197a1204daed6ce8c76c741fcaf1903c489/scipy-1.0.0rc2-cp36-none-win_amd64.whl
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION%"
@@ -32,10 +30,9 @@ init:
       conda config --set always_yes yes --set changeps1 no &&
       conda update -q conda &&
       conda info -a &&
-      conda install -c anaconda scipy numpy)
+      conda install -c anaconda numpy)
   - if [%ENV%]==[python] (
-      pip install wheel &&
-      pip install %SCIPY%)
+      pip install wheel)
 
 install:
   - pip install -r %APPVEYOR_BUILD_FOLDER%\requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,5 @@ numpy==1.13.3
 python-dateutil==2.6.1
 requests==2.18.4
 ruamel.yaml==0.15.34
-scipy==0.19.1
 six==1.11.0
 urllib3==1.22

--- a/setup.py
+++ b/setup.py
@@ -31,11 +31,9 @@ setup_args = {
     'author_email': 'ajtritt@lbl.gov',
     'url': 'https://github.com/NeurodataWithoutBorders/pynwb',
     'license': license,
-    'setup_requires': ['numpy'],
     'install_requires':
     [
         'numpy',
-        'scipy',
         'h5py',
         'ruamel.yaml',
         'python-dateutil',

--- a/tests/build_fake_data.py
+++ b/tests/build_fake_data.py
@@ -5,7 +5,6 @@ from pynwb import NWBFile, get_build_manager
 from form.backends.hdf5 import HDF5IO
 
 import numpy as np
-import scipy.stats as sps
 import os
 from datetime import datetime
 
@@ -55,7 +54,7 @@ np.random.seed(1234)
 ephys_data = np.random.rand(data_len)
 ephys_timestamps = np.arange(data_len) / rate
 spatial_timestamps = ephys_timestamps[::10]
-spatial_data = np.cumsum(sps.norm.rvs(size=(2,len(spatial_timestamps))), axis=-1).T
+spatial_data = np.cumsum(np.random.normal(size=(2,len(spatial_timestamps))), axis=-1).T
 
 ephys_ts = ElectricalSeries('test_ephys_data',
                             'test_source',
@@ -76,7 +75,7 @@ spatial_ts = SpatialSeries('test_spatial_data',
                            timestamps=spatial_timestamps,
                            resolution=0.1,
                            comments="This data was generated with numpy, using 1234 as the seed",
-                           description="This 2D Brownian process generated with numpy.cumsum(scipy.stats.norm.rvs(size=(2,len(timestamps))), axis=-1).T")
+                           description="This 2D Brownian process generated with numpy.cumsum(numpy.random.normal(size=(2,len(spatial_timestamps))), axis=-1).T"
 
 # Create experimental epochs
 epoch_tags = ('test_example',)
@@ -96,4 +95,3 @@ io.close()
 io = HDF5IO(filename, manager, mode='r')
 io.read()
 io.close()
-


### PR DESCRIPTION
Fixes #168.
Thanks to @neuromusic for the one-liner.
Makes the builds faster and it is easier for the end user not to install scipy especially on Windows.