### PR TITLE
fix inheritance of links

### DIFF
--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -749,7 +749,6 @@ class GroupSpec(BaseStorageSpec):
         for link in inc_spec.links:
             if link.data_type_inc is not None:
                 data_types.append(link)
-                continue
             self.__new_links.discard(link.name)
             if link.name in self.__links:
                 self.__overridden_links.add(link.name)


### PR DESCRIPTION
## Motivation

Links to IntracellularElectrode in PatchClampSeries subtypes were not being created

## How to test the behavior?
write a PatchClampSeries subtype

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
