### PR TITLE
Refactor get_builder_dt legacy to be explicit

### DIFF
--- a/src/pynwb/legacy/map.py
+++ b/src/pynwb/legacy/map.py
@@ -23,56 +23,101 @@ class ObjectMapperLegacy(ObjectMapper):
 
 class TypeMapLegacy(TypeMap):
 
-    def get_builder_dt(self, builder):
+    def get_builder_dt(self, builder):  # noqa: C901
+        '''
+        For a given builder, return the neurodata_type.  In this legacy
+        TypeMap, the builder may have out-of-spec neurodata_type; this
+        function coerces this to a 2.0 compatible version.
+        '''
 
-        if builder.name == 'roi_ids':
-            pass
-        elif builder.name == 'root':
+        if builder.name == 'root':
             return 'NWBFile'
-        attrs = builder.attributes
-        ndt = attrs.get('neurodata_type')
-        if ndt == 'Module':
-            return 'ProcessingModule'
-        elif ndt == 'TimeSeries':
-            ancestry = attrs['ancestry']
-            if decode(ancestry[-1]) == 'TwoPhotonSeries' and decode(builder.name) == 'corrected':
-                return 'ImageSeries'
-            else:
-                return decode(ancestry[-1])
-
-        elif ndt == 'Interface':
-            return builder.name
-        if ndt == 'Epoch':
-            return 'Epoch'
         else:
-            parent_ndt = self.get_builder_dt(builder.parent)
-            if parent_ndt == 'Epoch':
-                return 'EpochTimeSeries'
-            if parent_ndt == 'MotionCorrection':
-                return 'CorrectedImageStack'
-            if parent_ndt == 'ImagingPlane' and isinstance(builder, GroupBuilder):
-                return 'OpticalChannel'
-            if parent_ndt == 'ImageSegmentation':
-                if builder.name in ('roi_ids', 'cell_specimen_ids'):
+
+            attrs = builder.attributes
+            ndt = attrs.get('neurodata_type')
+
+            if ndt == 'Module':
+                return 'ProcessingModule'
+            elif ndt == 'Interface':
+                return builder.name
+            elif ndt == 'Epoch':
+                return 'Epoch'
+            elif ndt == 'TimeSeries':
+                ancestry = decode(attrs['ancestry'][-1])
+                if ancestry == 'TwoPhotonSeries' and decode(builder.name) == 'corrected':
+                    return 'ImageSeries'
+                else:
+                    return ancestry
+            elif ndt == 'Custom':
+                parent_ndt = self.get_builder_dt(builder.parent)
+                if parent_ndt == 'ImageSegmentation' and builder.name in ('roi_ids', 'cell_specimen_ids'):
+                    return None
+                elif parent_ndt == 'PlaneSegmentation' and builder.name in ('roi_list', 'imaging_plane_name'):
+                    return None
+                elif parent_ndt == 'IntervalSeries' and builder.name in ('frame_duration',):
+                    return None
+                elif parent_ndt == 'TimeSeries' and builder.name in ('feature_description',
+                                                                     'bits_per_pixel',
+                                                                     'dimension',
+                                                                     'field_of_view',
+                                                                     'format'):
+                    return None
+                elif parent_ndt == 'ImagingPlane' and builder.parent.name in ('imaging_plane_1',):
+                    return None
+                elif parent_ndt == 'AbstractFeatureSeries' and builder.name in ('frame_duration',):
+                    return None
+                elif parent_ndt == 'IndexSeries' and builder.name in ('frame_duration',):
+                    return None
+                elif builder.parent.name == 'general':
+                    return None
+                elif parent_ndt == 'RoiResponseSeries' and builder.name in ('r',
+                                                                            'neuropil_traces_path',
+                                                                            'rmse',
+                                                                            'comments'):
                     return None
                 else:
-                    return 'PlaneSegmentation'
-
+                    raise RuntimeError(('Unable to determine neurodata_type: attrs["neurodata_type"]: "Custom",'
+                                        'parent.neurodata_type: %s' % parent_ndt))
             else:
-                if parent_ndt == 'PlaneSegmentation':
+                parent_ndt = self.get_builder_dt(builder.parent)
+                if parent_ndt == 'Epoch':
+                    return 'EpochTimeSeries'
+                elif parent_ndt == 'MotionCorrection':
+                    return 'CorrectedImageStack'
+                elif parent_ndt == 'ImagingPlane' and isinstance(builder, GroupBuilder):
+                    return 'OpticalChannel'
+                elif parent_ndt == 'ImageSegmentation':
+                    return 'PlaneSegmentation'
+                elif parent_ndt == 'PlaneSegmentation':
                     if builder.name in ('roi_list', 'imaging_plane_name'):
                         return None
                     else:
                         return 'ROI'
-
-                parent_names = {
-                    'extracellular_ephys': 'ElectrodeGroup',
-                    'intracellular_ephys': 'IntracellularElectrodeGroup',
-                    'optophysiology': 'ImagingPlane',
-                    'optogenetics': 'OptogeneticStimulusSite'
-                }
-                return decode(parent_names.get(builder.parent.name))
-            return None
+                else:
+                    parent_names = {
+                        'extracellular_ephys': 'ElectrodeGroup',
+                        'intracellular_ephys': 'IntracellularElectrodeGroup',
+                        'optophysiology': 'ImagingPlane',
+                        'optogenetics': 'OptogeneticStimulusSite',
+                        'root': None,
+                        'xy_translation': None,
+                        'imaging_plane_1': None,
+                        'running_speed': None,
+                        'general': None,
+                        '2p_image_series': None,
+                        'natural_movie_one_stimulus': None,
+                        'natural_scenes_stimulus': None,
+                        'devices': None,
+                        'spontaneous_stimulus': None,
+                        'static_gratings_stimulus': None,
+                        'maximum_intensity_projection_image': None,
+                        'imaging_plane_1_neuropil_response': None,
+                        'imaging_plane_1_demixed_signal': None,
+                        'corrected': None,
+                        'running_speed_index': None
+                    }
+                    return decode(parent_names[builder.parent.name])
 
     def get_builder_ns(self, builder):
         return 'core'


### PR DESCRIPTION
## Motivation

Resolves #258 

Debugging and developing legacy files (for example #275) is difficult because the code paths that legacy/map.py::get_builder_dt.py can take are very complicated.  This commit refactors this function, to make its behavior explicit and (relatively) easy.

## How to test the behavior?
```
make test
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
