### PR TITLE
Fixed bug to ensure apidoc and table setup is run on doc build

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -268,6 +268,7 @@ def run_apidoc(_):
     sys.path.append(src_dir)
     main(['-f', '-e', '-o', out_dir, src_dir])
 
+
 # https://github.com/sphinx-doc/sphinx/issues/3866
 class PatchedPythonDomain(PythonDomain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
@@ -275,6 +276,7 @@ class PatchedPythonDomain(PythonDomain):
             del node['refspecific']
         return super(PatchedPythonDomain, self).resolve_xref(
             env, fromdocname, builder, typ, target, node, contnode)
+
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,22 +109,6 @@ pygments_style = 'sphinx'
 html_theme = "sphinx_rtd_theme"
 html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
-
-def run_apidoc(_):
-    from sphinx.apidoc import main
-    import os
-    import sys
-    out_dir = os.path.dirname(__file__)
-    src_dir = os.path.join(out_dir, '../../src')
-    sys.path.append(src_dir)
-    main(['-f', '-e', '-o', out_dir, src_dir])
-
-
-def setup(app):
-    app.connect('builder-inited', run_apidoc)
-    app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
-
-
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
 # documentation.
@@ -274,6 +258,16 @@ latex_elements = {
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
+
+def run_apidoc(_):
+    from sphinx.apidoc import main
+    import os
+    import sys
+    out_dir = os.path.dirname(__file__)
+    src_dir = os.path.join(out_dir, '../../src')
+    sys.path.append(src_dir)
+    main(['-f', '-e', '-o', out_dir, src_dir])
+
 # https://github.com/sphinx-doc/sphinx/issues/3866
 class PatchedPythonDomain(PythonDomain):
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
@@ -282,6 +276,7 @@ class PatchedPythonDomain(PythonDomain):
         return super(PatchedPythonDomain, self).resolve_xref(
             env, fromdocname, builder, typ, target, node, contnode)
 
-
-def setup(sphinx):
-    sphinx.override_domain(PatchedPythonDomain)
+def setup(app):
+    app.connect('builder-inited', run_apidoc)
+    app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
+    app.override_domain(PatchedPythonDomain)


### PR DESCRIPTION
## Motivation

Fix #267 . The ``setup(app)`` function in ``docs/source/conf.py`` was overwritten. This pull request merges the two implementations to ensure that the changes implemented by the two functions are both being executed. This pull requests should also fix the issue from #279. 

## How to test the behavior?

Run  ``make clean`` `make html`` which will produce a list of missing files. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
