### PR TITLE
Add form to the api documentation

### DIFF
--- a/docs/source/api_docs.rst
+++ b/docs/source/api_docs.rst
@@ -19,6 +19,7 @@ API Documentation
    NWB Base Classes <pynwb.base>
    Miscellaneous <pynwb.misc>
    Epoch <pynwb.epoch>
+   Form <pynwb.form>
    PyNWB <pynwb>
    Flexible Object-Relational Mapping <form>
 


### PR DESCRIPTION
## Motivation

Add form api to the documentation. After the refactor, form module documentation became a submodule under pynwb in the docs. This PR brings form to the top level in the docs. Fixes #207

## How to test the behavior?
```
cd docs
pip install sphinx
pip install sphinx_rtd_theme
make html
chromium _build/html/api_docs.html # choice of browser
```
![deepinscreenshot_select-area_20171108132945](https://user-images.githubusercontent.com/11761461/32567195-8f88ae62-c488-11e7-863c-8cfa07cfefe2.png)


## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with out coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
