### PR TITLE
add array_data macro to dynamically created constructors

### DIFF
--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -768,7 +768,7 @@ class TypeMap(object):
                 else:
                     return Container
             else:
-                return (list, tuple, dict, set)
+                return ('array_data',)
 
     @classmethod
     def __get_constructor(self, base, addl_fields):


### PR DESCRIPTION
## Motivation

fix #333 
## How to test the behavior?
 ```python
import numpy as np
import random

from pynwb.spec import NWBDatasetSpec, NWBNamespaceBuilder, NWBGroupSpec
from pynwb import get_class, load_namespaces, NWBFile, NWBHDF5IO

ns_path = "spikey.namespace.yaml"
ext_source = "spikey.extensions.yaml"
PopulationSpikeTimes = NWBGroupSpec(doc='Population Spike Times',
                                      datasets=[
                                          NWBDatasetSpec(doc='spike times for all neurons', 
                                                         shape=(1,), 
                                                         name='times', dtype='float'),
                                          NWBDatasetSpec(doc='data pointer', 
                                                         shape=(1,),
                                                         name='data_pointer', dtype='int')
                             ],
                           neurodata_type_def='PopulationSpikeTimes',
                           neurodata_type_inc='NWBContainer')
ns_builder = NWBNamespaceBuilder('spikey extensions', "spikey")
ns_builder.add_spec(ext_source, PopulationSpikeTimes)
ns_builder.export(ns_path)

# generate fake data
duration = 10
nspikes = 1000
nunits = 5

times = np.random.rand(nspikes) * duration
data_pointer = np.sort(random.sample(range(len(times)), nunits))

## pull types from yaml files
load_namespaces(ns_path)
PopulationSpikeTimes = get_class('PopulationSpikeTimes', 'spikey')

pop_data = PopulationSpikeTimes(name='example population', source='source',
                                                          times=times, data_pointer=data_pointer)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
