### PR TITLE
Added tip to the extensions tutorial to point users to the schema docs

### DIFF
--- a/docs/source/tutorial_source/extension.rst
+++ b/docs/source/tutorial_source/extension.rst
@@ -59,6 +59,14 @@ The second file contains the details on newly defined types.
       neurodata_type_def: TetrodeSeries
       neurodata_type_inc: ElectricalSeries
 
+.. tip::
+
+    Detailed documentation of all components and `neurodata_types` that are part of the core schema of NWB:N are
+    available in the schema docs at `http://nwb-schema.readthedocs.io <http://nwb-schema.readthedocs.io>`_ .
+    Before creating a new type from scratch, please have a look at the schema docs to see if using or extending an
+    existing type may solve your problem. Also, the schema docs are helpful when extending an existing type to
+    better understand the design and structure of the neurodata_type you are using.
+
 
 Using extensions
 -----------------------------------------------------


### PR DESCRIPTION
This is in response to discussions in #323

## Motivation

Make sure users know where to find documentation on existing types when trying to create a new extension.

## How to test the behavior?

This is a change to the docs only

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
