### PR TITLE
removes reference_images kwarg from ROI docval. fixes #307. fixes #326

### DIFF
--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -179,8 +179,7 @@ class ROI(NWBContainer):
             {'name': 'pix_mask', 'type': Iterable, 'doc': 'List of pixels (x,y) that compose the mask.'},
             {'name': 'pix_mask_weight', 'type': Iterable, 'doc': 'Weight of each pixel listed in pix_mask.'},
             {'name': 'img_mask', 'type': Iterable, 'doc': 'ROI mask, represented in 2D ([y][x]) intensity image.'},
-            {'name': 'reference_images', 'type': (ImageSeries, str),
-             'doc': 'One or more image stacks that the masks apply to (can be oneelement stack).'})
+            )
     def __init__(self, **kwargs):
         roi_description, pix_mask, pix_mask_weight, img_mask = popargs(
             'roi_description', 'pix_mask', 'pix_mask_weight', 'img_mask', kwargs)


### PR DESCRIPTION
## Motivation

fixes #307 

## How to test the behavior?
```
import numpy as np

NA = 'THIS REQUIRED ATTRIBUTE INTENTIONALLY LEFT BLANK.'

from pynwb import image, ophys
max_proj = image.ImageSeries(
    name = 'Maximum Projection Image',
    source = NA,
    data = np.random.rand(10,10),
    unit = NA,
    format = 'raw',
    timestamps = [0.0], 
)

roi = ophys.ROI(
    name = NA,
    source = NA,
    roi_description = NA,
    pix_mask = [],
    pix_mask_weight = [],
    img_mask = np.random.rand(10,10),
    reference_images = max_proj, 
)

print roi.reference_images
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
