### PR TITLE
fix #293, fix #290

### DIFF
--- a/docs/source/tutorial_source/extension.rst
+++ b/docs/source/tutorial_source/extension.rst
@@ -17,14 +17,14 @@ it calls :py:meth:`~form.spec.write.NamespaceBuilder.export` to save the extensi
 
 .. code-block:: python
 
-    from pynwb import NWBNamespaceBuilder, NWBGroupSpec, NWBAttributeSpec
+    from pynwb.spec import NWBNamespaceBuilder, NWBGroupSpec, NWBAttributeSpec
 
     ns_path = "mylab.namespace.yaml"
     ext_source = "mylab.extensions.yaml"
 
     ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', "mylab")
     ext = NWBGroupSpec('A custom ElectricalSeries for my lab',
-                       attributes=[NWBAttributeSpec('trode_id', 'int', 'the tetrode id')],
+                       attributes=[NWBAttributeSpec('trode_id', 'the tetrode id', 'int')],
                        neurodata_type_inc='ElectricalSeries',
                        neurodata_type_def='TetrodeSeries')
 


### PR DESCRIPTION
## Motivation

Documentation was out of sync with the state of the API

## How to test the behavior?

See http://pynwb.readthedocs.io/en/latest/tutorials.html#defining-extensions

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
