### PR TITLE
requirements: Per recommendation, constrain version to <0.15

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,1 @@
+ruamel.yaml<0.15 # See http://yaml.readthedocs.io/en/latest/basicuse.html

--- a/docs/source/update_requirements.rst
+++ b/docs/source/update_requirements.rst
@@ -26,8 +26,8 @@ the following script:
    mkvirtualenv pynwb-requirements
 
    cd pynwb
-   pip install .
-   pip freeze > requirements.txt
+   pip install -U -e . -c constraints.txt
+   pip freeze | grep -v 'pynwb' > requirements.txt
 
    deactivate
    rmvirtualenv pynwb-requirements

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ idna==2.6
 numpy==1.13.3
 python-dateutil==2.6.1
 requests==2.18.4
-ruamel.yaml==0.15.34
+ruamel.yaml==0.14.12
 six==1.11.0
 urllib3==1.22

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup_args = {
     [
         'numpy',
         'h5py',
-        'ruamel.yaml',
+        'ruamel.yaml<0.15',
         'python-dateutil',
         'six',
         'requests'


### PR DESCRIPTION
> This is the new (0.15+) interface for ``ruamel.yaml``, it is still in
> the process of being fleshed out. Please pin your dependency to
> ruamel.yaml<0.15 for production software.

Source: http://yaml.readthedocs.io/en/latest/basicuse.html