### PR TITLE
Added a pointer to the installation instructions to the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,11 @@ The NWB:N team consists of neuroscientists and software developers
 who recognize that adoption of a unified data format is an important step toward
 breaking down the barriers to data sharing in neuroscience.
 
+Installation
+============
+
+See the PyNWB documentation for details http://pynwb.readthedocs.io/en/latest/getting_started.html#installation
+
 Code of Conduct
 ===============
 


### PR DESCRIPTION
## Motivation

On the slack channel a user noted that they could not find installation instructions for PyNWB from the repo.

## Changes?

Added installation section with a link to the installation instructions in the PyNWB docs to the README.rst

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
