### PR TITLE
Add usedevelop flag for coverage-tox issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,25 @@ ci-steps: &ci-steps
         command: |
           . ../venv/bin/activate
           pip install tox
-          tox -e $TOX_ENV
+          tox -e $TEST_TOX_ENV
         # Install is expected to be quick. Increase timeout in case there are some network issues.
         # While pip installing tox does not output by default. Circle thinks task is dead after 10 min.
         no_output_timeout: 30m
     - run:
+        name: Run coverage and submit to codecov-io
+        command: |
+          . ../venv/bin/activate
+          tox -e $COVERAGE_TOX_ENV
+    - run:
+        name: Build wheel and source distribution
+        command: |
+          . ../venv/bin/activate
+          tox -e $BUILD_TOX_ENV
+    - run:
         name: Test installation from a wheel
         command: |
           . ../venv/bin/activate
-          tox -e $TOX_ENV recreate --installpkg dist/*-none-any.whl
+          tox -e $TEST_TOX_ENV recreate --installpkg dist/*-none-any.whl
     - run:
         <<: *publish-prerelease-on-github
 
@@ -63,21 +73,27 @@ jobs:
     docker:
       - image: circleci/python:2.7.14-jessie
     environment:
-     - TOX_ENV: "py27,CI-py27"
+     - TEST_TOX_ENV: "py27"
+     - COVERAGE_TOX_ENV: "coverage-py27"
+     - BUILD_TOX_ENV: "build-py27"
     <<: *ci-steps
 
   python35:
     docker:
       - image: circleci/python:3.5.4-jessie
     environment:
-     - TOX_ENV: "py35,CI-py35"
+     - TEST_TOX_ENV: "py35"
+     - COVERAGE_TOX_ENV: "coverage-py35"
+     - BUILD_TOX_ENV: "build-py35"
     <<: *ci-steps
 
   python36:
     docker:
       - image: circleci/python:3.6.3-jessie
     environment:
-     - TOX_ENV: "py36,CI-py36"
+     - TEST_TOX_ENV: "py36"
+     - COVERAGE_TOX_ENV: "coverage-py36"
+     - BUILD_TOX_ENV: "build-py36"
     <<: *ci-steps
 
 workflows:

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,4 @@
 [run]
 branch = True
-source = src/
+source = src/pynwb
 omit = src/pynwb/_version.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,16 +12,24 @@ matrix:
       language: generic
       env:
         - TRAVIS_PYTHON_VERSION=3.6.3
+        - TEST_TOX_ENV=py36
+        - COVERAGE_TOX_ENV=coverage-py36
+        - BUILD_TOX_ENV=build-py36
 
     - os: osx
       language: generic
       env:
         - TRAVIS_PYTHON_VERSION=3.5.4
-
+        - TEST_TOX_ENV=py35
+        - COVERAGE_TOX_ENV=coverage-py35
+        - BUILD_TOX_ENV=build-py35
     - os: osx
       language: generic
       env:
         - TRAVIS_PYTHON_VERSION=2.7.14
+        - TEST_TOX_ENV=py27
+        - COVERAGE_TOX_ENV=coverage-py27
+        - BUILD_TOX_ENV=build-py27
 
 cache:
   directories:
@@ -40,6 +48,7 @@ install:
   - pip install tox-travis tox-pyenv
 
 script:
-  - tox
-  - tox -e CI-py27, CI-py35, CI-py36
-  - tox recreate --installpkg dist/*-none-any.whl
+  - tox -e $TEST_TOX_ENV
+  - tox -e $COVERAGE_TOX_ENV
+  - tox -e $BUILD_TOX_ENV
+  - tox -e $TEST_TOX_ENV recreate --installpkg dist/*-none-any.whl

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ pdfdoc:
 	@echo "To view the PDF documentation open: docs/_build/latex/PyNWB.pdf"
 
 coverage-only:
-	tox -e coverage
+	tox -e localcoverage
 
 coverage-open:
 	@echo "To view coverage data open: ./tests/coverage/htmlcov/index.html"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,10 +48,13 @@ test_script:
 
 after_test:
   - coverage run %APPVEYOR_BUILD_FOLDER%\test.py --pynwb
+  - coverage report -m
   - codecov -F pynwb
   - coverage run  %APPVEYOR_BUILD_FOLDER%\test.py --example --integration
+  - coverage report -m
   - codecov -F integration
   - coverage run %APPVEYOR_BUILD_FOLDER%\test.py --form
+  - coverage report -m
   - codecov -F form
   - ps: (Get-Item $env:APPVEYOR_BUILD_FOLDER\dist\*none-any.whl).Name | ForEach-Object {pip install -U $env:APPVEYOR_BUILD_FOLDER\dist\$_}
   - python %APPVEYOR_BUILD_FOLDER%\test.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,21 +9,44 @@ environment:
     - PYTHON_VERSION: 2.7
       PYTHON: C:\Miniconda-x64
       ENV: miniconda
+      TEST_TOX_ENV: py27
+      COVERAGE_TOX_ENV: coverage-py27
+      BUILD_TOX_ENV: build-py27
+
     - PYTHON_VERSION: 3.5
       PYTHON: C:\Miniconda35-x64
       ENV: miniconda
+      TEST_TOX_ENV: py35
+      COVERAGE_TOX_ENV: coverage-py35
+      BUILD_TOX_ENV: build-py35
+
     - PYTHON_VERSION: 3.6
       PYTHON: C:\Miniconda36-x64
       ENV: miniconda
+      TEST_TOX_ENV: py36
+      COVERAGE_TOX_ENV: coverage-py36
+      BUILD_TOX_ENV: build-py36
+
     - PYTHON_VERSION: 2.7
       PYTHON: C:\\Python27-x64
       ENV: python
+      TEST_TOX_ENV: py27
+      COVERAGE_TOX_ENV: coverage-py27
+      BUILD_TOX_ENV: build-py27
+
     - PYTHON_VERSION: 3.5
       PYTHON: C:\\Python35-x64
       ENV: python
+      TEST_TOX_ENV: py35
+      COVERAGE_TOX_ENV: coverage-py35
+      BUILD_TOX_ENV: build-py35
+
     - PYTHON_VERSION: 3.6
       PYTHON: C:\\Python36-x64
       ENV: python
+      TEST_TOX_ENV: py36
+      COVERAGE_TOX_ENV: coverage-py36
+      BUILD_TOX_ENV: build-py36
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION%"
@@ -35,28 +58,13 @@ init:
       conda install -c anaconda numpy)
   - if [%ENV%]==[python] (
       pip install wheel)
-
-install:
-  - pip install -r %APPVEYOR_BUILD_FOLDER%\requirements.txt
-  - pip install -r %APPVEYOR_BUILD_FOLDER%\requirements-dev.txt
-  - python %APPVEYOR_BUILD_FOLDER%\setup.py sdist
-  - python %APPVEYOR_BUILD_FOLDER%\setup.py bdist_wheel -d %APPVEYOR_BUILD_FOLDER%\dist
-  - pip install %APPVEYOR_BUILD_FOLDER%\
+  - pip install tox
 
 test_script:
-  - python %APPVEYOR_BUILD_FOLDER%\test.py
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - tox -e %TEST_TOX_ENV%
+  - tox -e %BUILD_TOX_ENV%
+  - ps: (Get-Item $env:APPVEYOR_BUILD_FOLDER\dist\*none-any.whl).Name | ForEach-Object {tox -e $env:TEST_TOX_ENV recreate --installpkg $env:APPVEYOR_BUILD_FOLDER\dist\$_}
 
 after_test:
-  - coverage run %APPVEYOR_BUILD_FOLDER%\test.py --pynwb
-  - coverage report -m
-  - codecov -F pynwb
-  - coverage run  %APPVEYOR_BUILD_FOLDER%\test.py --example --integration
-  - coverage report -m
-  - codecov -F integration
-  - coverage run %APPVEYOR_BUILD_FOLDER%\test.py --form
-  - coverage report -m
-  - codecov -F form
-  - ps: (Get-Item $env:APPVEYOR_BUILD_FOLDER\dist\*none-any.whl).Name | ForEach-Object {pip install -U $env:APPVEYOR_BUILD_FOLDER\dist\$_}
-  - python %APPVEYOR_BUILD_FOLDER%\test.py
-  - ps: (Get-Item $env:APPVEYOR_BUILD_FOLDER\dist\*.tar.gz).Name | ForEach-Object {pip install -U $env:APPVEYOR_BUILD_FOLDER\dist\$_}
-  - python %APPVEYOR_BUILD_FOLDER%\test.py
+  - tox -e %COVERAGE_TOX_ENV%

--- a/tox.ini
+++ b/tox.ini
@@ -17,17 +17,35 @@ deps =
 
 commands =
     python test.py
-    python setup.py sdist
-    python setup.py bdist_wheel
 
-[testenv:coverage]
+# Env to create coverage report locally
+[testenv:localcoverage]
 basepython = python3.6
 
 commands =
     coverage run test.py
     coverage html -d tests/coverage/htmlcov
 
-[testenv:CI]
+# Envs that builds wheels and source distribution
+[testenv:build]
+commands =
+    python setup.py sdist
+    python setup.py bdist_wheel
+
+[testenv:build-py27]
+basepython = python2.7
+commands = {[testenv:build]commands}
+
+[testenv:build-py35]
+basepython = python3.5
+commands = {[testenv:build]commands}
+
+[testenv:build-py36]
+basepython = python3.6
+commands = {[testenv:build]commands}
+
+# Envs that will only be executed on CI that does coverage reporting
+[testenv:coverage]
 commands =
     coverage run test.py --pynwb
     coverage report -m
@@ -39,17 +57,17 @@ commands =
     coverage report -m
     codecov -F form
 
-[testenv:CI-py27]
+[testenv:coverage-py27]
 passenv = CODECOV_TOKEN
 basepython = python2.7
-commands = {[testenv:CI]commands}
+commands = {[testenv:coverage]commands}
 
-[testenv:CI-py35]
+[testenv:coverage-py35]
 passenv = CODECOV_TOKEN
 basepython = python3.5
-commands = {[testenv:CI]commands}
+commands = {[testenv:coverage]commands}
 
-[testenv:CI-py36]
+[testenv:coverage-py36]
 passenv = CODECOV_TOKEN
 basepython = python3.6
-commands = {[testenv:CI]commands}
+commands = {[testenv:coverage]commands}

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@
 envlist = py27, py35, py36
 
 [testenv]
+usedevelop = True
 install_command =
     pip install -U {opts} {packages}
 
@@ -20,8 +21,7 @@ commands =
     python setup.py bdist_wheel
 
 [testenv:coverage]
-usedevelop = True
-basepython=python3.6
+basepython = python3.6
 
 commands =
     coverage run test.py
@@ -30,23 +30,26 @@ commands =
 [testenv:CI]
 commands =
     coverage run test.py --pynwb
+    coverage report -m
     codecov -F pynwb
     coverage run test.py --example --integration
+    coverage report -m
     codecov -F integration
     coverage run test.py --form
+    coverage report -m
     codecov -F form
 
 [testenv:CI-py27]
-basepython=python2.7
-passenv = *
+passenv = CODECOV_TOKEN
+basepython = python2.7
 commands = {[testenv:CI]commands}
 
 [testenv:CI-py35]
-basepython=python3.5
-passenv = *
+passenv = CODECOV_TOKEN
+basepython = python3.5
 commands = {[testenv:CI]commands}
 
 [testenv:CI-py36]
-basepython=python3.6
-passenv = *
+passenv = CODECOV_TOKEN
+basepython = python3.6
 commands = {[testenv:CI]commands}


### PR DESCRIPTION
## Motivation

Fixes #269 

Coverage was reporting 0% even if the coverage was ran. Running tox environment in development mode and correctly referencing pynwb path fixed this issue. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
