### PR TITLE
Move coverage report task to tox

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,21 +63,21 @@ jobs:
     docker:
       - image: circleci/python:2.7.14-jessie
     environment:
-     - TOX_ENV: "py27"
+     - TOX_ENV: "py27,CI-py27"
     <<: *ci-steps
 
   python35:
     docker:
       - image: circleci/python:3.5.4-jessie
     environment:
-     - TOX_ENV: "py35"
+     - TOX_ENV: "py35,CI-py35"
     <<: *ci-steps
 
   python36:
     docker:
       - image: circleci/python:3.6.3-jessie
     environment:
-     - TOX_ENV: "py36"
+     - TOX_ENV: "py36,CI-py36"
     <<: *ci-steps
 
 workflows:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,15 +41,5 @@ install:
 
 script:
   - tox
+  - tox -e CI-py27, CI-py35, CI-py36
   - tox recreate --installpkg dist/*-none-any.whl
-
-#after_success:
-#  - pip install -r requirements.txt
-#  - pip install -r requirements-dev.txt
-#  - pip install -e .
-#  - coverage run --source src test.py --pynwb
-#  - codecov -F pynwb
-#  - coverage run --source src test.py --integration
-#  - codecov -F integration
-#  - coverage run --source src test.py --form
-#  - codecov -F form

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ develop: build
 	$(PYTHON) setup.py develop
 
 test:
-	$(PYTHON) test.py
+	pip install -r requirements-dev.txt
+	tox
 
 test_docker:
 	docker build --quiet --no-cache --tag neurodatawithoutborders/pynwb:python27_test -f ./docker/python27_test/Dockerfile .
@@ -38,6 +39,7 @@ test_docker:
 	docker run --rm -it neurodatawithoutborders/pynwb:python36_test bash -c 'python test.py'
 
 apidoc:
+	pip install -r requirements-doc.txt
 	cd docs && $(MAKE) apidoc
 
 htmldoc-only: apidoc
@@ -59,9 +61,8 @@ pdfdoc:
 	@echo "To view the PDF documentation open: docs/_build/latex/PyNWB.pdf"
 
 coverage:
-	$(COVERAGE) run --source=. test.py
+	tox -e coverage
 
-coverage_html: coverage
-	$(COVERAGE) html -d tests/coverage/htmlcov
-	@echo ""
-	@echo "To view coverage data open: tests/coverage/htmlcov/index.html"
+coverage-open:
+	@echo "To view coverage data open: ./tests/coverage/htmlcov/index.html"
+	open ./tests/coverage/htmlcov/index.html || xdg-open ./tests/coverage/htmlcov/index.html

--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,35 @@ commands =
     python test.py
     python setup.py sdist
     python setup.py bdist_wheel
+
+[testenv:coverage]
+usedevelop = True
+basepython=python3.6
+
+commands =
+    coverage run --source src test.py
+    coverage html -d tests/coverage/htmlcov
+
+[testenv:CI]
+commands =
+    coverage run --source src test.py --pynwb
+    codecov -F pynwb
+    coverage run --source src test.py --integration
+    codecov -F integration
+    coverage run --source src test.py --form
+    codecov -F form
+
+[testenv:CI-py27]
+basepython=python2.7
+passenv = *
+commands = {[testenv:CI]commands}
+
+[testenv:CI-py35]
+basepython=python3.5
+passenv = *
+commands = {[testenv:CI]commands}
+
+[testenv:CI-py36]
+basepython=python3.6
+passenv = *
+commands = {[testenv:CI]commands}


### PR DESCRIPTION
## Motivation

Coverage was ran against the default Python3 in circleci (which was Python 3.5). Now it is a step in the tox file and reported by py36 in tox. Fixes #240.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
