### PR TITLE
H5SpecReader: Fix test_write_cache_spec failing on Python 3.5

### DIFF
--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -693,6 +693,8 @@ class H5SpecReader(SpecReader):
 
     def __read(self, path):
         s = self.__group[path][()]
+        if isinstance(s, bytes):
+            s = s.decode('UTF-8')
         d = json.loads(s)
         return d
 


### PR DESCRIPTION
This commit fixes the following error reported when running "test_write_cache_spec"
on python 3.5:

  TypeError: the JSON object must be str, not 'bytes'