### PR TITLE
doc: Add module API documentation. See #267

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,6 @@
 
 docs/notebooks/boc/
 
-# Auto-generated apidocs RST files
-docs/source/pynwb*.rst
-docs/source/modules.rst
-
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -158,6 +158,6 @@ doctest:
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 apidoc:
-	$(SPHINXAPIDOC) -f -e -o $(RSTDIR)  $(SRCDIR)
+	$(SPHINXAPIDOC) -f -e --no-toc -o $(RSTDIR)  $(SRCDIR)
 	@echo "Build rst docs from source code."
 

--- a/docs/source/pynwb.base.rst
+++ b/docs/source/pynwb.base.rst
@@ -1,0 +1,7 @@
+pynwb\.base module
+==================
+
+.. automodule:: pynwb.base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.behavior.rst
+++ b/docs/source/pynwb.behavior.rst
@@ -1,0 +1,7 @@
+pynwb\.behavior module
+======================
+
+.. automodule:: pynwb.behavior
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.core.rst
+++ b/docs/source/pynwb.core.rst
@@ -1,0 +1,7 @@
+pynwb\.core module
+==================
+
+.. automodule:: pynwb.core
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.ecephys.rst
+++ b/docs/source/pynwb.ecephys.rst
@@ -1,0 +1,7 @@
+pynwb\.ecephys module
+=====================
+
+.. automodule:: pynwb.ecephys
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.epoch.rst
+++ b/docs/source/pynwb.epoch.rst
@@ -1,0 +1,7 @@
+pynwb\.epoch module
+===================
+
+.. automodule:: pynwb.epoch
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.file.rst
+++ b/docs/source/pynwb.file.rst
@@ -1,0 +1,7 @@
+pynwb\.file module
+==================
+
+.. automodule:: pynwb.file
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.backends.hdf5.h5_utils.rst
+++ b/docs/source/pynwb.form.backends.hdf5.h5_utils.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.backends\.hdf5\.h5\_utils module
+=============================================
+
+.. automodule:: pynwb.form.backends.hdf5.h5_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.backends.hdf5.h5tools.rst
+++ b/docs/source/pynwb.form.backends.hdf5.h5tools.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.backends\.hdf5\.h5tools module
+===========================================
+
+.. automodule:: pynwb.form.backends.hdf5.h5tools
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.backends.hdf5.rst
+++ b/docs/source/pynwb.form.backends.hdf5.rst
@@ -1,0 +1,18 @@
+pynwb\.form\.backends\.hdf5 package
+===================================
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.form.backends.hdf5.h5_utils
+   pynwb.form.backends.hdf5.h5tools
+
+Module contents
+---------------
+
+.. automodule:: pynwb.form.backends.hdf5
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.backends.io.rst
+++ b/docs/source/pynwb.form.backends.io.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.backends\.io module
+================================
+
+.. automodule:: pynwb.form.backends.io
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.backends.rst
+++ b/docs/source/pynwb.form.backends.rst
@@ -1,0 +1,24 @@
+pynwb\.form\.backends package
+=============================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    pynwb.form.backends.hdf5
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.form.backends.io
+
+Module contents
+---------------
+
+.. automodule:: pynwb.form.backends
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.build.builders.rst
+++ b/docs/source/pynwb.form.build.builders.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.build\.builders module
+===================================
+
+.. automodule:: pynwb.form.build.builders
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.build.map.rst
+++ b/docs/source/pynwb.form.build.map.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.build\.map module
+==============================
+
+.. automodule:: pynwb.form.build.map
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.build.rst
+++ b/docs/source/pynwb.form.build.rst
@@ -1,0 +1,18 @@
+pynwb\.form\.build package
+==========================
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.form.build.builders
+   pynwb.form.build.map
+
+Module contents
+---------------
+
+.. automodule:: pynwb.form.build
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.container.rst
+++ b/docs/source/pynwb.form.container.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.container module
+=============================
+
+.. automodule:: pynwb.form.container
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.data_utils.rst
+++ b/docs/source/pynwb.form.data_utils.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.data\_utils module
+===============================
+
+.. automodule:: pynwb.form.data_utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.monitor.rst
+++ b/docs/source/pynwb.form.monitor.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.monitor module
+===========================
+
+.. automodule:: pynwb.form.monitor
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.rst
+++ b/docs/source/pynwb.form.rst
@@ -1,0 +1,30 @@
+pynwb\.form package
+===================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    pynwb.form.backends
+    pynwb.form.build
+    pynwb.form.spec
+    pynwb.form.validate
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.form.container
+   pynwb.form.data_utils
+   pynwb.form.monitor
+   pynwb.form.utils
+
+Module contents
+---------------
+
+.. automodule:: pynwb.form
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.spec.catalog.rst
+++ b/docs/source/pynwb.form.spec.catalog.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.spec\.catalog module
+=================================
+
+.. automodule:: pynwb.form.spec.catalog
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.spec.namespace.rst
+++ b/docs/source/pynwb.form.spec.namespace.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.spec\.namespace module
+===================================
+
+.. automodule:: pynwb.form.spec.namespace
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.spec.rst
+++ b/docs/source/pynwb.form.spec.rst
@@ -1,0 +1,20 @@
+pynwb\.form\.spec package
+=========================
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.form.spec.catalog
+   pynwb.form.spec.namespace
+   pynwb.form.spec.spec
+   pynwb.form.spec.write
+
+Module contents
+---------------
+
+.. automodule:: pynwb.form.spec
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.spec.spec.rst
+++ b/docs/source/pynwb.form.spec.spec.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.spec\.spec module
+==============================
+
+.. automodule:: pynwb.form.spec.spec
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.spec.write.rst
+++ b/docs/source/pynwb.form.spec.write.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.spec\.write module
+===============================
+
+.. automodule:: pynwb.form.spec.write
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.utils.rst
+++ b/docs/source/pynwb.form.utils.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.utils module
+=========================
+
+.. automodule:: pynwb.form.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.validate.errors.rst
+++ b/docs/source/pynwb.form.validate.errors.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.validate\.errors module
+====================================
+
+.. automodule:: pynwb.form.validate.errors
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.validate.rst
+++ b/docs/source/pynwb.form.validate.rst
@@ -1,0 +1,18 @@
+pynwb\.form\.validate package
+=============================
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.form.validate.errors
+   pynwb.form.validate.validator
+
+Module contents
+---------------
+
+.. automodule:: pynwb.form.validate
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.form.validate.validator.rst
+++ b/docs/source/pynwb.form.validate.validator.rst
@@ -1,0 +1,7 @@
+pynwb\.form\.validate\.validator module
+=======================================
+
+.. automodule:: pynwb.form.validate.validator
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.icephys.rst
+++ b/docs/source/pynwb.icephys.rst
@@ -1,0 +1,7 @@
+pynwb\.icephys module
+=====================
+
+.. automodule:: pynwb.icephys
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.image.rst
+++ b/docs/source/pynwb.image.rst
@@ -1,0 +1,7 @@
+pynwb\.image module
+===================
+
+.. automodule:: pynwb.image
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.io.base.rst
+++ b/docs/source/pynwb.io.base.rst
@@ -1,0 +1,7 @@
+pynwb\.io\.base module
+======================
+
+.. automodule:: pynwb.io.base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.io.core.rst
+++ b/docs/source/pynwb.io.core.rst
@@ -1,0 +1,7 @@
+pynwb\.io\.core module
+======================
+
+.. automodule:: pynwb.io.core
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.io.ecephys.rst
+++ b/docs/source/pynwb.io.ecephys.rst
@@ -1,0 +1,7 @@
+pynwb\.io\.ecephys module
+=========================
+
+.. automodule:: pynwb.io.ecephys
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.io.epoch.rst
+++ b/docs/source/pynwb.io.epoch.rst
@@ -1,0 +1,7 @@
+pynwb\.io\.epoch module
+=======================
+
+.. automodule:: pynwb.io.epoch
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.io.file.rst
+++ b/docs/source/pynwb.io.file.rst
@@ -1,0 +1,7 @@
+pynwb\.io\.file module
+======================
+
+.. automodule:: pynwb.io.file
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.io.ophys.rst
+++ b/docs/source/pynwb.io.ophys.rst
@@ -1,0 +1,7 @@
+pynwb\.io\.ophys module
+=======================
+
+.. automodule:: pynwb.io.ophys
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.io.rst
+++ b/docs/source/pynwb.io.rst
@@ -1,0 +1,22 @@
+pynwb\.io package
+=================
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.io.base
+   pynwb.io.core
+   pynwb.io.ecephys
+   pynwb.io.epoch
+   pynwb.io.file
+   pynwb.io.ophys
+
+Module contents
+---------------
+
+.. automodule:: pynwb.io
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.base.rst
+++ b/docs/source/pynwb.legacy.io.base.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.base module
+==============================
+
+.. automodule:: pynwb.legacy.io.base
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.behavior.rst
+++ b/docs/source/pynwb.legacy.io.behavior.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.behavior module
+==================================
+
+.. automodule:: pynwb.legacy.io.behavior
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.epoch.rst
+++ b/docs/source/pynwb.legacy.io.epoch.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.epoch module
+===============================
+
+.. automodule:: pynwb.legacy.io.epoch
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.file.rst
+++ b/docs/source/pynwb.legacy.io.file.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.file module
+==============================
+
+.. automodule:: pynwb.legacy.io.file
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.icephys.rst
+++ b/docs/source/pynwb.legacy.io.icephys.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.icephys module
+=================================
+
+.. automodule:: pynwb.legacy.io.icephys
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.image.rst
+++ b/docs/source/pynwb.legacy.io.image.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.image module
+===============================
+
+.. automodule:: pynwb.legacy.io.image
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.misc.rst
+++ b/docs/source/pynwb.legacy.io.misc.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.misc module
+==============================
+
+.. automodule:: pynwb.legacy.io.misc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.ogen.rst
+++ b/docs/source/pynwb.legacy.io.ogen.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.ogen module
+==============================
+
+.. automodule:: pynwb.legacy.io.ogen
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.ophys.rst
+++ b/docs/source/pynwb.legacy.io.ophys.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.io\.ophys module
+===============================
+
+.. automodule:: pynwb.legacy.io.ophys
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.io.rst
+++ b/docs/source/pynwb.legacy.io.rst
@@ -1,0 +1,25 @@
+pynwb\.legacy\.io package
+=========================
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.legacy.io.base
+   pynwb.legacy.io.behavior
+   pynwb.legacy.io.epoch
+   pynwb.legacy.io.file
+   pynwb.legacy.io.icephys
+   pynwb.legacy.io.image
+   pynwb.legacy.io.misc
+   pynwb.legacy.io.ogen
+   pynwb.legacy.io.ophys
+
+Module contents
+---------------
+
+.. automodule:: pynwb.legacy.io
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.map.rst
+++ b/docs/source/pynwb.legacy.map.rst
@@ -1,0 +1,7 @@
+pynwb\.legacy\.map module
+=========================
+
+.. automodule:: pynwb.legacy.map
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.legacy.rst
+++ b/docs/source/pynwb.legacy.rst
@@ -1,0 +1,24 @@
+pynwb\.legacy package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+
+    pynwb.legacy.io
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.legacy.map
+
+Module contents
+---------------
+
+.. automodule:: pynwb.legacy
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.misc.rst
+++ b/docs/source/pynwb.misc.rst
@@ -1,0 +1,7 @@
+pynwb\.misc module
+==================
+
+.. automodule:: pynwb.misc
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.ogen.rst
+++ b/docs/source/pynwb.ogen.rst
@@ -1,0 +1,7 @@
+pynwb\.ogen module
+==================
+
+.. automodule:: pynwb.ogen
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.ophys.rst
+++ b/docs/source/pynwb.ophys.rst
@@ -1,0 +1,7 @@
+pynwb\.ophys module
+===================
+
+.. automodule:: pynwb.ophys
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.retinotopy.rst
+++ b/docs/source/pynwb.retinotopy.rst
@@ -1,0 +1,7 @@
+pynwb\.retinotopy module
+========================
+
+.. automodule:: pynwb.retinotopy
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.rst
+++ b/docs/source/pynwb.rst
@@ -1,0 +1,39 @@
+pynwb package
+=============
+
+Subpackages
+-----------
+
+.. toctree::
+
+    pynwb.form
+    pynwb.io
+    pynwb.legacy
+
+Submodules
+----------
+
+.. toctree::
+
+   pynwb.base
+   pynwb.behavior
+   pynwb.core
+   pynwb.ecephys
+   pynwb.epoch
+   pynwb.file
+   pynwb.icephys
+   pynwb.image
+   pynwb.misc
+   pynwb.ogen
+   pynwb.ophys
+   pynwb.retinotopy
+   pynwb.spec
+   pynwb.validate
+
+Module contents
+---------------
+
+.. automodule:: pynwb
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.spec.rst
+++ b/docs/source/pynwb.spec.rst
@@ -1,0 +1,7 @@
+pynwb\.spec module
+==================
+
+.. automodule:: pynwb.spec
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/pynwb.validate.rst
+++ b/docs/source/pynwb.validate.rst
@@ -1,0 +1,7 @@
+pynwb\.validate module
+======================
+
+.. automodule:: pynwb.validate
+    :members:
+    :undoc-members:
+    :show-inheritance:


### PR DESCRIPTION
## Motivation

API documentation missing from readthedocs. See #267 

Look like an alternative would be to write our builder on readthedocs, not sure if it is worth the effort. I think it is reasonable to expect developer to locally generated the documentation and checked in the update.

See https://docs.readthedocs.io/en/latest/builds.html#understanding-what-s-going-on