### PR TITLE
Proof of concept for #309

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -1,7 +1,7 @@
 from collections import Iterable
 
 from .form.utils import docval, getargs, popargs, fmt_docval_args
-from .form.data_utils import DataChunkIterator
+from .form.data_utils import AbstractDataChunkIterator
 
 from . import register_class, CORE_NAMESPACE
 from .core import NWBContainer
@@ -90,7 +90,7 @@ class TimeSeries(NWBContainer):
              'doc': ('Name of TimeSeries or Modules that serve as the source for the data '
                      'contained here. It can also be the name of a device, for stimulus or '
                      'acquisition data')},
-            {'name': 'data', 'type': (Iterable, 'TimeSeries', DataChunkIterator),
+            {'name': 'data', 'type': (Iterable, 'TimeSeries', AbstractDataChunkIterator),
              'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)'},
             {'name': 'resolution', 'type': (str, float),
@@ -102,7 +102,7 @@ class TimeSeries(NWBContainer):
              'default': _default_conversion},
 
             # time related data is optional, but one is required -- this will have to be enforced in the constructor
-            {'name': 'timestamps', 'type': (Iterable, 'TimeSeries', DataChunkIterator),
+            {'name': 'timestamps', 'type': (Iterable, 'TimeSeries', AbstractDataChunkIterator),
              'doc': 'Timestamps for samples stored in data', 'default': None},
             {'name': 'starting_time', 'type': float, 'doc': 'The timestamp of the first sample', 'default': None},
             {'name': 'rate', 'type': float, 'doc': 'Sampling rate in Hz', 'default': None},
@@ -139,7 +139,7 @@ class TimeSeries(NWBContainer):
         if isinstance(data, TimeSeries):
             data.fields['data_link'].append(self)
             self.fields['num_samples'] = data.num_samples
-        elif isinstance(data, DataChunkIterator):
+        elif isinstance(data, AbstractDataChunkIterator):
             self.fields['num_samples'] = -1
         else:
             self.fields['num_samples'] = len(data)

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -3,7 +3,7 @@ from h5py import RegionReference
 from collections import Iterable
 
 from .form.utils import docval, getargs, popargs, call_docval_func
-from .form.data_utils import DataChunkIterator, ShapeValidator
+from .form.data_utils import AbstractDataChunkIterator, ShapeValidator
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
@@ -115,7 +115,7 @@ class ElectricalSeries(TimeSeries):
              'doc': ('Name of TimeSeries or Modules that serve as the source for the data '
                      'contained here. It can also be the name of a device, for stimulus or '
                      'acquisition data')},
-            {'name': 'data', 'type': (list, np.ndarray, DataChunkIterator, TimeSeries, Iterable),
+            {'name': 'data', 'type': (list, np.ndarray, AbstractDataChunkIterator, TimeSeries, Iterable),
              'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
 
             {'name': 'electrodes', 'type': ElectrodeTableRegion,
@@ -126,7 +126,7 @@ class ElectricalSeries(TimeSeries):
             {'name': 'conversion', 'type': float,
              'doc': 'Scalar to multiply each element by to conver to volts', 'default': _default_conversion},
 
-            {'name': 'timestamps', 'type': (list, np.ndarray, DataChunkIterator, TimeSeries, Iterable),
+            {'name': 'timestamps', 'type': (list, np.ndarray, AbstractDataChunkIterator, TimeSeries, Iterable),
              'doc': 'Timestamps for samples stored in data', 'default': None},
             {'name': 'starting_time', 'type': float, 'doc': 'The timestamp of the first sample', 'default': None},
             {'name': 'rate', 'type': float, 'doc': 'Sampling rate in Hz', 'default': None},
@@ -169,9 +169,9 @@ class SpikeEventSeries(ElectricalSeries):
              'doc': ('Name of TimeSeries or Modules that serve as the source for the data '
                      'contained here. It can also be the name of a device, for stimulus or '
                      'acquisition data')},
-            {'name': 'data', 'type': (list, np.ndarray, DataChunkIterator, TimeSeries, Iterable),
+            {'name': 'data', 'type': (list, np.ndarray, AbstractDataChunkIterator, TimeSeries, Iterable),
              'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
-            {'name': 'timestamps', 'type': (list, np.ndarray, DataChunkIterator, TimeSeries, Iterable),
+            {'name': 'timestamps', 'type': (list, np.ndarray, AbstractDataChunkIterator, TimeSeries, Iterable),
              'doc': 'Timestamps for samples stored in data'},
             {'name': 'electrodes', 'type': ElectrodeTableRegion,
              'doc': 'the table region corresponding to the electrodes from which this series was recorded'},
@@ -194,11 +194,11 @@ class SpikeEventSeries(ElectricalSeries):
         name, source, data, electrodes = popargs('name', 'source', 'data', 'electrodes', kwargs)
         timestamps = getargs('timestamps', kwargs)
         if not (isinstance(data, TimeSeries) and isinstance(timestamps, TimeSeries)):
-            if not (isinstance(data, DataChunkIterator) and isinstance(timestamps, DataChunkIterator)):
+            if not (isinstance(data, AbstractDataChunkIterator) and isinstance(timestamps, AbstractDataChunkIterator)):
                 if len(data) != len(timestamps):
                     raise Exception('Must provide the same number of timestamps and spike events')
             else:
-                # TODO: add check when we have DataChunkIterators
+                # TODO: add check when we have AbstractDataChunkIterators
                 pass
         super(SpikeEventSeries, self).__init__(name, source, data, electrodes, **kwargs)
 
@@ -400,11 +400,11 @@ class FeatureExtraction(NWBContainer):
     @docval({'name': 'source', 'type': str, 'doc': 'The source of the data'},
             {'name': 'electrodes', 'type': ElectrodeTableRegion,
              'doc': 'the table region corresponding to the electrodes from which this series was recorded'},
-            {'name': 'description', 'type': (list, tuple, np.ndarray, DataChunkIterator),
+            {'name': 'description', 'type': (list, tuple, np.ndarray, AbstractDataChunkIterator),
              'doc': 'A description for each feature extracted', 'ndim': 1},
-            {'name': 'times', 'type': (list, tuple, np.ndarray, DataChunkIterator),
+            {'name': 'times', 'type': (list, tuple, np.ndarray, AbstractDataChunkIterator),
              'doc': 'The times of events that features correspond to', 'ndim': 1},
-            {'name': 'features', 'type': (list, tuple, np.ndarray, DataChunkIterator),
+            {'name': 'features', 'type': (list, tuple, np.ndarray, AbstractDataChunkIterator),
              'doc': 'Features for each channel', 'ndim': 3},
             {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'FeatureExtraction'})
     def __init__(self, **kwargs):

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -8,7 +8,7 @@ import warnings
 from ...container import Container
 
 from ...utils import docval, getargs, popargs, call_docval_func
-from ...data_utils import AbstractDataChunkIterator, get_shape
+from ...data_utils import AbstractDataChunkIterator, get_shape, DataChunkIterator
 from ...build import Builder, GroupBuilder, DatasetBuilder, LinkBuilder, BuildManager, RegionBuilder, TypeMap
 from ...spec import RefSpec, DtypeSpec, NamespaceCatalog, SpecWriter, SpecReader, GroupSpec
 from ...spec import NamespaceBuilder
@@ -291,9 +291,6 @@ class HDF5IO(FORMIO):
                 datas.append((self.__file.get(dbldr.name), dbldr.data))
 
         for dset, data in datas:
-            recommended_chunks = data.recommended_chunk_shape()
-            chunks = True if recommended_chunks is None else recommended_chunks
-            baseshape = data.recommended_data_shape()
             for chunk_i in data:
                 # Determine the minimum array dimensions to fit the chunk selection
                 max_bounds = self.__selection_max_bounds__(chunk_i.selection)
@@ -545,7 +542,7 @@ class HDF5IO(FORMIO):
                     self.__queue_ref(_filler)
                 return
             elif isinstance(data, Iterable) and not self.isinstance_inmemory_array(data):
-                dset = self.__chunked_iter_fill__(parent, name, AbstractDataChunkIterator(data=data, buffer_size=100))
+                dset = self.__chunked_iter_fill__(parent, name, DataChunkIterator(data=data, buffer_size=100))
             elif hasattr(data, '__len__'):
                 dset = self.__list_fill__(parent, name, data, dtype_spec=dtype)
             else:

--- a/src/pynwb/form/backends/io.py
+++ b/src/pynwb/form/backends/io.py
@@ -38,10 +38,21 @@ class FORMIO(with_metaclass(ABCMeta, object)):
         f_builder = self.__manager.build(container, source=self.__source)
         self.write_builder(f_builder)
 
+    @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'})
+    def plumb_data(self, **kwargs):
+        container = getargs('container', kwargs)
+        f_builder = self.__manager.build(container, source=self.__source)
+        self.write_plumb_data(f_builder)
+
     @abstractmethod
     @docval(returns='a GroupBuilder representing the read data', rtype='GroupBuilder')
     def read_builder(self):
         ''' Read data and return the GroupBuilder represention '''
+        pass
+
+    @abstractmethod
+    @docval({'name': 'builder', 'type': GroupBuilder, 'doc': 'the GroupBuilder object representing the Container'})
+    def write_plumb_data(self, **kwargs):
         pass
 
     @abstractmethod


### PR DESCRIPTION
This implements a streaming data iterator as described in https://github.com/NeurodataWithoutBorders/pynwb/issues/309. I think it fully implements it, although it still has a few rough edges and I didn't run `flake8` on it. Just want to get some feedback first.

The name `plumb_data` is random and can be changed if you like.

You can test with
```py
import numpy as np
from datetime import datetime
from pynwb import NWBFile
from pynwb import get_manager
from pynwb.form.backends.hdf5 import HDF5IO
from pynwb.form.build import Builder, BuildManager
from pynwb.form.data_utils import DataChunkIterator, DataChunkStream
from pynwb.ecephys import ElectricalSeries
from pynwb.behavior import SpatialSeries


rate = 10.0
np.random.seed(1234)
data_len = 1000
ephys_data = np.random.rand(data_len)
ephys_timestamps = np.arange(data_len) / rate
spatial_timestamps = ephys_timestamps[::10]
spatial_data = np.cumsum(np.random.normal(size=(2, len(spatial_timestamps))), axis=-1).T

f = NWBFile('the PyNWB tutorial', 'my first synthetic recording', 'EXAMPLE_ID', datetime.now(),
            experimenter='Dr. Bilbo Baggins',
            lab='Bag End Laboratory',
            institution='University of Middle Earth at the Shire',
            experiment_description='I went on an adventure with thirteen dwarves to reclaim vast treasures.',
            session_id='LONELYMTN')

filename = r"G:\Python\example.h5"
io = HDF5IO(filename, manager=get_manager(), mode='w')

epoch_tags = ('example_epoch',)
ep1 = f.create_epoch(source='an hypothetical source', name='epoch1', start=0.0, stop=1.0,
                     tags=epoch_tags,
                     description="the first test epoch")
ep2 = f.create_epoch(source='an hypothetical source', name='epoch2', start=0.0, stop=1.0,
                     tags=epoch_tags,
                     description="the second test epoch")
device = f.create_device(name='trodes_rig123', source="a source")
electrode_name = 'tetrode1'
source = "an hypothetical source"
description = "an example tetrode"
location = "somewhere in the hippocampus"
electrode_group = f.create_electrode_group(electrode_name,
                                           source=source,
                                           description=description,
                                           location=location,
                                           device=device)
for idx in [1, 2, 3, 4]:
    f.add_electrode(idx,
                    x=1.0, y=2.0, z=3.0,
                    imp=float(-idx),
                    location='CA1', filtering='none',
                    description='channel %s' % idx, group=electrode_group)
electrode_table_region = f.create_electrode_table_region([0, 2], 'the first and third electrodes')

stream = DataChunkStream(min_buffer_size=3000, dtype=ephys_data.dtype)
ephys_ts = ElectricalSeries('test_ephys_data',
                            'an hypothetical source',
                            stream,
                            electrode_table_region,
                            timestamps=ephys_timestamps,
                            # Alternatively, could specify starting_time and rate as follows
                            # starting_time=ephys_timestamps[0],
                            # rate=rate,
                            resolution=0.001,
                            comments="This data was randomly generated with numpy, using 1234 as the seed",
                            description="Random numbers generated with numpy.random.rand")
f.add_acquisition(ephys_ts, [ep1, ep2])

spatial_ts = SpatialSeries('test_spatial_timeseries',
                           'a stumbling rat',
                           DataChunkIterator(spatial_data),
                           'origin on x,y-plane',
                           timestamps=spatial_timestamps,
                           resolution=0.1,
                           comments="This data was generated with numpy, using 1234 as the seed",
                           description="This 2D Brownian process generated with "
                                       "np.cumsum(np.random.normal(size=(2, len(spatial_timestamps))), axis=-1).T")
f.add_acquisition(spatial_ts, [ep1, ep2])

io.write(f)


def read():
    io2 = HDF5IO(filename, get_manager(), mode='r')
    f2 = io2.read()
    d = f2.get_acquisition('test_ephys_data')
    print(d.num_samples, d.data.shape)
    io2.close()


read()
for _ in range(10):
    stream.append_data(ephys_data)
    io.plumb_data(f)
    read()

stream.flush_data()
io.plumb_data(f)
read()
io.close()
```
Notice that it buffers with 3000. When run this prints

```
0 (0,)
0 (0,)
0 (0,)
3000 (3000,)
3000 (3000,)
3000 (3000,)
6000 (6000,)
6000 (6000,)
6000 (6000,)
9000 (9000,)
9000 (9000,)
10000 (10000,)
```