### PR TITLE
Add NWBDataInterface

### DIFF
--- a/docs/code/creating-and-writing-nwbfile.py
+++ b/docs/code/creating-and-writing-nwbfile.py
@@ -109,6 +109,37 @@ def main():
     f.add_acquisition(spatial_ts, [ep1, ep2])
     # create-timeseries: end
 
+    # create-data-interface: start
+    from pynwb.ecephys import LFP
+    from pynwb.behavior import Position
+
+    lfp = f.add_acquisition(LFP('a hypothetical source'))
+    ephys_ts = lfp.create_electrical_series('test_ephys_data',
+                                            'an hypothetical source',
+                                            ephys_data,
+                                            electrode_table_region,
+                                            timestamps=ephys_timestamps,
+                                            # Alternatively, could specify starting_time and rate as follows
+                                            # starting_time=ephys_timestamps[0],
+                                            # rate=rate,
+                                            resolution=0.001,
+                                            comments="This data was randomly generated with numpy, using 1234 as the seed",
+                                            description="Random numbers generated with numpy.random.rand")
+    f.set_epoch_timeseries([ep1, ep2], ephys_ts)
+
+    pos = f.add_acquisition(Position('a hypothetical source'))
+    spatial_ts = pos.create_spatial_series('test_spatial_timeseries',
+                                           'a stumbling rat',
+                                           spatial_data,
+                                           'origin on x,y-plane',
+                                           timestamps=spatial_timestamps,
+                                           resolution=0.1,
+                                           comments="This data was generated with numpy, using 1234 as the seed",
+                                           description="This 2D Brownian process generated with "
+                                                       "np.cumsum(np.random.normal(size=(2, len(spatial_timestamps))), axis=-1).T")
+    f.set_epoch_timeseries([ep1, ep2], spatial_ts)
+    # create-data-interface: end
+
 
 if __name__ == "__main__":
     main()

--- a/docs/code/creating-and-writing-nwbfile.py
+++ b/docs/code/creating-and-writing-nwbfile.py
@@ -123,7 +123,7 @@ def main():
                                             # starting_time=ephys_timestamps[0],
                                             # rate=rate,
                                             resolution=0.001,
-                                            comments="This data was randomly generated with numpy, using 1234 as the seed",
+                                            comments="This data was randomly generated with numpy, using 1234 as the seed",  # noqa: E501
                                             description="Random numbers generated with numpy.random.rand")
     f.set_epoch_timeseries([ep1, ep2], ephys_ts)
 
@@ -136,7 +136,7 @@ def main():
                                            resolution=0.1,
                                            comments="This data was generated with numpy, using 1234 as the seed",
                                            description="This 2D Brownian process generated with "
-                                                       "np.cumsum(np.random.normal(size=(2, len(spatial_timestamps))), axis=-1).T")
+                                                       "np.cumsum(np.random.normal(size=(2, len(spatial_timestamps))), axis=-1).T")  # noqa: E501
     f.set_epoch_timeseries([ep1, ep2], spatial_ts)
     # create-data-interface: end
 

--- a/docs/code/creating-and-writing-nwbfile.py
+++ b/docs/code/creating-and-writing-nwbfile.py
@@ -109,6 +109,37 @@ def main():
     f.add_acquisition(spatial_ts, [ep1, ep2])
     # create-timeseries: end
 
+    # create-data-interface: start
+    from pynwb.ecephys import LFP
+    from pynwb.behavior import Position
+
+    lfp = f.add_acquisition(LFP('a hypothetical source'))
+    ephys_ts = lfp.create_electrical_series('test_ephys_data',
+                                            'an hypothetical source',
+                                            ephys_data,
+                                            electrode_table_region,
+                                            timestamps=ephys_timestamps,
+                                            # Alternatively, could specify starting_time and rate as follows
+                                            # starting_time=ephys_timestamps[0],
+                                            # rate=rate,
+                                            resolution=0.001,
+                                            comments="This data was randomly generated with numpy, using 1234 as the seed",
+                                            description="Random numbers generated with numpy.random.rand")
+    f.set_epoch_timeseries([ep1, ep2], ephys_ts)
+
+    pos = f.add_acquisition(Position('a hypothetical source'))
+    spatial_ts = pos.create_spatial_series('test_spatial_timeseries',
+                                           'a stumbling rat',
+                                           spatial_data,
+                                           'origin on x,y-plane',
+                                           timestamps=spatial_timestamps,
+                                           resolution=0.1,
+                                           comments="This data was generated with numpy, using 1234 as the seed",
+                                           description="This 2D Brownian process generated with "
+                                                       "np.cumsum(np.random.normal(size=(2, len(spatial_timestamps))), axis=-1).T")
+    f.set_epoch_timeseries([ep1, ep2], spatial_ts)
+    # create-data-interface: end
+
     # create-compressed-timeseries: start
     from pynwb.ecephys import ElectricalSeries
     from pynwb.behavior import SpatialSeries
@@ -138,7 +169,6 @@ def main():
                                            "np.cumsum(np.random.normal(size=(2, len(spatial_timestamps))), axis=-1).T")
     f.add_acquisition(spatial_ts, [ep1, ep2])
     # create-compressed-timeseries: end
-
 
 if __name__ == "__main__":
     main()

--- a/docs/code/creating-and-writing-nwbfile.py
+++ b/docs/code/creating-and-writing-nwbfile.py
@@ -119,9 +119,6 @@ def main():
                                             ephys_data,
                                             electrode_table_region,
                                             timestamps=ephys_timestamps,
-                                            # Alternatively, could specify starting_time and rate as follows
-                                            # starting_time=ephys_timestamps[0],
-                                            # rate=rate,
                                             resolution=0.001,
                                             comments="This data was randomly generated with numpy, using 1234 as the seed",  # noqa: E501
                                             description="Random numbers generated with numpy.random.rand")
@@ -150,9 +147,6 @@ def main():
                                 H5DataIO(ephys_data, compress=True),
                                 electrode_table_region,
                                 timestamps=H5DataIO(ephys_timestamps, compress=True),
-                                # Alternatively, could specify starting_time and rate as follows
-                                # starting_time=ephys_timestamps[0],
-                                # rate=rate,
                                 resolution=0.001,
                                 comments="This data was randomly generated with numpy, using 1234 as the seed",
                                 description="Random numbers generated with numpy.random.rand")

--- a/docs/code/creating-and-writing-nwbfile.py
+++ b/docs/code/creating-and-writing-nwbfile.py
@@ -164,5 +164,6 @@ def main():
     f.add_acquisition(spatial_ts, [ep1, ep2])
     # create-compressed-timeseries: end
 
+
 if __name__ == "__main__":
     main()

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -36,8 +36,19 @@ add_function_parentheses = False
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.autodoc', 'sphinx.ext.napoleon', 'sphinx.ext.intersphinx']
-intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.intersphinx'
+]
+
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3.5', None),
+    'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+    'scipy': ('http://docs.scipy.org/doc/scipy/reference', None),
+    'matplotlib': ('http://matplotlib.org', None),
+    'h5py': ('http://docs.h5py.org/en/latest/', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -97,6 +97,8 @@ and adding them with :py:meth:`~pynwb.file.NWBFile.add_acquisition`.
    :end-before: create-timeseries: end
    :dedent: 4
 
+For additional :py:class:`~pynwb.base.TimeSeries` classes that can be added as acquisition, see the :ref:`TimeSeries overview <timeseries_overview>`.
+
 
 Adding other acquisition data
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -111,17 +113,23 @@ The follow example shows how to do this with two container types that hold :py:c
    :end-before: create-data-interface: end
    :dedent: 4
 
+For additional :py:class:`~pynwb.core.NWBDataInterface` classes that can be added as acquisition, see the :ref:`ProcessingModules overview <modules_overview>`.
 
 .. _useextension:
 
-Creating Compressed TimeSeries
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Compressing datasets
+^^^^^^^^^^^^^^^^^^^^
+
+HDF5 allows for compression of dataset. This is controled on a per-dataset basis [#]_. To compress a dataset,
+wrap the data object (e.g. a :py:class:`list` or :py:class:`~numpy.ndarray`) with :py:class:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`.
 
 .. literalinclude:: ../code/creating-and-writing-nwbfile.py
    :language: python
    :start-after: create-compressed-timeseries: start
    :end-before: create-compressed-timeseries: end
    :dedent: 4
+
+.. [#] Global compression of all datasets is not allowed for performance reasons.
 
 
 Using Extensions

--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -98,6 +98,20 @@ and adding them with :py:meth:`~pynwb.file.NWBFile.add_acquisition`.
    :dedent: 4
 
 
+Adding other acquisition data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Subclasses of :py:class:`~pynwb.core.NWBDataInterface` can also be added as acquisition data.
+
+The follow example shows how to do this with two container types that hold :py:class:`~pynwb.base.TimeSeries`.
+
+.. literalinclude:: ../code/creating-and-writing-nwbfile.py
+   :language: python
+   :start-after: create-data-interface: start
+   :end-before: create-data-interface: end
+   :dedent: 4
+
+
 .. _useextension:
 
 Creating Compressed TimeSeries

--- a/docs/source/example.rst
+++ b/docs/source/example.rst
@@ -98,6 +98,20 @@ and adding them with :py:meth:`~pynwb.file.NWBFile.add_acquisition`.
    :dedent: 4
 
 
+Adding other acquisition data
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Subclasses of :py:class:`~pynwb.core.NWBDataInterface` can also be added as acquisition data.
+
+The follow example shows how to do this with two container types that hold :py:class:`~pynwb.base.TimeSeries`.
+
+.. literalinclude:: ../code/creating-and-writing-nwbfile.py
+   :language: python
+   :start-after: create-data-interface: start
+   :end-before: create-data-interface: end
+   :dedent: 4
+
+
 .. _useextension:
 
 Using Extensions

--- a/docs/source/overview_nwbfile.rst
+++ b/docs/source/overview_nwbfile.rst
@@ -33,8 +33,6 @@ serves as the base class for all other TimeSeries types.
 
 The following TimeSeries objects are provided by the API and NWB specification:
 
-* :py:class:`~pynwb.base.TimeSeries` - a general
-
   * :py:class:`~pynwb.ecephys.ElectricalSeries`
 
     * :py:class:`~pynwb.ecephys.SpikeEventSeries`
@@ -71,17 +69,15 @@ Processing Modules
 
 Processing modules are objects that group together common analyses done during processing of data.
 Processing module objects are unique collections of analysis results. To standardize the storage of
-common analyses, NWB provides the concept of an * NWBContaine*, where the output of
-common analyses are represented as objects that extend the :py:class:`~pynwb.base.NWBContainer` class.
-In most cases, you will not need to interact with the :py:class:`~pynwb.base. NWBContaine` class directly.
+common analyses, NWB provides the concept of an *NWBDataInterface*, where the output of
+common analyses are represented as objects that extend the :py:class:`~pynwb.core.NWBDataInterface` class.
+In most cases, you will not need to interact with the :py:class:`~pynwb.core.NWBDataInterface` class directly.
 More commonly, you will be creating instances of classes that extend this class. For example, a common
 analysis step for spike data (represented in NWB as a :py:class:`~pynwb.ecephys.SpikeEventSeries` object)
-is spike clustering. In NWB, the result of this kind of analysis will be represented with a :
-py:class:`~pynwb.ecephys.Clustering` object.
+is spike clustering. In NWB, the result of this kind of analysis will be represented with a
+:py:class:`~pynwb.ecephys.Clustering` object.
 
-The following analysis NWBContainer objects are provided by the API and NWB specification:
-
-* :py:class:`~pynwb.ui.iface.Interface`
+The following analysis :py:class:`~pynwb.core.NWBDataInterface` objects are provided by the API and NWB specification:
 
   * :py:class:`~pynwb.behavior.BehavioralEpochs`
   * :py:class:`~pynwb.behavior.BehavioralEvents`
@@ -101,6 +97,10 @@ The following analysis NWBContainer objects are provided by the API and NWB spec
   * :py:class:`~pynwb.ecephys.LFP`
   * :py:class:`~pynwb.behavior.MotionCorrection`
   * :py:class:`~pynwb.behavior.Position`
+
+Additionally, the :py:class:`~pynwb.base.TimeSeries` described :ref:`above <timeseries_overview>`
+are also subclasses of :py:class:`~pynwb.core.NWBDataInterface`, and can therefore be used anywhere
+:py:class:`~pynwb.core.NWBDataInterface` is allowed.
 
 .. note::
 

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -1,10 +1,12 @@
+from warnings import warn
+
 from collections import Iterable
 
 from .form.utils import docval, getargs, popargs, fmt_docval_args
 from .form.data_utils import DataChunkIterator, DataIO
 
 from . import register_class, CORE_NAMESPACE
-from .core import NWBContainer
+from .core import NWBContainer, NWBDataInterface
 
 _default_conversion = 1.0
 _default_resolution = 0.0
@@ -39,8 +41,8 @@ class ProcessingModule(NWBContainer):
     def containers(self):
         return tuple(self.__containers.values())
 
-    @docval({'name': 'container', 'type': NWBContainer, 'doc': 'the NWBContainer to add to this Module'})
-    def add_container(self, **kwargs):
+    @docval({'name': 'container', 'type': NWBDataInterface, 'doc': 'the NWBDataInterface to add to this Module'})
+    def add_data_interface(self, **kwargs):
         '''
         Add an NWBContainer to this ProcessingModule
         '''
@@ -49,16 +51,32 @@ class ProcessingModule(NWBContainer):
         container.parent = self
 
     @docval({'name': 'container_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})
-    def get_container(self, **kwargs):
+    def get_data_interface(self, **kwargs):
         '''
         Retrieve an NWBContainer from this ProcessingModule
         '''
         container_name = getargs('container_name', kwargs)
         return self.__containers.get(container_name)
 
+    @docval({'name': 'container', 'type': NWBDataInterface, 'doc': 'the NWBDataInterface to add to this Module'})
+    def add_container(self, **kwargs):
+        '''
+        Add an NWBContainer to this ProcessingModule
+        '''
+        warn(PendingDeprecationWarning('add_container will be replaced by add_data_interface'))
+        self.add_data_interface(**kwargs)
+
+    @docval({'name': 'container_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})
+    def get_container(self, **kwargs):
+        '''
+        Retrieve an NWBContainer from this ProcessingModule
+        '''
+        warn(PendingDeprecationWarning('get_container will be replaced by get_data_interface'))
+        return self.get_data_interface(**kwargs)
+
 
 @register_class('TimeSeries', CORE_NAMESPACE)
-class TimeSeries(NWBContainer):
+class TimeSeries(NWBDataInterface):
     """A generic base class for time series data"""
     __nwbfields__ = ("comments",
                      "description",

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -50,7 +50,7 @@ class SpatialSeries(TimeSeries):
              'doc': 'Human-readable comments about this TimeSeries dataset', 'default': 'no comments'},
             {'name': 'description', 'type': str,
              'doc': 'Description of this TimeSeries dataset', 'default': 'no description'},
-            {'name': 'parent', 'type': 'NWBContainer',
+            {'name': 'parent', 'type': NWBContainer,
              'doc': 'The parent NWBContainer for this NWBContainer', 'default': None},
             {'name': 'control', 'type': Iterable,
              'doc': 'Numerical labels that apply to each element in data', 'default': None},

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -3,7 +3,7 @@ from collections import Iterable
 from .form.utils import docval, popargs
 
 from . import register_class, CORE_NAMESPACE
-from .core import NWBContainer, set_parents
+from .core import NWBContainer, set_parents, NWBDataInterface
 from .misc import IntervalSeries
 from .base import TimeSeries, _default_conversion, _default_resolution
 from .image import ImageSeries
@@ -67,7 +67,7 @@ class SpatialSeries(TimeSeries):
 
 
 @register_class('BehavioralEpochs', CORE_NAMESPACE)
-class BehavioralEpochs(NWBContainer):
+class BehavioralEpochs(NWBDataInterface):
     """
     TimeSeries for storing behavoioral epochs. The objective of this and the other two Behavioral
     interfaces (e.g. BehavioralEvents and BehavioralTimeSeries) is to provide generic hooks for
@@ -96,7 +96,7 @@ class BehavioralEpochs(NWBContainer):
 
 
 @register_class('BehavioralEvents', CORE_NAMESPACE)
-class BehavioralEvents(NWBContainer):
+class BehavioralEvents(NWBDataInterface):
     """
     TimeSeries for storing behavioral events. See description of BehavioralEpochs for more details.
     """
@@ -116,7 +116,7 @@ class BehavioralEvents(NWBContainer):
 
 
 @register_class('BehavioralTimeSeries', CORE_NAMESPACE)
-class BehavioralTimeSeries(NWBContainer):
+class BehavioralTimeSeries(NWBDataInterface):
     """
     TimeSeries for storing Behavoioral time series data. See description of BehavioralEpochs for
     more details.
@@ -137,7 +137,7 @@ class BehavioralTimeSeries(NWBContainer):
 
 
 @register_class('PupilTracking', CORE_NAMESPACE)
-class PupilTracking(NWBContainer):
+class PupilTracking(NWBDataInterface):
     """
     Eye-tracking data, representing pupil size.
     """
@@ -157,7 +157,7 @@ class PupilTracking(NWBContainer):
 
 
 @register_class('EyeTracking', CORE_NAMESPACE)
-class EyeTracking(NWBContainer):
+class EyeTracking(NWBDataInterface):
     """
     Eye-tracking data, representing direction of gaze.
     """
@@ -176,7 +176,7 @@ class EyeTracking(NWBContainer):
 
 
 @register_class('CompassDirection', CORE_NAMESPACE)
-class CompassDirection(NWBContainer):
+class CompassDirection(NWBDataInterface):
     """
     With a CompassDirection interface, a module publishes a SpatialSeries object representing a
     floating point value for theta. The SpatialSeries::reference_frame field should indicate what
@@ -200,7 +200,7 @@ class CompassDirection(NWBContainer):
 
 
 @register_class('Position', CORE_NAMESPACE)
-class Position(NWBContainer):
+class Position(NWBDataInterface):
     """
     Position data, whether along the x, x/y or x/y/z axis.
     """
@@ -219,7 +219,7 @@ class Position(NWBContainer):
 
 
 @register_class('CorrectedImageStack', CORE_NAMESPACE)
-class CorrectedImageStack(NWBContainer):
+class CorrectedImageStack(NWBDataInterface):
     """
     """
 
@@ -248,7 +248,7 @@ class CorrectedImageStack(NWBContainer):
 
 
 @register_class('MotionCorrection', CORE_NAMESPACE)
-class MotionCorrection(NWBContainer):
+class MotionCorrection(NWBDataInterface):
     """
     An image stack where all frames are shifted (registered) to a common coordinate system, to
     account for movement and drift between frames. Note: each frame at each point in time is

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -3,7 +3,7 @@ from collections import Iterable
 from .form.utils import docval, popargs
 
 from . import register_class, CORE_NAMESPACE
-from .core import NWBContainer, set_parents, NWBDataInterface
+from .core import NWBContainer, set_parents, NWBDataInterface, MultiTSInterface
 from .misc import IntervalSeries
 from .base import TimeSeries, _default_conversion, _default_resolution
 from .image import ImageSeries
@@ -200,26 +200,23 @@ class CompassDirection(NWBDataInterface):
 
 
 @register_class('Position', CORE_NAMESPACE)
-class Position(NWBDataInterface):
+class Position(MultiTSInterface):
     """
     Position data, whether along the x, x/y or x/y/z axis.
     """
 
-    __nwbfields__ = ('spatial_series',)
+    __clsconf__ = {
+        'add': 'add_spatial_series',
+        'create': 'create_spatial_series',
+        'ts_type': SpatialSeries,
+        'ts_attr': 'spatial_series'
+    }
 
     _help = "Position data, whether along the x, xy or xyz axis"
 
-    @docval({'name': 'name', 'type': str, 'doc': 'The name of this Position container', 'default': 'Position'},
-            {'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'spatial_series', 'type': (list, SpatialSeries), 'doc': ''})
-    def __init__(self, **kwargs):
-        source, spatial_series = popargs('source', 'spatial_series', kwargs)
-        super(Position, self).__init__(source, **kwargs)
-        self.spatial_series = set_parents(spatial_series, self)
-
 
 @register_class('CorrectedImageStack', CORE_NAMESPACE)
-class CorrectedImageStack(NWBDataInterface):
+class CorrectedImageStack(NWBContainer):
     """
     """
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -148,9 +148,11 @@ class NWBContainer(NWBBaseType, Container):
                 return_dict[i.name] = i
             return return_dict
 
+
 @register_class('NWBDataInterface', CORE_NAMESPACE)
 class NWBDataInterface(NWBContainer):
     pass
+
 
 @register_class('NWBData', CORE_NAMESPACE)
 class NWBData(NWBBaseType, Data):

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -283,7 +283,7 @@ class MultiTSInterface(NWBDataInterface):
                 func_name='__init__')
         def _func(self, **kwargs):
             source, ts = popargs('source', attr_name, kwargs)
-            super(MultiESInterface, self).__init__(source, **kwargs)
+            super(MultiTSInterface, self).__init__(source, **kwargs)
             setattr(self, attr_name, dict())
             add = getattr(self, add_name)
             if isinstance(ts, ts_type):

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -148,6 +148,9 @@ class NWBContainer(NWBBaseType, Container):
                 return_dict[i.name] = i
             return return_dict
 
+@register_class('NWBDataInterface', CORE_NAMESPACE)
+class NWBDataInterface(NWBContainer):
+    pass
 
 @register_class('NWBData', CORE_NAMESPACE)
 class NWBData(NWBBaseType, Data):

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -148,7 +148,7 @@ groups:
     to a particular type of data.
   groups:
   - doc: Interface objects containing data output from processing steps
-    neurodata_type_inc: NWBContainer
+    neurodata_type_inc: NWBDataInterface
     quantity: '*'
   neurodata_type_def: ProcessingModule
   neurodata_type_inc: NWBContainer

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -7,7 +7,7 @@ datasets:
   neurodata_type_def: NWBData
 groups:
 - attributes:
-  - doc: Short description of what this type of Interface contains.
+  - doc: Short description of what this type of NWBContainer contains.
     dtype: text
     name: help
   - doc: Path to the origin of the data represented in this interface.
@@ -15,6 +15,9 @@ groups:
     name: source
   doc: The attributes specified here are included in all interfaces.
   neurodata_type_def: NWBContainer
+- doc: An abstract data type for differentiating experimental data from metadata
+  neurodata_type_inc: NWBContainer
+  neurodata_type_def: NWBDataInterface
 - attributes:
   - default_value: no comments
     doc: Human-readable comments about the TimeSeries. This second descriptive field
@@ -131,7 +134,7 @@ groups:
     name: sync
     quantity: '?'
   neurodata_type_def: TimeSeries
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Description of Module
     dtype: text
@@ -149,3 +152,19 @@ groups:
     quantity: '*'
   neurodata_type_def: ProcessingModule
   neurodata_type_inc: NWBContainer
+- attributes:
+  - doc: Description of images in this container
+    dtype: text
+    name: description
+  - doc: Value is 'A collection of images that have some meaningful relationship'
+    dtype: text
+    name: help
+    value: A collection of images that have some meaningful relationship
+  datasets:
+    - doc: Images stored in this NWBDataInterface
+      neurodata_type_inc: Image
+      quantity: '+'
+  default_name: Images
+  doc: A NWBDataInterface for storing images that have some relationship
+  neurodata_type_def: Images
+  neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.behavior.yaml
+++ b/src/pynwb/data/nwb.behavior.yaml
@@ -181,7 +181,7 @@ groups:
       name: original
       target_type: ImageSeries
     neurodata_type_def: CorrectedImageStack
-    neurodata_type_inc: NWBDataInterface
+    neurodata_type_inc: NWBContainer
     quantity: +
   default_name: MotionCorrection
   neurodata_type_def: MotionCorrection

--- a/src/pynwb/data/nwb.behavior.yaml
+++ b/src/pynwb/data/nwb.behavior.yaml
@@ -63,7 +63,7 @@ groups:
     quantity: '*'
   default_name: BehavioralEpochs
   neurodata_type_def: BehavioralEpochs
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Position data, whether along the x, xy or xyz axis'
     dtype: text
@@ -77,7 +77,7 @@ groups:
     quantity: '*'
   default_name: BehavioralEvents
   neurodata_type_def: BehavioralEvents
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'General container for storing continuously sampled behavioral data.'
     dtype: text
@@ -91,7 +91,7 @@ groups:
     quantity: '*'
   default_name: BehavioralTimeSeries
   neurodata_type_def: BehavioralTimeSeries
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Eye-tracking data, representing pupil size'
     dtype: text
@@ -104,7 +104,7 @@ groups:
     quantity: +
   default_name: PupilTracking
   neurodata_type_def: PupilTracking
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Eye-tracking data, representing direction of gaze'
     dtype: text
@@ -117,7 +117,7 @@ groups:
     quantity: '*'
   default_name: EyeTracking
   neurodata_type_def: EyeTracking
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Direction as measured radially. Spatial series reference frame
       should indicate which direction corresponds to zero and what is the direction
@@ -137,7 +137,7 @@ groups:
     quantity: '*'
   default_name: CompassDirection
   neurodata_type_def: CompassDirection
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Position data, whether along the x, xy or xyz axis'
     dtype: text
@@ -150,7 +150,7 @@ groups:
     quantity: +
   default_name: Position
   neurodata_type_def: Position
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Image stacks whose frames have been shifted (registered) to account
       for motion'
@@ -181,8 +181,8 @@ groups:
       name: original
       target_type: ImageSeries
     neurodata_type_def: CorrectedImageStack
-    neurodata_type_inc: NWBContainer
+    neurodata_type_inc: NWBDataInterface
     quantity: +
   default_name: MotionCorrection
   neurodata_type_def: MotionCorrection
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -116,7 +116,7 @@ groups:
     target_type: Clustering
   default_name: ClusterWaveforms
   neurodata_type_def: ClusterWaveforms
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Clustered spike data, whether from automatic clustering tools (eg,
       klustakwik) or as a result of manual sorting'
@@ -156,7 +156,7 @@ groups:
     or as a result of manual sorting.
   default_name: Clustering
   neurodata_type_def: Clustering
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Container for salient features of detected events'
     dtype: text
@@ -195,7 +195,7 @@ groups:
     SpikeEvent TimeSeries or other source.
   default_name: FeatureExtraction
   neurodata_type_def: FeatureExtraction
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Detected spike events from voltage trace(s)'
     dtype: text
@@ -238,7 +238,7 @@ groups:
     target_type: ElectricalSeries
   default_name: EventDetection
   neurodata_type_def: EventDetection
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Waveform of detected extracellularly recorded spike events'
     dtype: text
@@ -253,7 +253,7 @@ groups:
     quantity: '*'
   default_name: EventWaveform
   neurodata_type_def: EventWaveform
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Ephys data from one or more channels that is subjected to filtering,
       such as for gamma or theta oscillations (LFP has its own interface). Filter
@@ -278,7 +278,7 @@ groups:
     quantity: +
   default_name: FilteredEphys
   neurodata_type_def: FilteredEphys
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'LFP data from one or more channels. Filter properties should be
       noted in the ElectricalSeries'
@@ -295,7 +295,7 @@ groups:
     quantity: +
   default_name: LFP
   neurodata_type_def: LFP
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Metadata about a physical grouping of channels'
     dtype: str

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -45,32 +45,9 @@ groups:
       group, the data can exist in a separate HDF5 file that is linked to by the file
       being used for processing and analysis.'
     groups:
-    - datasets:
-      - attributes:
-        - doc: 'Human description of image. COMMENT: If image is of slice data, include
-            slice thickness and orientation, and reference to appropriate entry in
-            /general/slices'
-          dtype: text
-          name: description
-        - doc: 'Format of the image.  COMMENT: eg, jpg, png, mpeg'
-          dtype: text
-          name: format
-        doc: 'Photograph of experiment or experimental setup (video also OK). COMMENT:
-          Name is arbitrary.  Data is stored as a single binary object (HDF5 opaque
-          type).'
-        dtype: binary
-        neurodata_type_def: Image
-        quantity: '*'
-      doc: Acquired images
-      name: images
-    - doc: 'Acquired TimeSeries.COMMENT: When importing acquisition data to an NWB
-        file, all acquisition/tracking/stimulus data must already be aligned to a
-        common time frame. It is assumed that this task has already been performed.'
-      groups:
-      - doc: TimeSeries object containing data generated during data acquisition
-        neurodata_type_inc: TimeSeries
-        quantity: '*'
-      name: timeseries
+    - doc: Any objects representing acquired data
+      neurodata_type_inc: NWBDataInterface
+      quantity: '*'
     name: acquisition
   - doc: 'Lab-specific and custom scientific analysis of data. There is no defined
       format for the content of this group - the format is up to the individual user/lab.

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -145,8 +145,8 @@ groups:
       name: unit_description
     doc: Group storing times for &lt;unit_N&gt;.
     neurodata_type_def: SpikeUnit
-    neurodata_type_inc: NWBContainer
+    neurodata_type_inc: NWBDataInterface
     quantity: +
   default_name: UnitTimes
   neurodata_type_def: UnitTimes
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -78,7 +78,7 @@ groups:
     quantity: '*'
   default_name: DfOverF
   neurodata_type_def: DfOverF
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Fluorescence over time of one or more ROIs. TimeSeries names should
       correspond to imaging plane names'
@@ -95,7 +95,7 @@ groups:
     quantity: +
   default_name: Fluorescence
   neurodata_type_def: Fluorescence
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Stores groups of pixels that define regions of interest from one
       or more imaging planes'
@@ -159,7 +159,7 @@ groups:
         name: roi_description
       doc: Name of ROI
       neurodata_type_def: ROI
-      neurodata_type_inc: NWBContainer
+      neurodata_type_inc: NWBDataInterface
       quantity: '*'
     - doc: Stores image stacks segmentation mask apply to.
       groups:
@@ -172,11 +172,11 @@ groups:
       name: imaging_plane
       target_type: ImagingPlane
     neurodata_type_def: PlaneSegmentation
-    neurodata_type_inc: NWBContainer
+    neurodata_type_inc: NWBDataInterface
     quantity: '*'
   default_name: ImageSegmentation
   neurodata_type_def: ImageSegmentation
-  neurodata_type_inc: NWBContainer
+  neurodata_type_inc: NWBDataInterface
 - attributes:
   - doc: Value is 'Metadata about an imaging plane'
     dtype: text

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -159,7 +159,7 @@ groups:
         name: roi_description
       doc: Name of ROI
       neurodata_type_def: ROI
-      neurodata_type_inc: NWBDataInterface
+      neurodata_type_inc: NWBContainer
       quantity: '*'
     - doc: Stores image stacks segmentation mask apply to.
       groups:
@@ -172,7 +172,7 @@ groups:
       name: imaging_plane
       target_type: ImagingPlane
     neurodata_type_def: PlaneSegmentation
-    neurodata_type_inc: NWBDataInterface
+    neurodata_type_inc: NWBContainer
     quantity: '*'
   default_name: ImageSegmentation
   neurodata_type_def: ImageSegmentation

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -340,7 +340,8 @@ class MultiESInterface(NWBDataInterface):
     __nwbfields__ = ('electrical_series',)
 
     @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'electrical_series', 'type': (list, dict, ElectricalSeries), 'doc': 'LFP electrophysiology data', 'default': dict()},
+            {'name': 'electrical_series', 'type': (list, dict, ElectricalSeries),
+             'doc': 'LFP electrophysiology data', 'default': dict()},
             {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'LFP'})
     def __init__(self, **kwargs):
         source, electrical_series = popargs('source', 'electrical_series', kwargs)
@@ -391,7 +392,8 @@ class LFP(MultiESInterface):
               "should be noted in the ElectricalSeries")
 
     @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'electrical_series', 'type': (list, dict, ElectricalSeries), 'doc': 'LFP electrophysiology data', 'default': dict()},
+            {'name': 'electrical_series', 'type': (list, dict, ElectricalSeries),
+             'doc': 'LFP electrophysiology data', 'default': dict()},
             {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'LFP'})
     def __init__(self, **kwargs):
         cargs, ckwargs = fmt_docval_args(MultiESInterface.__init__, kwargs)
@@ -416,7 +418,8 @@ class FilteredEphys(MultiESInterface):
               "be noted in the ElectricalSeries")
 
     @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'electrical_series', 'type': (list, dict, ElectricalSeries), 'doc': 'filtered electrophysiology data', 'default': dict()},
+            {'name': 'electrical_series', 'type': (list, dict, ElectricalSeries),
+             'doc': 'filtered electrophysiology data', 'default': dict()},
             {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'FilteredEphys'})
     def __init__(self, **kwargs):
         cargs, ckwargs = fmt_docval_args(MultiESInterface.__init__, kwargs)

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -7,7 +7,7 @@ from .form.data_utils import DataChunkIterator, ShapeValidator
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
-from .core import NWBContainer, set_parents, NWBTable, NWBTableRegion
+from .core import NWBContainer, set_parents, NWBTable, NWBTableRegion, NWBDataInterface
 
 
 @register_class('Device', CORE_NAMESPACE)
@@ -204,7 +204,7 @@ class SpikeEventSeries(ElectricalSeries):
 
 
 @register_class('EventDetection', CORE_NAMESPACE)
-class EventDetection(NWBContainer):
+class EventDetection(NWBDataInterface):
     """
     Detected spike events from voltage trace(s).
     """
@@ -242,7 +242,7 @@ class EventDetection(NWBContainer):
 
 
 @register_class('EventWaveform', CORE_NAMESPACE)
-class EventWaveform(NWBContainer):
+class EventWaveform(NWBDataInterface):
     """
     Spike data for spike events detected in raw data
     stored in this NWBFile, or events detect at acquisition
@@ -262,7 +262,7 @@ class EventWaveform(NWBContainer):
 
 
 @register_class('Clustering', CORE_NAMESPACE)
-class Clustering(NWBContainer):
+class Clustering(NWBDataInterface):
     """
     Specifies cluster event times and cluster metric for maximum ratio of
     waveform peak to RMS on any channel in cluster.
@@ -299,7 +299,7 @@ class Clustering(NWBContainer):
 
 
 @register_class('ClusterWaveforms', CORE_NAMESPACE)
-class ClusterWaveforms(NWBContainer):
+class ClusterWaveforms(NWBDataInterface):
     """
     Describe cluster waveforms by mean and standard deviation for at each sample.
     """
@@ -332,7 +332,7 @@ class ClusterWaveforms(NWBContainer):
 
 
 @register_class('LFP', CORE_NAMESPACE)
-class LFP(NWBContainer):
+class LFP(NWBDataInterface):
     """
     LFP data from one or more channels. The electrode map in each published ElectricalSeries will
     identify which channels are providing LFP data. Filter properties should be noted in the
@@ -345,7 +345,7 @@ class LFP(NWBContainer):
               "should be noted in the ElectricalSeries")
 
     @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'electrical_series', 'type': ElectricalSeries, 'doc': 'LFP electrophysiology data'},
+            {'name': 'electrical_series', 'type': (list, ElectricalSeries), 'doc': 'LFP electrophysiology data'},
             {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'LFP'})
     def __init__(self, **kwargs):
         source, electrical_series = popargs('source', 'electrical_series', kwargs)
@@ -355,7 +355,7 @@ class LFP(NWBContainer):
 
 
 @register_class('FilteredEphys', CORE_NAMESPACE)
-class FilteredEphys(NWBContainer):
+class FilteredEphys(NWBDataInterface):
     """
     Ephys data from one or more channels that has been subjected to filtering. Examples of filtered
     data include Theta and Gamma (LFP has its own interface). FilteredEphys modules publish an
@@ -374,7 +374,7 @@ class FilteredEphys(NWBContainer):
               "be noted in the ElectricalSeries")
 
     @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'electrical_series', 'type': ElectricalSeries, 'doc': 'filtered electrophysiology data'},
+            {'name': 'electrical_series', 'type': (list, ElectricalSeries), 'doc': 'filtered electrophysiology data'},
             {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'FilteredEphys'})
     def __init__(self, **kwargs):
         source, electrical_series = popargs('source', 'electrical_series', kwargs)
@@ -384,7 +384,7 @@ class FilteredEphys(NWBContainer):
 
 
 @register_class('FeatureExtraction', CORE_NAMESPACE)
-class FeatureExtraction(NWBContainer):
+class FeatureExtraction(NWBDataInterface):
     """
     Features, such as PC1 and PC2, that are extracted from signals stored in a SpikeEvent
     TimeSeries or other source.

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -11,7 +11,7 @@ from .epoch import Epoch
 from .ecephys import ElectrodeTable, ElectrodeTableRegion, ElectrodeGroup, Device
 from .icephys import IntracellularElectrode
 from .ophys import ImagingPlane
-from .core import NWBContainer, LabelledDict
+from .core import NWBContainer, LabelledDict, NWBData
 
 from h5py import RegionReference
 
@@ -21,7 +21,7 @@ def _not_parent(arg):
 
 
 @register_class('Image', CORE_NAMESPACE)
-class Image(Container):
+class Image(NWBData):
     # TODO: Implement this
     pass
 

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -11,7 +11,7 @@ from .epoch import Epoch
 from .ecephys import ElectrodeTable, ElectrodeTableRegion, ElectrodeGroup, Device
 from .icephys import IntracellularElectrode
 from .ophys import ImagingPlane
-from .core import NWBContainer, LabelledDict, NWBData
+from .core import NWBContainer, LabelledDict, NWBData, NWBDataInterface
 
 from h5py import RegionReference
 
@@ -356,18 +356,18 @@ class NWBFile(NWBContainer):
             raise TypeError(type(timeseries))
         return ts
 
-    @docval({'name': 'ts', 'type': TimeSeries, 'doc': 'the  TimeSeries object to add'},
+    @docval({'name': 'ts', 'type': NWBDataInterface, 'doc': 'the  NWBDataInterface object to add'},
             {'name': 'epoch', 'type': (str, Epoch, list, tuple), 'doc': 'the name of an epoch \
             or an Epoch object or a list of names of epochs or Epoch objects', 'default': None},
-            returns="the TimeSeries object")
+            returns="the NWBDataInterface object")
     def add_acquisition(self, **kwargs):
         ts, epoch = getargs('ts', 'epoch', kwargs)
         self.__set_timeseries(self.__acquisition, ts, epoch)
 
-    @docval({'name': 'name', 'type': str, 'doc': 'the name of this TimeSeries'})
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this NWBDataInterface'})
     def get_acquisition(self, **kwargs):
         '''
-        Retrieve acquisition TimeSeries data
+        Retrieve acquisition NWBDataInterface data
         '''
         name = getargs('name', kwargs)
         return self.__get_timeseries(self.__acquisition, name)
@@ -495,9 +495,7 @@ class NWBFile(NWBContainer):
         name = getargs('name', kwargs)
         return self.__ic_electrodes.get(name)
 
-    @docval({'name': 'name',  'type': str, 'doc': 'the name of the processing module'},
-            {'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'description',  'type': str, 'doc': 'description of the processing module'},
+    @docval(*filter(_not_parent, get_docval(ProcessingModule.__init__)),
             returns="a processing module", rtype=ProcessingModule)
     def create_processing_module(self, **kwargs):
         '''

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -356,13 +356,14 @@ class NWBFile(NWBContainer):
             raise TypeError(type(timeseries))
         return ts
 
-    @docval({'name': 'ts', 'type': NWBDataInterface, 'doc': 'the  NWBDataInterface object to add'},
+    @docval({'name': 'di', 'type': NWBDataInterface, 'doc': 'the  NWBDataInterface object to add'},
             {'name': 'epoch', 'type': (str, Epoch, list, tuple), 'doc': 'the name of an epoch \
             or an Epoch object or a list of names of epochs or Epoch objects', 'default': None},
             returns="the NWBDataInterface object")
     def add_acquisition(self, **kwargs):
-        ts, epoch = getargs('ts', 'epoch', kwargs)
-        self.__set_timeseries(self.__acquisition, ts, epoch)
+        di, epoch = getargs('di', 'epoch', kwargs)
+        self.__set_timeseries(self.__acquisition, di, epoch)
+        return di
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this NWBDataInterface'})
     def get_acquisition(self, **kwargs):

--- a/src/pynwb/form/utils.py
+++ b/src/pynwb/form/utils.py
@@ -322,6 +322,7 @@ def docval(*validator, **options):
     def dec(func):
         _docval = _copy.copy(options)
         func.__name__ = _docval.get('func_name', func.__name__)
+        func.__doc__ = _docval.get('doc', func.__doc__)
         pos = list()
         kw = list()
         for a in val_copy:

--- a/src/pynwb/form/utils.py
+++ b/src/pynwb/form/utils.py
@@ -321,6 +321,7 @@ def docval(*validator, **options):
 
     def dec(func):
         _docval = _copy.copy(options)
+        func.__name__ = _docval.get('func_name', func.__name__)
         pos = list()
         kw = list()
         for a in val_copy:

--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -9,7 +9,7 @@ class ModuleMap(ObjectMapper):
 
     def __init__(self, spec):
         super(ModuleMap, self).__init__(spec)
-        containers_spec = self.spec.get_neurodata_type('NWBContainer')
+        containers_spec = self.spec.get_neurodata_type('NWBDataInterface')
         self.map_spec('containers', containers_spec)
 
     @ObjectMapper.constructor_arg('name')

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -8,8 +8,7 @@ class NWBFileMap(ObjectMapper):
 
     def __init__(self, spec):
         super(NWBFileMap, self).__init__(spec)
-        raw_ts_spec = self.spec.get_group('acquisition').get_group('timeseries')\
-                                                        .get_neurodata_type('TimeSeries')
+        raw_ts_spec = self.spec.get_group('acquisition').get_neurodata_type('NWBDataInterface')
         self.map_spec('acquisition', raw_ts_spec)
 
         stimulus_spec = self.spec.get_group('stimulus')

--- a/src/pynwb/legacy/io/base.py
+++ b/src/pynwb/legacy/io/base.py
@@ -16,7 +16,7 @@ class ModuleMap(ObjectMapper):
 
     def __init__(self, spec):
         super(ModuleMap, self).__init__(spec)
-        containers_spec = self.spec.get_neurodata_type('NWBContainer')
+        containers_spec = self.spec.get_neurodata_type('NWBDataInterface')
         self.map_spec('containers', containers_spec)
 
     @ObjectMapper.constructor_arg('name')

--- a/src/pynwb/legacy/io/file.py
+++ b/src/pynwb/legacy/io/file.py
@@ -9,7 +9,7 @@ class NWBFileMap(ObjectMapper):
 
     def __init__(self, spec):
         super(NWBFileMap, self).__init__(spec)
-        raw_ts_spec = self.spec.get_group('acquisition').get_group('timeseries').get_neurodata_type('TimeSeries')
+        raw_ts_spec = self.spec.get_group('acquisition').get_neurodata_type('NWBDataInterface')
         self.map_spec('acquisition', raw_ts_spec)
 
         stimulus_spec = self.spec.get_group('stimulus')

--- a/src/pynwb/legacy/map.py
+++ b/src/pynwb/legacy/map.py
@@ -123,7 +123,7 @@ class TypeMapLegacy(TypeMap):
                         'pupil_location': None,
                         'pupil_location_spherical': None
                     }
-                    return decode(parent_names[builder.parent.name])
+                    return decode(parent_names.get(builder.parent.name))
 
     def get_builder_ns(self, builder):
         return 'core'

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -6,7 +6,7 @@ from .form.utils import docval, popargs, fmt_docval_args
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer
+from .core import NWBContainer, NWBDataInterface
 
 
 @register_class('OpticalChannel', CORE_NAMESPACE)
@@ -222,7 +222,7 @@ class PlaneSegmentation(NWBContainer):
 
 
 @register_class('ImageSegmentation', CORE_NAMESPACE)
-class ImageSegmentation(NWBContainer):
+class ImageSegmentation(NWBDataInterface):
     """
     Stores pixels in an image that represent different regions of interest (ROIs) or masks. All
     segmentation for a given imaging plane is stored together, with storage for multiple imaging
@@ -305,7 +305,7 @@ class RoiResponseSeries(TimeSeries):
 
 
 @register_class('DfOverF', CORE_NAMESPACE)
-class DfOverF(NWBContainer):
+class DfOverF(NWBDataInterface):
     """
     dF/F information about a region of interest (ROI). Storage hierarchy of dF/F should be the same
     as for segmentation (ie, same names for ROIs and for image planes).
@@ -327,7 +327,7 @@ class DfOverF(NWBContainer):
 
 
 @register_class('Fluorescence', CORE_NAMESPACE)
-class Fluorescence(NWBContainer):
+class Fluorescence(NWBDataInterface):
     """
     Fluorescence information about a region of interest (ROI). Storage hierarchy of fluorescence
     should be the same as for segmentation (ie, same names for ROIs and for image planes).

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -6,7 +6,7 @@ from .form.utils import docval, popargs, fmt_docval_args
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, NWBDataInterface
+from .core import NWBContainer, NWBDataInterface, MultiTSInterface
 
 
 @register_class('OpticalChannel', CORE_NAMESPACE)
@@ -305,44 +305,34 @@ class RoiResponseSeries(TimeSeries):
 
 
 @register_class('DfOverF', CORE_NAMESPACE)
-class DfOverF(NWBDataInterface):
+class DfOverF(MultiTSInterface):
     """
     dF/F information about a region of interest (ROI). Storage hierarchy of dF/F should be the same
     as for segmentation (ie, same names for ROIs and for image planes).
     """
 
-    __nwbfields__ = ('roi_response_series',)
+    __clsconf__ = {
+        'ts_attr': 'roi_response_series',
+        'ts_type': RoiResponseSeries,
+        'add': 'add_roi_response_series',
+        'create': 'create_roi_response_series'
+    }
 
     _help = "Df/f over time of one or more ROIs. TimeSeries names should correspond to imaging plane names"
 
-    @docval({'name': 'source', 'type': str, 'doc': 'The source of the data represented in this Module Interface.'},
-            {'name': 'roi_response_series', 'type': (RoiResponseSeries, list),
-             'doc': 'RoiResponseSeries or any subtype.'},
-            {'name': 'name', 'type': str, 'doc': 'the name of this DfOverF container', 'default': 'DfOverF'})
-    def __init__(self, **kwargs):
-        roi_response_series = popargs('roi_response_series', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(DfOverF, self).__init__, kwargs)
-        super(DfOverF, self).__init__(*pargs, **pkwargs)
-        self.roi_response_series = roi_response_series
-
 
 @register_class('Fluorescence', CORE_NAMESPACE)
-class Fluorescence(NWBDataInterface):
+class Fluorescence(MultiTSInterface):
     """
     Fluorescence information about a region of interest (ROI). Storage hierarchy of fluorescence
     should be the same as for segmentation (ie, same names for ROIs and for image planes).
     """
 
-    __nwbfields__ = ('roi_response_series',)
+    __clsconf__ = {
+        'ts_attr': 'roi_response_series',
+        'ts_type': RoiResponseSeries,
+        'add': 'add_roi_response_series',
+        'create': 'create_roi_response_series'
+    }
 
     _help = "Fluorescence over time of one or more ROIs. TimeSeries names should correspond to imaging plane names."
-
-    @docval({'name': 'source', 'type': str, 'doc': 'the source of the data represented in this Module Interface'},
-            {'name': 'roi_response_series', 'type': (RoiResponseSeries, list),
-             'doc': 'RoiResponseSeries or any subtype.'},
-            {'name': 'name', 'type': str, 'doc': 'the name of this Fluorescence container', 'default': 'Fluorescence'})
-    def __init__(self, **kwargs):
-        roi_response_series = popargs('roi_response_series', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(Fluorescence, self).__init__, kwargs)
-        super(Fluorescence, self).__init__(*pargs, **pkwargs)
-        self.roi_response_series = roi_response_series

--- a/src/pynwb/retinotopy.py
+++ b/src/pynwb/retinotopy.py
@@ -3,7 +3,7 @@ from collections import Iterable
 from .form.utils import docval, popargs, fmt_docval_args
 
 from . import register_class, CORE_NAMESPACE
-from .core import NWBContainer
+from .core import NWBContainer, NWBDataInterface
 
 
 class AImage(NWBContainer):
@@ -64,7 +64,7 @@ class AxisMap(NWBContainer):
 
 
 @register_class('ImageRetinotopy', CORE_NAMESPACE)    # make sure to uncomment this after this class is implemented
-class ImagingRetinotopy(NWBContainer):
+class ImagingRetinotopy(NWBDataInterface):
     """
     Intrinsic signal optical imaging or widefield imaging for measuring retinotopy. Stores orthogonal
     maps (e.g., altitude/azimuth; radius/theta) of responses to specific stimuli and a combined

--- a/test.py
+++ b/test.py
@@ -32,7 +32,8 @@ class SuccessRecordingResult(unittest.TextTestResult):
 
         cases = []
 
-        cases.extend(self.successes)
+        if hasattr(self, 'successes'):
+            cases.extend(self.successes)
         cases.extend([failure[0] for failure in self.failures])
 
         return cases

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -43,9 +43,7 @@ class TestHDF5Writer(unittest.TestCase):
                                                                          attributes={'unit': 'Seconds',
                                                                                      'interval': 1})})
         self.builder = GroupBuilder(
-            'root', groups={'acquisition': GroupBuilder(
-                'acquisition', groups={'timeseries': GroupBuilder('timeseries', groups={'test_timeseries': ts_builder}),
-                                       'images': GroupBuilder('images')}),
+            'root', groups={'acquisition': GroupBuilder('acquisition'),
                             'analysis': GroupBuilder('analysis'),
                             'epochs': GroupBuilder('epochs'),
                             'general': GroupBuilder('general'),
@@ -80,10 +78,7 @@ class TestHDF5Writer(unittest.TestCase):
         self.assertIn('nwb_version', f)
         self.assertIn('session_start_time', f)
         acq = f.get('acquisition')
-        self.assertIn('images', acq)
-        self.assertIn('timeseries', acq)
-        ts = acq.get('timeseries')
-        self.assertIn('test_timeseries', ts)
+        self.assertIn('test_timeseries', acq)
 
     def test_write_clobber(self):
         io = HDF5IO(self.path, self.manager)

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -43,7 +43,7 @@ class TestHDF5Writer(unittest.TestCase):
                                                                          attributes={'unit': 'Seconds',
                                                                                      'interval': 1})})
         self.builder = GroupBuilder(
-            'root', groups={'acquisition': GroupBuilder('acquisition'),
+            'root', groups={'acquisition': GroupBuilder('acquisition', groups={'test_timeseries': ts_builder}),
                             'analysis': GroupBuilder('analysis'),
                             'epochs': GroupBuilder('epochs'),
                             'general': GroupBuilder('general'),

--- a/tests/integration/ui_write/test_legacy.py
+++ b/tests/integration/ui_write/test_legacy.py
@@ -15,7 +15,6 @@ class TestLegacy(unittest.TestCase):
         if os.path.exists(self.filename):
             os.remove(self.filename)
 
-    #@unittest.skipTest('This is not a real test')
     def test_roundtrip(self):
 
         legacy_map = pynwb.legacy.get_type_map()

--- a/tests/integration/ui_write/test_legacy.py
+++ b/tests/integration/ui_write/test_legacy.py
@@ -15,6 +15,7 @@ class TestLegacy(unittest.TestCase):
         if os.path.exists(self.filename):
             os.remove(self.filename)
 
+    #@unittest.skipTest('This is not a real test')
     def test_roundtrip(self):
 
         legacy_map = pynwb.legacy.get_type_map()

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -60,9 +60,7 @@ class TestNWBFileIO(base.TestMapNWBContainer):
         return GroupBuilder('root',
                             groups={'acquisition': GroupBuilder(
                                 'acquisition',
-                                groups={'timeseries': GroupBuilder('timeseries',
-                                                                   groups={'test_timeseries': ts_builder}),
-                                        'images': GroupBuilder('images')}),
+                                groups={'test_timeseries': ts_builder}),
                                     'analysis': GroupBuilder('analysis'),
                                     'epochs': GroupBuilder('epochs'),
                                     'general': GroupBuilder('general'),

--- a/tests/unit/pynwb_tests/test_behavior.py
+++ b/tests/unit/pynwb_tests/test_behavior.py
@@ -73,7 +73,7 @@ class PositionConstructor(unittest.TestCase):
         sS = SpatialSeries('test_sS', 'a hypothetical source', list(), 'reference_frame', timestamps=list())
         pc = Position('test_pc', sS)
         self.assertEqual(pc.source, 'test_pc')
-        self.assertEqual(pc.spatial_series, [sS])
+        self.assertEqual(pc.spatial_series.get('test_sS'), sS)
 
 
 class MotionCorrectionConstructor(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_ephys.py
+++ b/tests/unit/pynwb_tests/test_ephys.py
@@ -117,7 +117,7 @@ class ClusterWaveformsConstructor(unittest.TestCase):
         self.assertEqual(cw.waveform_sd, stdevs)
 
 
-class LFPConstructor(unittest.TestCase):
+class LFPTest(unittest.TestCase):
     def test_init(self):
         dev1 = Device('dev1', 'a test source')  # noqa: F405
         group = ElectrodeGroup(  # noqa: F405, F841
@@ -128,10 +128,22 @@ class LFPConstructor(unittest.TestCase):
             'test_eS', 'a hypothetical source', [0, 1, 2, 3], region, timestamps=[0.1, 0.2, 0.3, 0.4])
         lfp = LFP('test_lfp', eS)  # noqa: F405
         self.assertEqual(lfp.source, 'test_lfp')
-        self.assertEqual(lfp.electrical_series, eS)
+        self.assertEqual(lfp.electrical_series.get('test_eS'), eS)
+
+    def test_add_electrical_series(self):
+        lfp = LFP('test_lfp')  # noqa: F405
+        dev1 = Device('dev1', 'a test source')  # noqa: F405
+        group = ElectrodeGroup(  # noqa: F405, F841
+            'tetrode1', 'a test source', 'tetrode description', 'tetrode location', dev1)
+        table = make_electrode_table()
+        region = ElectrodeTableRegion(table, [0, 2], 'the first and third electrodes')  # noqa: F405
+        eS = ElectricalSeries(  # noqa: F405
+            'test_eS', 'a hypothetical source', [0, 1, 2, 3], region, timestamps=[0.1, 0.2, 0.3, 0.4])
+        lfp.add_electrical_series(eS)
+        self.assertEqual(lfp.electrical_series.get('test_eS'), eS)
 
 
-class FilteredEphysConstructor(unittest.TestCase):
+class FilteredEphysTest(unittest.TestCase):
     def test_init(self):
         dev1 = Device('dev1', 'a test source')  # noqa: F405
         group = ElectrodeGroup(  # noqa: F405, F841
@@ -142,7 +154,19 @@ class FilteredEphysConstructor(unittest.TestCase):
             'test_eS', 'a hypothetical source', [0, 1, 2, 3], region, timestamps=[0.1, 0.2, 0.3, 0.4])
         fe = FilteredEphys('test_fe', eS)  # noqa: F405
         self.assertEqual(fe.source, 'test_fe')
-        self.assertEqual(fe.electrical_series, eS)
+        self.assertEqual(fe.electrical_series.get('test_eS'), eS)
+
+    def test_add_electrical_series(self):
+        fe = FilteredEphys('test_fe')  # noqa: F405
+        dev1 = Device('dev1', 'a test source')  # noqa: F405
+        group = ElectrodeGroup(  # noqa: F405, F841
+            'tetrode1', 'a test source', 'tetrode description', 'tetrode location', dev1)
+        table = make_electrode_table()
+        region = ElectrodeTableRegion(table, [0, 2], 'the first and third electrodes')  # noqa: F405
+        eS = ElectricalSeries(  # noqa: F405
+            'test_eS', 'a hypothetical source', [0, 1, 2, 3], region, timestamps=[0.1, 0.2, 0.3, 0.4])
+        fe.add_electrical_series(eS)
+        self.assertEqual(fe.electrical_series.get('test_eS'), eS)
 
 
 class FeatureExtractionConstructor(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_ephys.py
+++ b/tests/unit/pynwb_tests/test_ephys.py
@@ -82,7 +82,7 @@ class EventWaveformConstructor(unittest.TestCase):
 
         ew = EventWaveform('test_ew', sES)  # noqa: F405
         self.assertEqual(ew.source, 'test_ew')
-        self.assertEqual(ew.spike_event_series, [sES])
+        self.assertEqual(ew.spike_event_series['test_sES'], sES)
 
 
 class ClusteringConstructor(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -87,7 +87,7 @@ class DfOverFConstructor(unittest.TestCase):
 
         dof = DfOverF('test_dof', rrs)
         self.assertEqual(dof.source, 'test_dof')
-        self.assertEqual(dof.roi_response_series, rrs)
+        self.assertEqual(dof.roi_response_series['test_ts'], rrs)
 
 
 class FluorescenceConstructor(unittest.TestCase):
@@ -99,7 +99,7 @@ class FluorescenceConstructor(unittest.TestCase):
 
         ff = Fluorescence('test_ff', ts)
         self.assertEqual(ff.source, 'test_ff')
-        self.assertEqual(ff.roi_response_series, ts)
+        self.assertEqual(ff.roi_response_series['test_ts'], ts)
 
 
 class ImageSegmentationConstructor(unittest.TestCase):


### PR DESCRIPTION
## Motivation

The structure of /acqusition and the type requirements were too rigid. To address this, the following modifications were made:

1. Create **NWBDataInterface**, a neurodata_type that specializes **NWBContainer** to be used for representing non-metadata data objects.  Types that were formerly **Interfaces** (in NWB 1.x) and **TimeSeries** are now subtypes of **NWBDataInterface**. 
2. **NWBDataInterface** objects can be added NWBFiles as acquisition data, or as members of a **ProcessingModule** object.
3. Create a new **NWBDataInterface** called **Images** for storing a collection of images. This is not meant to replace **ImageSeries**. This interface replaces acquisition/images and provides a more general container for use elsewhere in NWB.

also fix #348 

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
