### PR TITLE
extension clarifying example

### DIFF
--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -324,16 +324,10 @@ Create a new type
 
     from pynwb.spec import NWBGroupSpec
 
-    # A list of NWBAttributeSpec objects to specify new attributes
-    addl_attributes = [...]
-    # A list of NWBDatasetSpec objects to specify new datasets
-    addl_datasets = [...]
-    # A list of NWBDatasetSpec objects to specify new groups
-    addl_groups = [...]
     spec = NWBGroupSpec('A custom NWB type',
-                        attributes = addl_attributes,
-                        datasets = addl_datasets,
-                        groups = addl_groups,
+                        attributes = [...],
+                        datasets = [...],
+                        groups = [...],
                         neurodata_type_def='MyNewNWBType')
 
 Extend an existing type


### PR DESCRIPTION
## Motivation

In the example case, the attributes, datasets, and groups are not "additional", since they are the only ones, so I changed to code to be a bit more clear and different from the case where you are truly extending a type