### PR TITLE
Add caching specification to file to ensure readability of distributed files

### DIFF
--- a/src/pynwb/form/backends/hdf5/__init__.py
+++ b/src/pynwb/form/backends/hdf5/__init__.py
@@ -2,3 +2,5 @@
 from .h5tools import HDF5IO
 from .h5_utils import H5RegionSlicer
 from . import h5tools
+from .h5tools import H5SpecWriter
+from .h5tools import H5SpecReader

--- a/src/pynwb/form/backends/io.py
+++ b/src/pynwb/form/backends/io.py
@@ -21,6 +21,11 @@ class FORMIO(with_metaclass(ABCMeta, object)):
         '''The BuildManager this FORMIO is using'''
         return self.__manager
 
+    @property
+    def source(self):
+        '''The source of the container being read/written i.e. file path'''
+        return self.__source
+
     @docval(returns='the Container object that was read in', rtype=Container)
     def read(self, **kwargs):
         f_builder = self.read_builder()

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -21,6 +21,10 @@ class BuildManager(object):
         self.__containers = dict()
         self.__type_map = type_map
 
+    @property
+    def namespace_catalog(self):
+        return self.__type_map.namespace_catalog
+
     @docval({"name": "container", "type": Container, "doc": "the container to convert to a Builder"},
             {"name": "source", "type": str,
              "doc": "the source of container being built i.e. file path", 'default': None})
@@ -695,6 +699,10 @@ class TypeMap(object):
         self.__container_types = dict()
         self.__data_types = dict()
         self.__default_mapper_cls = getargs('mapper_cls', kwargs)
+
+    @property
+    def namespace_catalog(self):
+        return self.__ns_catalog
 
     def __copy__(self):
         ret = TypeMap(self.__ns_catalog, self.__default_mapper_cls)

--- a/src/pynwb/form/spec/__init__.py
+++ b/src/pynwb/form/spec/__init__.py
@@ -12,6 +12,8 @@ from .spec import GroupSpec
 from .catalog import SpecCatalog
 from .namespace import SpecNamespace
 from .namespace import NamespaceCatalog
+from .namespace import SpecReader
 from .write import NamespaceBuilder
+from .write import SpecWriter
 
 from ..utils import docval

--- a/src/pynwb/form/spec/namespace.py
+++ b/src/pynwb/form/spec/namespace.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from datetime import datetime
 from copy import deepcopy, copy
 import ruamel.yaml as yaml
@@ -5,6 +6,9 @@ import os.path
 import string
 from warnings import warn
 from itertools import chain
+from abc import ABCMeta, abstractmethod
+from six import with_metaclass
+
 
 from ..utils import docval, getargs, popargs, get_docval
 from .catalog import SpecCatalog
@@ -97,6 +101,10 @@ class SpecNamespace(dict):
         return self.get('name', None)
 
     @property
+    def doc(self):
+        return self['doc']
+
+    @property
     def catalog(self):
         """The SpecCatalog containing all the Specs"""
         return self.__catalog
@@ -132,6 +140,46 @@ class SpecNamespace(dict):
         return cls(*args, **kwargs)
 
 
+class SpecReader(with_metaclass(ABCMeta, object)):
+
+    @abstractmethod
+    def read_spec(self):
+        pass
+
+    @abstractmethod
+    def read_namespace(self):
+        pass
+
+
+class YAMLSpecReader(SpecReader):
+
+    @docval({'name': 'indir', 'type': str, 'doc': 'the path spec files are relative to', 'default': '.'})
+    def __init__(self, **kwargs):
+        self.__indir = getargs('indir', kwargs)
+
+    def read_namespace(self, namespace_path):
+        namespaces = None
+        with open(namespace_path, 'r') as stream:
+            d = yaml.safe_load(stream)
+            namespaces = d.get('namespaces')
+            if namespaces is None:
+                raise ValueError("no 'namespaces' found in %s" % namespace_path)
+        return namespaces
+
+    def read_spec(self, spec_path):
+        specs = None
+        with open(self.__get_spec_path(spec_path), 'r') as stream:
+            specs = yaml.safe_load(stream)
+            if not ('datasets' in specs or 'groups' in specs):
+                raise ValueError("no 'groups' or 'datasets' found in %s" % spec_path)
+        return specs
+
+    def __get_spec_path(self, spec_path):
+        if os.path.isabs(spec_path):
+            return spec_path
+        return os.path.join(self.__indir, spec_path)
+
+
 class NamespaceCatalog(object):
 
     @docval({'name': 'group_spec_cls', 'type': type,
@@ -142,14 +190,15 @@ class NamespaceCatalog(object):
              'doc': 'the class to use for specification namespaces', 'default': SpecNamespace},)
     def __init__(self, **kwargs):
         """Create a catalog for storing  multiple Namespaces"""
-        self.__namespaces = dict()
+        self.__namespaces = OrderedDict()
         self.__dataset_spec_cls = getargs('dataset_spec_cls', kwargs)
         self.__group_spec_cls = getargs('group_spec_cls', kwargs)
         self.__spec_namespace_cls = getargs('spec_namespace_cls', kwargs)
         # keep track of all spec objects ever loaded, so we don't have
         # multiple object instances of a spec
         self.__loaded_specs = dict()
-        self.__loaded_ns_files = dict()
+        self.__included_specs = dict()
+        self.__included_sources = dict()
 
     @property
     @docval(returns='a tuple of the availble namespaces', rtype=tuple)
@@ -166,6 +215,11 @@ class NamespaceCatalog(object):
     def group_spec_cls(self):
         """The GroupSpec class used in this NamespaceCatalog"""
         return self.__group_spec_cls
+
+    @property
+    def spec_namespace_cls(self):
+        """The SpecNamespace class used in this NamespaceCatalog"""
+        return self.__spec_namespace_cls
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this namespace'},
             {'name': 'namespace', 'type': SpecNamespace, 'doc': 'the SpecNamespace object'})
@@ -211,39 +265,66 @@ class NamespaceCatalog(object):
             raise KeyError("'%s' not a namespace" % namespace)
         return spec_ns.get_hierarchy(data_type)
 
-    def __load_spec_file(self, spec_file_path, catalog, dtypes=None, resolve=True):
-        ret = self.__loaded_specs.get(spec_file_path)
+    @docval(rtype=tuple)
+    def get_sources(self, **kwargs):
+        '''
+        Get all the source specification files that were loaded in this catalog
+        '''
+        return tuple(self.__loaded_specs.keys())
+
+    @docval({'name': 'namespace', 'type': str, 'doc': 'the name of the namespace'},
+            rtype=tuple)
+    def get_namespace_sources(self, **kwargs):
+        '''
+        Get all the source specifications that were loaded for a given namespace
+        '''
+        namespace = getargs('namespace', kwargs)
+        return tuple(self.__included_sources[namespace])
+
+    @docval({'name': 'source', 'type': str, 'doc': 'the name of the source'},
+            rtype=tuple)
+    def get_types(self, **kwargs):
+        '''
+        Get the types that were loaded from a given source
+        '''
+        source = getargs('source', kwargs)
+        ret = self.__loaded_specs.get(source)
+        if ret is not None:
+            ret = tuple(ret)
+        return ret
+
+    def __load_spec_file(self, reader, spec_source, catalog, dtypes=None, resolve=True):
+        ret = self.__loaded_specs.get(spec_source)
 
         def __reg_spec(spec_cls, spec_dict):
             dt_def = spec_dict.get(spec_cls.def_key())
             if dt_def is None:
-                msg = 'skipping spec in %s, no %s found' % (spec_file_path, spec_cls.def_key())
+                msg = 'skipping spec in %s, no %s found' % (spec_source, spec_cls.def_key())
                 warn(msg)
                 return
             if dtypes and dt_def not in dtypes:
                 return
             if resolve:
-                self.__resolve_includes(spec_dict, catalog, spec_file_path)
+                self.__resolve_includes(spec_dict, catalog)
             spec_obj = spec_cls.build_spec(spec_dict)
-            catalog.auto_register(spec_obj, spec_file_path)
+            return catalog.auto_register(spec_obj, spec_source)
+
         if ret is None:
-            ret = dict()
-            with open(spec_file_path, 'r') as stream:
-                d = yaml.safe_load(stream)
-                specs = d.get('datasets', list())
-                for spec_dict in specs:
-                    __reg_spec(self.__dataset_spec_cls, spec_dict)
-                specs = d.get('groups', list())
-                for spec_dict in specs:
-                    __reg_spec(self.__group_spec_cls, spec_dict)
-            self.__loaded_specs[spec_file_path] = ret
+            ret = list()
+            d = reader.read_spec(spec_source)
+            specs = d.get('datasets', list())
+            for spec_dict in specs:
+                ret.extend(__reg_spec(self.__dataset_spec_cls, spec_dict))
+            specs = d.get('groups', list())
+            for spec_dict in specs:
+                ret.extend(__reg_spec(self.__group_spec_cls, spec_dict))
+            self.__loaded_specs[spec_source] = ret
         return ret
 
-    def __resolve_includes(self, spec_dict, catalog, spec_file_path):
+    def __resolve_includes(self, spec_dict, catalog):
         """
             Pull in any attributes, datasets, or groups included
         """
-        modified = False
         dt_inc = spec_dict.get(self.__group_spec_cls.inc_key())
         dt_def = spec_dict.get(self.__group_spec_cls.def_key())
         if dt_inc is not None and dt_def is not None:
@@ -252,40 +333,33 @@ class NamespaceCatalog(object):
                 msg = "Cannot resolve include spec '%s' for type '%s'" % (dt_inc, dt_def)
                 raise ValueError(msg)
             spec_dict[self.__group_spec_cls.inc_key()] = parent_spec
-            modified = True
         it = chain(spec_dict.get('groups', list()), spec_dict.get('datasets', list()))
         for subspec_dict in it:
-            sub_modified = self.__resolve_includes(subspec_dict, catalog, spec_file_path)  # noqa: F841
-        return modified
-
-    @classmethod
-    def __get_spec_path(cls, ns_path, spec_path):
-        if os.path.isabs(spec_path):
-            return spec_path
-        return os.path.join(os.path.dirname(ns_path), spec_path)
+            self.__resolve_includes(subspec_dict, catalog)
 
     @docval({'name': 'namespace_path', 'type': str, 'doc': 'the path to the file containing the namespaces(s) to load'},
-            {'name': 'resolve', 'type': bool,
+            {'name': 'resolve',
+             'type': bool,
              'doc': 'whether or not to include objects from included/parent spec objects', 'default': True},
+            {'name': 'reader',
+             'type': SpecReader,
+             'doc': 'the class to user for reading specifications', 'default': None},
             returns='a dictionary describing the dependencies of loaded namespaces', rtype=dict)
     def load_namespaces(self, **kwargs):
         """Load the namespaces in the given file"""
-        namespace_path, resolve = getargs('namespace_path', 'resolve', kwargs)
-        # load namespace definition from file
-        if not os.path.exists(namespace_path):
-            # TODO: Fix this line for Python2
-            # Raise OSError maybe?
-            raise FileNotFoundError("namespace file '%s' not found" % namespace_path)  # noqa: F821
-        ret = self.__loaded_ns_files.get(namespace_path)
+        namespace_path, resolve, reader = getargs('namespace_path', 'resolve', 'reader', kwargs)
+        if reader is None:
+            # load namespace definition from file
+            if not os.path.exists(namespace_path):
+                msg = "namespace file '%s' not found" % namespace_path
+                raise IOError(msg)
+            reader = YAMLSpecReader(indir=os.path.dirname(namespace_path))
+        ret = self.__included_specs.get(namespace_path)
         if ret is None:
             ret = dict()
         else:
             return ret
-        with open(namespace_path, 'r') as stream:
-            d = yaml.safe_load(stream)
-            namespaces = d.get('namespaces')
-            if namespaces is None:
-                raise ValueError("no 'namespaces' found in %s" % namespace_path)
+        namespaces = reader.read_namespace(namespace_path)
         types_key = self.__spec_namespace_cls.types_key()
         # now load specs into namespace
         for ns in namespaces:
@@ -294,11 +368,11 @@ class NamespaceCatalog(object):
             for s in ns['schema']:
                 if 'source' in s:
                     # read specs from file
-                    spec_file = self.__get_spec_path(namespace_path, s['source'])
                     dtypes = None
                     if types_key in s:
                         dtypes = set(s[types_key])
-                    ndts = self.__load_spec_file(spec_file, catalog, dtypes=dtypes, resolve=resolve)  # noqa: F841
+                    self.__load_spec_file(reader, s['source'], catalog, dtypes=dtypes, resolve=resolve)
+                    self.__included_sources.setdefault(ns['name'], list()).append(s['source'])
                 elif 'namespace' in s:
                     # load specs from namespace
                     try:
@@ -317,5 +391,5 @@ class NamespaceCatalog(object):
             ret[ns['name']] = included_types
             # construct namespace
             self.add_namespace(ns['name'], self.__spec_namespace_cls.build_namespace(catalog=catalog, **ns))
-        self.__loaded_ns_files[namespace_path] = ret
+        self.__included_specs[namespace_path] = ret
         return ret

--- a/src/pynwb/form/utils.py
+++ b/src/pynwb/form/utils.py
@@ -324,6 +324,18 @@ def docval(*validator, **options):
     return dec
 
 
+def __sig_arg(argval):
+    if 'default' in argval:
+        default = argval['default']
+        if isinstance(default, str):
+            default = "'%s'" % default
+        else:
+            default = str(default)
+        return "%s=%s" % (argval['name'], default)
+    else:
+        return argval['name']
+
+
 def __builddoc(func, validator, docstring_fmt, arg_fmt, ret_fmt=None, returns=None, rtype=None):
     '''Generate a Spinxy docstring'''
     def to_str(argtype):
@@ -339,14 +351,7 @@ def __builddoc(func, validator, docstring_fmt, arg_fmt, ret_fmt=None, returns=No
             fmt['type'] = " or ".join(map(to_str, arg['type']))
         else:
             fmt['type'] = to_str(arg['type'])
-
         return arg_fmt.format(**fmt)
-
-    def __sig_arg(argval):
-        if 'default' in argval:
-            return "%s=%s" % (argval['name'], str(argval['default']))
-        else:
-            return argval['name']
 
     sig = "%s(%s)\n\n" % (func.__name__, ", ".join(map(__sig_arg, validator)))
     desc = func.__doc__.strip() if func.__doc__ is not None else ""

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 import six
 from datetime import datetime
 import os
@@ -8,6 +8,8 @@ from pynwb import NWBFile, TimeSeries, get_manager
 
 from pynwb.form.backends.hdf5 import HDF5IO
 from pynwb.form.build import GroupBuilder, DatasetBuilder
+from pynwb.form.spec import NamespaceCatalog
+from pynwb.spec import NWBGroupSpec, NWBDatasetSpec, NWBNamespace
 
 
 class TestHDF5Writer(unittest.TestCase):
@@ -92,3 +94,28 @@ class TestHDF5Writer(unittest.TestCase):
             io = HDF5IO(self.path, self.manager, mode='w-')
             io.write(self.container)
             io.close()
+
+    def test_write_cache_spec(self):
+        '''
+        Round-trip test for writing spec and reading it back in
+        '''
+        io = HDF5IO(self.path, self.manager)
+        io.write(self.container, cache_spec=True)
+        io.close()
+        f = File(self.path)
+        self.assertIn('specifications', f)
+        ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace)
+        HDF5IO.load_namespaces(ns_catalog, self.path, namespaces=['core'])
+        original_ns = self.manager.namespace_catalog.get_namespace('core')
+        cached_ns = ns_catalog.get_namespace('core')
+        for key in ('author', 'contact', 'doc', 'full_name', 'name'):
+            with self.subTest(namespace_field=key):
+                self.assertEqual(original_ns[key], cached_ns[key])
+        for dt in original_ns.get_registered_types():
+            with self.subTest(neurodata_type=dt):
+                original_spec = original_ns.get_spec(dt)
+                cached_spec = cached_ns.get_spec(dt)
+                with self.subTest(test='data_type spec read back in'):
+                    self.assertIsNotNone(cached_spec)
+                with self.subTest(test='cached spec preserved original spec'):
+                    self.assertDictEqual(original_spec, cached_spec)

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -38,39 +38,39 @@ class H5IOTest(unittest.TestCase):
     ##########################################
     def test__chunked_iter_fill_iterator_matched_buffer_size(self):
         dci = DataChunkIterator(data=range(10), buffer_size=2)
-        my_dset = self.io.__chunked_iter_fill__(self.f, 'test_dataset', dci)
+        my_dset = HDF5IO.__chunked_iter_fill__(self.f, 'test_dataset', dci)
         self.assertListEqual(my_dset[:].tolist(), list(range(10)))
 
     def test__chunked_iter_fill_iterator_unmatched_buffer_size(self):
         dci = DataChunkIterator(data=range(10), buffer_size=3)
-        my_dset = self.io.__chunked_iter_fill__(self.f, 'test_dataset', dci)
+        my_dset = HDF5IO.__chunked_iter_fill__(self.f, 'test_dataset', dci)
         self.assertListEqual(my_dset[:].tolist(), list(range(10)))
 
     def test__chunked_iter_fill_numpy_matched_buffer_size(self):
         a = np.arange(30).reshape(5, 2, 3)
         dci = DataChunkIterator(data=a, buffer_size=1)
-        my_dset = self.io.__chunked_iter_fill__(self.f, 'test_dataset', dci)
+        my_dset = HDF5IO.__chunked_iter_fill__(self.f, 'test_dataset', dci)
         self.assertTrue(np.all(my_dset[:] == a))
         self.assertTupleEqual(my_dset.shape, a.shape)
 
     def test__chunked_iter_fill_numpy_unmatched_buffer_size(self):
         a = np.arange(30).reshape(5, 2, 3)
         dci = DataChunkIterator(data=a, buffer_size=3)
-        my_dset = self.io.__chunked_iter_fill__(self.f, 'test_dataset', dci)
+        my_dset = HDF5IO.__chunked_iter_fill__(self.f, 'test_dataset', dci)
         self.assertTrue(np.all(my_dset[:] == a))
         self.assertTupleEqual(my_dset.shape, a.shape)
 
     def test__chunked_iter_fill_list_matched_buffer_size(self):
         a = np.arange(30).reshape(5, 2, 3)
         dci = DataChunkIterator(data=a.tolist(), buffer_size=1)
-        my_dset = self.io.__chunked_iter_fill__(self.f, 'test_dataset', dci)
+        my_dset = HDF5IO.__chunked_iter_fill__(self.f, 'test_dataset', dci)
         self.assertTrue(np.all(my_dset[:] == a))
         self.assertTupleEqual(my_dset.shape, a.shape)
 
     def test__chunked_iter_fill_numpy_unmatched_buffer_size(self):  # noqa: F811
         a = np.arange(30).reshape(5, 2, 3)
         dci = DataChunkIterator(data=a.tolist(), buffer_size=3)
-        my_dset = self.io.__chunked_iter_fill__(self.f, 'test_dataset', dci)
+        my_dset = HDF5IO.__chunked_iter_fill__(self.f, 'test_dataset', dci)
         self.assertTrue(np.all(my_dset[:] == a))
         self.assertTupleEqual(my_dset.shape, a.shape)
 


### PR DESCRIPTION
NWB files contain a currently freeform area in ``/general/specifications`` for storing
specifications. To ease use of the specification data it is now possible to:

* Assign a neurodata_type to ``/general/specifications`` and create a custom ``NWBContainer``
  class to manage specifications.

* Create a new neurodata_type to be stored in ``/general/specifications`` to structure the
  storage of namespace and associated specification files rather than requiring that specs
  be stored in a single dataset

* Automatically write all specs used by (or registered with) PyNWB to the NWB file when a
  file is written. This will help ensure that the spec for all objects are always stored
  in the file.

* Add ability to use use specifications (including custom extensions) from the HDF5 directly
  on read. We possibly need an option here to allow the user decide whether to use specs from
  the HDF5 file or the specs currently registered with PyNWB.

See #44, #108

More specifically, this commit adds:
* class for loading namespace
* class for writing namespace
* tooling to ``h5tools`` for caching spec to file
* getter for ``FORMIO`` source
* return of registered types to ``SpecCatalog.auto_register``
* tracking of type sources in ``NamespaceCatalog``
* class for building specification files to ``NamespaceBuilder``
* requirement that spec files be in the same directory as namespace file
* getters for ``NamespaceCatalog`` to ``BuildManager``
* tracking of overridden specs
* ability to read/write specs to/from HDF5 file
* reference-to-reference write
* roundtrip test for caching spec to hdf5 file
* add roundtrip test for caching spec

This commit also implements the following changes:
* make dataset fill methods classmethods
* make ``Spec`` and ``Namespace`` catalogs maintain specs and namespaces with OrderedDict
* require parent spec be passed in, rather than parent spec nam
* import ``SpecNamespace`` to ``h5tools``
* fix bug when showing default strings in signature
* allow string to be passed into ``BaseStorageSpec`` when extending
* refactor caching of spec
* import HDF5 spec reader/writer classes to package-level
* use ``unittest2`` instead of ``unittest`` for ``integration.test_io``
* import spec reader/writer abstract classes to ``form.spec`` subpackage
* deploy spec caching feature