### PR TITLE
Enh/rename multitsinterface

### DIFF
--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -83,6 +83,7 @@ class BehavioralEpochs(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_interval_series',
+        'get': 'get_interval_series',
         'create': 'create_interval_series',
         'type': IntervalSeries,
         'attr': 'interval_series'
@@ -99,6 +100,7 @@ class BehavioralEvents(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_timeseries',
+        'get': 'get_timeseries',
         'create': 'create_timeseries',
         'type': TimeSeries,
         'attr': 'timeseries'
@@ -116,6 +118,7 @@ class BehavioralTimeSeries(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_timeseries',
+        'get': 'get_timeseries',
         'create': 'create_timeseries',
         'type': TimeSeries,
         'attr': 'timeseries'
@@ -130,6 +133,7 @@ class PupilTracking(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_timeseries',
+        'get': 'get_timeseries',
         'create': 'create_timeseries',
         'type': TimeSeries,
         'attr': 'timeseries'
@@ -144,6 +148,7 @@ class EyeTracking(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_spatial_series',
+        'get': 'get_spatial_series',
         'create': 'create_spatial_series',
         'type': SpatialSeries,
         'attr': 'spatial_series'
@@ -163,6 +168,7 @@ class CompassDirection(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_spatial_series',
+        'get': 'get_spatial_series',
         'create': 'create_spatial_series',
         'type': SpatialSeries,
         'attr': 'spatial_series'
@@ -180,6 +186,7 @@ class Position(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_spatial_series',
+        'get': 'get_spatial_series',
         'create': 'create_spatial_series',
         'type': SpatialSeries,
         'attr': 'spatial_series'
@@ -228,6 +235,7 @@ class MotionCorrection(MultiContainerInterface):
 
     __clsconf__ = {
         'add': 'add_corrected_image_stack',
+        'get': 'get_corrected_image_stack',
         'create': 'create_corrected_image_stack',
         'type': CorrectedImageStack,
         'attr': 'corrected_images_stacks'

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -3,7 +3,7 @@ from collections import Iterable
 from .form.utils import docval, popargs
 
 from . import register_class, CORE_NAMESPACE
-from .core import NWBContainer, MultiTSInterface
+from .core import NWBContainer, MultiContainerInterface
 from .misc import IntervalSeries
 from .base import TimeSeries, _default_conversion, _default_resolution
 from .image import ImageSeries
@@ -67,7 +67,7 @@ class SpatialSeries(TimeSeries):
 
 
 @register_class('BehavioralEpochs', CORE_NAMESPACE)
-class BehavioralEpochs(MultiTSInterface):
+class BehavioralEpochs(MultiContainerInterface):
     """
     TimeSeries for storing behavoioral epochs. The objective of this and the other two Behavioral
     interfaces (e.g. BehavioralEvents and BehavioralTimeSeries) is to provide generic hooks for
@@ -84,13 +84,13 @@ class BehavioralEpochs(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_interval_series',
         'create': 'create_interval_series',
-        'ts_type': IntervalSeries,
-        'ts_attr': 'interval_series'
+        'type': IntervalSeries,
+        'attr': 'interval_series'
     }
 
 
 @register_class('BehavioralEvents', CORE_NAMESPACE)
-class BehavioralEvents(MultiTSInterface):
+class BehavioralEvents(MultiContainerInterface):
     """
     TimeSeries for storing behavioral events. See description of BehavioralEpochs for more details.
     """
@@ -100,13 +100,13 @@ class BehavioralEvents(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_timeseries',
         'create': 'create_timeseries',
-        'ts_type': TimeSeries,
-        'ts_attr': 'timeseries'
+        'type': TimeSeries,
+        'attr': 'timeseries'
     }
 
 
 @register_class('BehavioralTimeSeries', CORE_NAMESPACE)
-class BehavioralTimeSeries(MultiTSInterface):
+class BehavioralTimeSeries(MultiContainerInterface):
     """
     TimeSeries for storing Behavoioral time series data. See description of BehavioralEpochs for
     more details.
@@ -117,13 +117,13 @@ class BehavioralTimeSeries(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_timeseries',
         'create': 'create_timeseries',
-        'ts_type': TimeSeries,
-        'ts_attr': 'timeseries'
+        'type': TimeSeries,
+        'attr': 'timeseries'
     }
 
 
 @register_class('PupilTracking', CORE_NAMESPACE)
-class PupilTracking(MultiTSInterface):
+class PupilTracking(MultiContainerInterface):
     """
     Eye-tracking data, representing pupil size.
     """
@@ -131,13 +131,13 @@ class PupilTracking(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_timeseries',
         'create': 'create_timeseries',
-        'ts_type': TimeSeries,
-        'ts_attr': 'timeseries'
+        'type': TimeSeries,
+        'attr': 'timeseries'
     }
 
 
 @register_class('EyeTracking', CORE_NAMESPACE)
-class EyeTracking(MultiTSInterface):
+class EyeTracking(MultiContainerInterface):
     """
     Eye-tracking data, representing direction of gaze.
     """
@@ -145,15 +145,15 @@ class EyeTracking(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_spatial_series',
         'create': 'create_spatial_series',
-        'ts_type': SpatialSeries,
-        'ts_attr': 'spatial_series'
+        'type': SpatialSeries,
+        'attr': 'spatial_series'
     }
 
     _help = "Eye-tracking data, representing direction of gaze"
 
 
 @register_class('CompassDirection', CORE_NAMESPACE)
-class CompassDirection(MultiTSInterface):
+class CompassDirection(MultiContainerInterface):
     """
     With a CompassDirection interface, a module publishes a SpatialSeries object representing a
     floating point value for theta. The SpatialSeries::reference_frame field should indicate what
@@ -164,8 +164,8 @@ class CompassDirection(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_spatial_series',
         'create': 'create_spatial_series',
-        'ts_type': SpatialSeries,
-        'ts_attr': 'spatial_series'
+        'type': SpatialSeries,
+        'attr': 'spatial_series'
     }
 
     _help = "Direction as measured radially. Spatial series reference frame \
@@ -173,7 +173,7 @@ class CompassDirection(MultiTSInterface):
 
 
 @register_class('Position', CORE_NAMESPACE)
-class Position(MultiTSInterface):
+class Position(MultiContainerInterface):
     """
     Position data, whether along the x, x/y or x/y/z axis.
     """
@@ -181,8 +181,8 @@ class Position(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_spatial_series',
         'create': 'create_spatial_series',
-        'ts_type': SpatialSeries,
-        'ts_attr': 'spatial_series'
+        'type': SpatialSeries,
+        'attr': 'spatial_series'
     }
 
     _help = "Position data, whether along the x, xy or xyz axis"
@@ -221,7 +221,7 @@ class CorrectedImageStack(NWBContainer):
 
 
 @register_class('MotionCorrection', CORE_NAMESPACE)
-class MotionCorrection(MultiTSInterface):
+class MotionCorrection(MultiContainerInterface):
     """
     A collection of corrected images stacks.
     """
@@ -229,8 +229,8 @@ class MotionCorrection(MultiTSInterface):
     __clsconf__ = {
         'add': 'add_corrected_image_stack',
         'create': 'create_corrected_image_stack',
-        'ts_type': CorrectedImageStack,
-        'ts_attr': 'corrected_images_stacks'
+        'type': CorrectedImageStack,
+        'attr': 'corrected_images_stacks'
     }
 
     _help = "Image stacks whose frames have been shifted (registered) to account for motion."

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -393,7 +393,7 @@ class MultiContainerInterface(NWBDataInterface):
             doc = "a dictionary containing the %s in this %s container" % (container_type.__name__, cls.__name__)
             setattr(cls, attr, property(getter, cls._setter(attr), None, doc))
         setattr(cls, add, cls.__make_add(add, attr, container_type))
-        if cls.__init__ is MultiContainerInterface.__init__:
+        if cls.__init__ == MultiContainerInterface.__init__:
             setattr(cls, '__init__', cls.__make_constructor(attr, add, container_type))
 
         # get create method name

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -251,7 +251,7 @@ class NWBTableRegion(NWBData, DataRegion):
         return self.__regionslicer[idx]
 
 
-class MultiTSInterface(NWBDataInterface):
+class MultiContainerInterface(NWBDataInterface):
     '''
     A class for dynamically defining a API classes that
     represent NWBDataInterfaces that contain multiple TimeSeries
@@ -262,8 +262,8 @@ class MultiTSInterface(NWBDataInterface):
 
     'add' to name the method for adding TimeSeries instances
     'create' to name the method fo creating TimeSeries instances
-    'ts_attr' to name the attribute that stores the TimeSeries instances
-    'ts_type' to provide the TimeSeries object type
+    'attr' to name the attribute that stores the TimeSeries instances
+    'type' to provide the TimeSeries object type
 
     See LFP or Position for an example of how to use this.
     '''
@@ -275,10 +275,39 @@ class MultiTSInterface(NWBDataInterface):
         return 'a %s' % noun
 
     @classmethod
-    def __make_add(cls, func_name, attr_name, ts_type):
-        doc = "Add %s to this %s" % (cls.__add_article(ts_type.__name__), cls.__name__)
+    def __make_get(cls, func_name, attr_name, container_type):
+        doc = "Get %s from this %s" % (cls.__add_article(container_type.__name__), cls.__name__)
 
-        @docval({'name': attr_name, 'type': ts_type, 'doc': 'the %s to add' % ts_type.__name__},
+
+        @docval({'name': 'name', 'type': str, 'doc': 'the name of the %s' % container_type.__name__,
+                 'default': None}, rtype=container_type, returns='the %s with the given name' % container_type.__name__,
+                func_name=func_name, doc=doc)
+        def _func(self, **kwargs):
+            name = getargs('name', kwargs)
+            d = getattr(self, attr_name)
+            if len(d) == 0:
+                msg = "%s '%s' is empty" % (cls.__name__, self.name)
+                raise ValueError(msg)
+            if len(d) > 1 and name is None:
+                msg = "more than one %s in this %s -- must specify a name" % container_type.__name__, cls.__name__
+                raise ValueError(msg)
+            ret = None
+            if len(d) == 1:
+                for v in d.values():
+                    ret = v
+            else:
+                ret = d.get(name)
+                if ret is None:
+                    msg = "'%s' not found in %s '%s'" % (name, cls.__name__, self.name)
+                    raise KeyError(msg)
+            return ret
+
+        return _func
+    @classmethod
+    def __make_add(cls, func_name, attr_name, container_type):
+        doc = "Add %s to this %s" % (cls.__add_article(container_type.__name__), cls.__name__)
+
+        @docval({'name': attr_name, 'type': container_type, 'doc': 'the %s to add' % container_type.__name__},
                 func_name=func_name, doc=doc)
         def _func(self, **kwargs):
             ts = getargs(attr_name, kwargs)
@@ -291,32 +320,32 @@ class MultiTSInterface(NWBDataInterface):
         return _func
 
     @classmethod
-    def __make_create(cls, func_name, add_name, ts_type):
+    def __make_create(cls, func_name, add_name, container_type):
         doc = "Create %s and add it to this %s" % \
-                       (cls.__add_article(ts_type.__name__), cls.__name__)
+                       (cls.__add_article(container_type.__name__), cls.__name__)
 
-        @docval(*filter(_not_parent, get_docval(ts_type.__init__)), func_name=func_name, doc=doc,
-                returns="the %s object that was created" % ts_type.__name__, rtype=ts_type)
+        @docval(*filter(_not_parent, get_docval(container_type.__init__)), func_name=func_name, doc=doc,
+                returns="the %s object that was created" % container_type.__name__, rtype=container_type)
         def _func(self, **kwargs):
-            cargs, ckwargs = fmt_docval_args(ts_type.__init__, kwargs)
-            ret = ts_type(*cargs, **ckwargs)
+            cargs, ckwargs = fmt_docval_args(container_type.__init__, kwargs)
+            ret = container_type(*cargs, **ckwargs)
             getattr(self, add_name)(ret)
             return ret
         return _func
 
     @classmethod
-    def __make_constructor(cls, attr_name, add_name, ts_type):
+    def __make_constructor(cls, attr_name, add_name, container_type):
         @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
-                {'name': attr_name, 'type': (list, dict, ts_type),
-                 'doc': '%s to store in this interface' % ts_type.__name__, 'default': dict()},
+                {'name': attr_name, 'type': (list, dict, container_type),
+                 'doc': '%s to store in this interface' % container_type.__name__, 'default': dict()},
                 {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': cls.__name__},
                 func_name='__init__')
         def _func(self, **kwargs):
             source, ts = popargs('source', attr_name, kwargs)
-            super(MultiTSInterface, self).__init__(source, **kwargs)
+            super(MultiContainerInterface, self).__init__(source, **kwargs)
             setattr(self, attr_name, dict())
             add = getattr(self, add_name)
-            if isinstance(ts, ts_type):
+            if isinstance(ts, container_type):
                 add(ts)
             elif isinstance(ts, list):
                 for tmp in ts:
@@ -337,14 +366,35 @@ class MultiTSInterface(NWBDataInterface):
         if not isinstance(cls.__clsconf__, dict):
             raise TypeError("'__clsconf__' must be of type dict")
 
-        add = cls.__clsconf__['add']
-        create = cls.__clsconf__['create']
-        ts_attr = cls.__clsconf__['ts_attr']
-        ts_type = cls.__clsconf__['ts_type']
-        if not hasattr(cls, ts_attr):
-            getter = cls._getter(ts_attr)
-            doc = "a dictionary containing the %s in this %s" % (ts_type.__name__, cls.__name__)
-            setattr(cls, ts_attr, property(getter, cls._setter(ts_attr), None, doc))
-        setattr(cls, add, cls.__make_add(add, ts_attr, ts_type))
-        setattr(cls, create, cls.__make_create(create, add, ts_type))
-        setattr(cls, '__init__', cls.__make_constructor(ts_attr, add, ts_type))
+        # get add method name
+        add = cls.__clsconf__.get('add')
+        if add is None:
+            msg = "MultiContainerInterface subclass '%s' is missing 'add' key in __clsconf__" % cls.__name__
+            raise ValueError(msg)
+
+        # get container attribute name
+        attr = cls.__clsconf__.get('attr')
+        if attr is None:
+            msg = "MultiContainerInterface subclass '%s' is missing 'attr' key in __clsconf__" % cls.__name__
+            raise ValueError(msg)
+
+        # get container type
+        container_type = cls.__clsconf__.get('type')
+        if container_type is None:
+            msg = "MultiContainerInterface subclass '%s' is missing 'type' key in __clsconf__" % cls.__name__
+            raise ValueError(msg)
+        if not hasattr(cls, attr):
+            getter = cls._getter(attr)
+            doc = "a dictionary containing the %s in this %s container" % (container_type.__name__, cls.__name__)
+            setattr(cls, attr, property(getter, cls._setter(attr), None, doc))
+        setattr(cls, add, cls.__make_add(add, attr, container_type))
+        setattr(cls, '__init__', cls.__make_constructor(attr, add, container_type))
+
+        # get create method name
+        create = cls.__clsconf__.get('create')
+        if create is not None:
+            setattr(cls, create, cls.__make_create(create, add, container_type))
+
+        get = cls.__clsconf__.get('get')
+        if get is not None:
+            setattr(cls, get, cls.__make_get(get, attr, container_type))

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -254,16 +254,21 @@ class NWBTableRegion(NWBData, DataRegion):
 class MultiContainerInterface(NWBDataInterface):
     '''
     A class for dynamically defining a API classes that
-    represent NWBDataInterfaces that contain multiple TimeSeries
+    represent NWBDataInterfaces that contain multiple Containers
     of the same type
 
     To use, extend this class, and create a dictionary as a class
     attribute with the following keys:
 
-    'add' to name the method for adding TimeSeries instances
-    'create' to name the method fo creating TimeSeries instances
-    'attr' to name the attribute that stores the TimeSeries instances
-    'type' to provide the TimeSeries object type
+    * 'add' to name the method for adding Container instances
+
+    * 'create' to name the method fo creating Container instances
+
+    * 'get' to name the method for getting Container instances
+
+    * 'attr' to name the attribute that stores the Container instances
+
+    * 'type' to provide the Container object type
 
     See LFP or Position for an example of how to use this.
     '''

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -393,7 +393,8 @@ class MultiContainerInterface(NWBDataInterface):
             doc = "a dictionary containing the %s in this %s container" % (container_type.__name__, cls.__name__)
             setattr(cls, attr, property(getter, cls._setter(attr), None, doc))
         setattr(cls, add, cls.__make_add(add, attr, container_type))
-        setattr(cls, '__init__', cls.__make_constructor(attr, add, container_type))
+        if cls.__init__ is MultiContainerInterface.__init__:
+            setattr(cls, '__init__', cls.__make_constructor(attr, add, container_type))
 
         # get create method name
         create = cls.__clsconf__.get('create')

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -278,7 +278,6 @@ class MultiContainerInterface(NWBDataInterface):
     def __make_get(cls, func_name, attr_name, container_type):
         doc = "Get %s from this %s" % (cls.__add_article(container_type.__name__), cls.__name__)
 
-
         @docval({'name': 'name', 'type': str, 'doc': 'the name of the %s' % container_type.__name__,
                  'default': None}, rtype=container_type, returns='the %s with the given name' % container_type.__name__,
                 func_name=func_name, doc=doc)
@@ -303,6 +302,7 @@ class MultiContainerInterface(NWBDataInterface):
             return ret
 
         return _func
+
     @classmethod
     def __make_add(cls, func_name, attr_name, container_type):
         doc = "Add %s to this %s" % (cls.__add_article(container_type.__name__), cls.__name__)

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -7,7 +7,7 @@ from .form.data_utils import DataChunkIterator, ShapeValidator
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
-from .core import NWBContainer, NWBTable, NWBTableRegion, NWBDataInterface, MultiTSInterface
+from .core import NWBContainer, NWBTable, NWBTableRegion, NWBDataInterface, MultiContainerInterface
 
 
 @register_class('Device', CORE_NAMESPACE)
@@ -242,15 +242,15 @@ class EventDetection(NWBDataInterface):
 
 
 @register_class('EventWaveform', CORE_NAMESPACE)
-class EventWaveform(MultiTSInterface):
+class EventWaveform(MultiContainerInterface):
     """
     Spike data for spike events detected in raw data
     stored in this NWBFile, or events detect at acquisition
     """
 
     __clsconf__ = {
-        'ts_attr': 'spike_event_series',
-        'ts_type': SpikeEventSeries,
+        'attr': 'spike_event_series',
+        'type': SpikeEventSeries,
         'add': 'add_spike_event_series',
         'create': 'create_spike_event_series'
     }
@@ -331,7 +331,7 @@ class ClusterWaveforms(NWBDataInterface):
 
 
 @register_class('LFP', CORE_NAMESPACE)
-class LFP(MultiTSInterface):
+class LFP(MultiContainerInterface):
     """
     LFP data from one or more channels. The electrode map in each published ElectricalSeries will
     identify which channels are providing LFP data. Filter properties should be noted in the
@@ -339,10 +339,11 @@ class LFP(MultiTSInterface):
     """
 
     __clsconf__ = {
-        'ts_attr': 'electrical_series',
-        'ts_type': ElectricalSeries,
+        'attr': 'electrical_series',
+        'type': ElectricalSeries,
         'add': 'add_electrical_series',
-        'create': 'create_electrical_series'
+        'create': 'create_electrical_series',
+        'get': 'get_electrical_series'
     }
 
     __help = ("LFP data from one or more channels. Filter properties "
@@ -350,7 +351,7 @@ class LFP(MultiTSInterface):
 
 
 @register_class('FilteredEphys', CORE_NAMESPACE)
-class FilteredEphys(MultiTSInterface):
+class FilteredEphys(MultiContainerInterface):
     """
     Ephys data from one or more channels that has been subjected to filtering. Examples of filtered
     data include Theta and Gamma (LFP has its own interface). FilteredEphys modules publish an
@@ -367,8 +368,8 @@ class FilteredEphys(MultiTSInterface):
               "be noted in the ElectricalSeries")
 
     __clsconf__ = {
-        'ts_attr': 'electrical_series',
-        'ts_type': ElectricalSeries,
+        'attr': 'electrical_series',
+        'type': ElectricalSeries,
         'add': 'add_electrical_series',
         'create': 'create_electrical_series'
     }

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -252,6 +252,7 @@ class EventWaveform(MultiContainerInterface):
         'attr': 'spike_event_series',
         'type': SpikeEventSeries,
         'add': 'add_spike_event_series',
+        'get': 'get_spike_event_series',
         'create': 'create_spike_event_series'
     }
 
@@ -342,6 +343,7 @@ class LFP(MultiContainerInterface):
         'attr': 'electrical_series',
         'type': ElectricalSeries,
         'add': 'add_electrical_series',
+        'get': 'get_electrical_series',
         'create': 'create_electrical_series',
         'get': 'get_electrical_series'
     }
@@ -371,6 +373,7 @@ class FilteredEphys(MultiContainerInterface):
         'attr': 'electrical_series',
         'type': ElectricalSeries,
         'add': 'add_electrical_series',
+        'get': 'get_electrical_series',
         'create': 'create_electrical_series'
     }
 

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -315,6 +315,7 @@ class DfOverF(MultiContainerInterface):
         'attr': 'roi_response_series',
         'type': RoiResponseSeries,
         'add': 'add_roi_response_series',
+        'get': 'get_roi_response_series',
         'create': 'create_roi_response_series'
     }
 
@@ -332,6 +333,7 @@ class Fluorescence(MultiContainerInterface):
         'attr': 'roi_response_series',
         'type': RoiResponseSeries,
         'add': 'add_roi_response_series',
+        'get': 'get_roi_response_series',
         'create': 'create_roi_response_series'
     }
 

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -6,7 +6,7 @@ from .form.utils import docval, popargs, fmt_docval_args
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, NWBDataInterface, MultiTSInterface
+from .core import NWBContainer, NWBDataInterface, MultiContainerInterface
 
 
 @register_class('OpticalChannel', CORE_NAMESPACE)
@@ -305,15 +305,15 @@ class RoiResponseSeries(TimeSeries):
 
 
 @register_class('DfOverF', CORE_NAMESPACE)
-class DfOverF(MultiTSInterface):
+class DfOverF(MultiContainerInterface):
     """
     dF/F information about a region of interest (ROI). Storage hierarchy of dF/F should be the same
     as for segmentation (ie, same names for ROIs and for image planes).
     """
 
     __clsconf__ = {
-        'ts_attr': 'roi_response_series',
-        'ts_type': RoiResponseSeries,
+        'attr': 'roi_response_series',
+        'type': RoiResponseSeries,
         'add': 'add_roi_response_series',
         'create': 'create_roi_response_series'
     }
@@ -322,15 +322,15 @@ class DfOverF(MultiTSInterface):
 
 
 @register_class('Fluorescence', CORE_NAMESPACE)
-class Fluorescence(MultiTSInterface):
+class Fluorescence(MultiContainerInterface):
     """
     Fluorescence information about a region of interest (ROI). Storage hierarchy of fluorescence
     should be the same as for segmentation (ie, same names for ROIs and for image planes).
     """
 
     __clsconf__ = {
-        'ts_attr': 'roi_response_series',
-        'ts_type': RoiResponseSeries,
+        'attr': 'roi_response_series',
+        'type': RoiResponseSeries,
         'add': 'add_roi_response_series',
         'create': 'create_roi_response_series'
     }

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -207,12 +207,12 @@ class PlaneSegmentation(MultiContainerInterface):
                      'imaging_plane',
                      'reference_images')
 
-    @docval({'name': 'name', 'type': str, 'doc': 'name of PlaneSegmentation.'},
-            {'name': 'source', 'type': str, 'doc': 'the source of the data'},
+    @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
             {'name': 'description', 'type': str,
              'doc': 'Description of image plane, recording wavelength, depth, etc.'},
             {'name': 'imaging_plane', 'type': ImagingPlane,
              'doc': 'link to ImagingPlane group from which this TimeSeries data was generated.'},
+            {'name': 'name', 'type': str, 'doc': 'name of PlaneSegmentation.', 'default': None},
             {'name': 'roi', 'type': (Iterable, ROI), 'doc': 'List of ROIs in this imaging plane.',
              'default': list()},
             {'name': 'reference_images', 'type': ImageSeries, 'default': None,
@@ -220,6 +220,8 @@ class PlaneSegmentation(MultiContainerInterface):
     def __init__(self, **kwargs):
         description, roi, imaging_plane, reference_images = popargs(
             'description', 'roi', 'imaging_plane', 'reference_images', kwargs)
+        if kwargs.get('name') is None:
+            kwargs['name'] = imaging_plane.name
         pargs, pkwargs = fmt_docval_args(super(PlaneSegmentation, self).__init__, kwargs)
         super(PlaneSegmentation, self).__init__(*pargs, **pkwargs)
         self.description = description

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -6,7 +6,7 @@ from .form.utils import docval, popargs, fmt_docval_args
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBDataInterface, MultiContainerInterface
+from .core import NWBContainer, MultiContainerInterface
 
 
 @register_class('OpticalChannel', CORE_NAMESPACE)

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -6,7 +6,7 @@ from .form.utils import docval, popargs, fmt_docval_args
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, NWBDataInterface, MultiContainerInterface
+from .core import NWBDataInterface, MultiContainerInterface
 
 
 @register_class('OpticalChannel', CORE_NAMESPACE)

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -151,7 +151,7 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         iS = PlaneSegmentation('test_name', 'test source', 'description', ip, rois.values(), iSS)
         self.assertEqual(iS.description, 'description')
         self.assertEqual(iS.source, 'test source')
-        self.assertEqual(iS.rois, rois)
+        self.assertEqual(iS.roi, rois)
         self.assertEqual(iS.imaging_plane, ip)
         self.assertEqual(iS.reference_images, iSS)
 

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -26,7 +26,7 @@ def CreatePlaneSegmentation():
         'test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
         'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-    ps = PlaneSegmentation('name', 'test source', 'description', roi_list, ip, iSS)
+    ps = PlaneSegmentation('name', 'test source', 'description', ip, roi_list, iSS)
     return ps
 
 
@@ -116,18 +116,18 @@ class ImageSegmentationConstructor(unittest.TestCase):
 
         roi1 = ROI('roi1', 'test source', 'roi description1', pix_mask, pix_mask_weight, img_mask, iSS)
         roi2 = ROI('roi2', 'test source', 'roi description2', pix_mask, pix_mask_weight, img_mask, iSS)
-        roi_list = (roi1, roi2)
+        rois = (roi1, roi2)
 
         oc = OpticalChannel('test_optical_channel', 'test source', 'description', 'emission_lambda')
         ip = ImagingPlane('test_imaging_plane', 'test source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        ps = PlaneSegmentation('name', 'test source', 'description', roi_list, ip, iSS)
+        ps = PlaneSegmentation('name', 'test source', 'description', ip, rois, iSS)
 
         iS = ImageSegmentation('test_source', ps, name='test_iS')
         self.assertEqual(iS.name, 'test_iS')
         self.assertEqual(iS.source, 'test_source')
-        self.assertEqual(iS.plane_segmentations, [ps])
+        self.assertEqual(iS.plane_segmentations['name'], ps)
 
 
 class PlaneSegmentationConstructor(unittest.TestCase):
@@ -142,16 +142,16 @@ class PlaneSegmentationConstructor(unittest.TestCase):
 
         roi1 = ROI('roi1', 'test source', 'roi description1', pix_mask, pix_mask_weight, img_mask, iSS)
         roi2 = ROI('roi2', 'test source', 'roi description2', pix_mask, pix_mask_weight, img_mask, iSS)
-        roi_list = (roi1, roi2)
+        rois = {'roi1': roi1, 'roi2': roi2}
 
         oc = OpticalChannel('test_optical_channel', 'test_source', 'description', 'emission_lambda')
         ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        iS = PlaneSegmentation('test_name', 'test source', 'description', roi_list, ip, iSS)
+        iS = PlaneSegmentation('test_name', 'test source', 'description', ip, rois.values(), iSS)
         self.assertEqual(iS.description, 'description')
         self.assertEqual(iS.source, 'test source')
-        self.assertEqual(iS.roi_list, roi_list)
+        self.assertEqual(iS.rois, rois)
         self.assertEqual(iS.imaging_plane, ip)
         self.assertEqual(iS.reference_images, iSS)
 

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -26,7 +26,7 @@ def CreatePlaneSegmentation():
         'test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
         'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-    ps = PlaneSegmentation('name', 'test source', 'description', ip, roi_list, iSS)
+    ps = PlaneSegmentation('test source', 'description', ip, 'name', roi_list, iSS)
     return ps
 
 
@@ -122,7 +122,7 @@ class ImageSegmentationConstructor(unittest.TestCase):
         ip = ImagingPlane('test_imaging_plane', 'test source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        ps = PlaneSegmentation('name', 'test source', 'description', ip, rois, iSS)
+        ps = PlaneSegmentation('test source', 'description', ip, 'name', rois, iSS)
 
         iS = ImageSegmentation('test_source', ps, name='test_iS')
         self.assertEqual(iS.name, 'test_iS')
@@ -148,7 +148,7 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        iS = PlaneSegmentation('test_name', 'test source', 'description', ip, rois.values(), iSS)
+        iS = PlaneSegmentation('test source', 'description', ip, 'test_name', rois.values(), iSS)
         self.assertEqual(iS.description, 'description')
         self.assertEqual(iS.source, 'test source')
         self.assertEqual(iS.roi, rois)


### PR DESCRIPTION
## Motivation

The functionality of MultiTSInterface is useful for other NWBDataInterfaces that contain one more of another Container type. MultiTSInterface was generalized for use in these instances, and renamed to MultiContainerInterface

Additionally, MultiContainerInterface now supports adding a getter to the subclass

## How to test the behavior?
The following classes now extend MultiContainerInterface (and have getters):
EventWaveform
LFP
FilteredEphys
DfOverF
Fluorescence
Position
EyeTracking
PupilTracking
CompassDirection
BehavioralTimeSeries
BehavioralEvents
BehavioralEpochs
MotionCorrection

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
