### PR TITLE
Enh/dup ts check

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -33,18 +33,7 @@ class ProcessingModule(NWBContainer):
         description, containers = popargs('description', 'containers', kwargs)
         super(ProcessingModule, self).__init__(**kwargs)
         self.description = description
-        self.__containers = self.__to_dict(containers)
-
-    def __to_dict(self, arg):
-        if arg is None:
-            return dict()
-        else:
-            return_dict = {}
-            for i in arg:
-                assert i.name is not None  # If a container doesn't have a name, it gets lost!
-                assert i.name not in return_dict
-                return_dict[i.name] = i
-            return return_dict
+        self.__containers = self._to_dict(containers, 'module_containers')
 
     @property
     def containers(self):

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -21,6 +21,22 @@ def set_parents(container, parent):
     return ret
 
 
+class LabelledDict(dict):
+    '''
+    A dict wrapper class for aggregating Timeseries
+    from the standard locations
+    '''
+
+    @docval({'name': 'label', 'type': str, 'doc': 'the TimeSeries type ('})
+    def __init__(self, **kwargs):
+        label = getargs('label', kwargs)
+        self.__label = label
+
+    @property
+    def label(self):
+        return self.__label
+
+
 class NWBBaseType(with_metaclass(ExtenderMeta)):
     '''The base class to any NWB types.
 
@@ -120,6 +136,17 @@ class NWBContainer(NWBBaseType, Container):
     def __init__(self, **kwargs):
         call_docval_func(super(NWBContainer, self).__init__, kwargs)
         self.source = getargs('source', kwargs)
+
+    def _to_dict(self, arg, label="NULL"):
+        return_dict = LabelledDict(label)
+        if arg is None:
+            return return_dict
+        else:
+            for i in arg:
+                assert i.name is not None  # If a container doesn't have a name, it gets lost!
+                assert i.name not in return_dict
+                return_dict[i.name] = i
+            return return_dict
 
 
 @register_class('NWBData', CORE_NAMESPACE)

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -11,7 +11,7 @@ from .epoch import Epoch
 from .ecephys import ElectrodeTable, ElectrodeTableRegion, ElectrodeGroup, Device
 from .icephys import IntracellularElectrode
 from .ophys import ImagingPlane
-from .core import NWBContainer
+from .core import NWBContainer, LabelledDict
 
 from h5py import RegionReference
 
@@ -30,22 +30,6 @@ class Image(Container):
 class SpecFile(Container):
     # TODO: Implement this
     pass
-
-
-class TimeSeriesDict(dict):
-    '''
-    A dict wrapper class for aggregating Timeseries
-    from the standard locations
-    '''
-
-    @docval({'name': 'ts_type', 'type': str, 'doc': 'the TimeSeries type ('})
-    def __init__(self, **kwargs):
-        ts_type = getargs('ts_type', kwargs)
-        self.__ts_type = ts_type
-
-    @property
-    def ts_type(self):
-        return self.__ts_type
 
 
 @register_class('NWBFile', CORE_NAMESPACE)
@@ -145,15 +129,15 @@ class NWBFile(NWBContainer):
         self.__stimulus = self.__build_ts('stimulus', kwargs)
         self.__stimulus_template = self.__build_ts('stimulus_template', kwargs)
 
-        self.__modules = self.__to_dict(getargs('modules', kwargs))
-        self.__epochs = self.__to_dict(getargs('epochs', kwargs))
+        self.__modules = self._to_dict('modules', kwargs)
+        self.__epochs = self._to_dict('epochs', kwargs)
         self.__ec_electrodes = getargs('ec_electrodes', kwargs)
-        self.__ec_electrode_groups = self.__to_dict(getargs('ec_electrode_groups', kwargs))
-        self.__devices = self.__to_dict(getargs('devices', kwargs))
+        self.__ec_electrode_groups = self._to_dict('ec_electrode_groups', kwargs)
+        self.__devices = self._to_dict('devices', kwargs)
 
-        self.__ic_electrodes = self.__to_dict(getargs('ic_electrodes', kwargs))
+        self.__ic_electrodes = self._to_dict('ic_electrodes', kwargs)
 
-        self.__imaging_planes = self.__to_dict(getargs('imaging_planes', kwargs))
+        self.__imaging_planes = self._to_dict('imaging_planes', kwargs)
 
         recommended = [
             'experimenter',
@@ -165,14 +149,11 @@ class NWBFile(NWBContainer):
         for attr in recommended:
             setattr(self, attr, kwargs.get(attr, None))
 
-    def __to_dict(self, arg):
-        if arg is None:
-            return dict()
-        else:
-            return {i.name: i for i in arg}
+    def _to_dict(self, label, const_args):
+        return super(NWBFile, self)._to_dict(getargs(label, const_args), label)
 
     def __build_ts(self, ts_type, kwargs):
-        ret = TimeSeriesDict(ts_type)
+        ret = LabelledDict(ts_type)
         const_arg = getargs(ts_type, kwargs)
         if const_arg:
             for ts in const_arg:
@@ -427,7 +408,7 @@ class NWBFile(NWBContainer):
 
     def __set_timeseries(self, ts_dict, ts, epoch=None):
         if ts.name in ts_dict:
-            msg = "%s already exists in %s" % (ts.name, ts_dict.ts_type)
+            msg = "%s already exists in %s" % (ts.name, ts_dict.label)
             raise ValueError(msg)
         ts_dict[ts.name] = ts
         if ts.parent is None:

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -47,6 +47,7 @@ class TimeSeriesDict(dict):
     def ts_type(self):
         return self.__ts_type
 
+
 @register_class('NWBFile', CORE_NAMESPACE)
 class NWBFile(NWBContainer):
     """

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -53,23 +53,23 @@ class NWBFileTest(unittest.TestCase):
         six.assertCountEqual(self, expected_tags, tags)
 
     def test_add_acquisition(self):
-        self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
-                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0, 1, 2, 3, 4, 5],
+                                                'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
         self.assertEqual(len(self.nwbfile.acquisition), 1)
 
     def test_add_stimulus(self):
-        self.nwbfile.add_stimulus(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
-                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.nwbfile.add_stimulus(TimeSeries('test_ts', 'unit test test_add_acquisition', [0, 1, 2, 3, 4, 5],
+                                             'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
         self.assertEqual(len(self.nwbfile.stimulus), 1)
 
     def test_add_stimulus_template(self):
-        self.nwbfile.add_stimulus_template(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
-                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.nwbfile.add_stimulus_template(TimeSeries('test_ts', 'unit test test_add_acquisition', [0, 1, 2, 3, 4, 5],
+                                                      'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
         self.assertEqual(len(self.nwbfile.stimulus_template), 1)
 
     def test_add_acquisition_check_dups(self):
-        self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
-                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0, 1, 2, 3, 4, 5],
+                                                'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
         with self.assertRaises(ValueError):
-            self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
-                                                    timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+            self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0, 1, 2, 3, 4, 5],
+                                                    'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -4,7 +4,7 @@ import six
 
 from datetime import datetime
 
-from pynwb import NWBFile
+from pynwb import NWBFile, TimeSeries
 from pynwb.ecephys import Device
 
 
@@ -51,3 +51,25 @@ class NWBFileTest(unittest.TestCase):
                                   tags=tags2, descrition='test epoch')
         tags = self.nwbfile.epoch_tags
         six.assertCountEqual(self, expected_tags, tags)
+
+    def test_add_acquisition(self):
+        self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
+                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.assertEqual(len(self.nwbfile.acquisition), 1)
+
+    def test_add_stimulus(self):
+        self.nwbfile.add_stimulus(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
+                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.assertEqual(len(self.nwbfile.stimulus), 1)
+
+    def test_add_stimulus_template(self):
+        self.nwbfile.add_stimulus_template(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
+                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.assertEqual(len(self.nwbfile.stimulus_template), 1)
+
+    def test_add_acquisition_check_dups(self):
+        self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
+                                                timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        with self.assertRaises(ValueError):
+            self.nwbfile.add_acquisition(TimeSeries('test_ts', 'unit test test_add_acquisition', [0,1,2,3,4,5], 'grams',
+                                                    timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))


### PR DESCRIPTION
## Motivation

NWBFile wasn't catching when users were adding TimeSeries with duplicate names

## How to test the behavior?
The following code should raise a ValueError
```
self.nwbfile.add_acquisition(TimeSeries('test_ts', ...))
self.nwbfile.add_acquisition(TimeSeries('test_ts', ...))
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
