### PR TITLE
Enh/add one or more

### DIFF
--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -312,12 +312,13 @@ class MultiContainerInterface(NWBDataInterface):
     def __make_add(cls, func_name, attr_name, container_type):
         doc = "Add %s to this %s" % (cls.__add_article(container_type.__name__), cls.__name__)
 
-        @docval({'name': attr_name, 'type': (list, tuple, dict, container_type), 'doc': 'the %s to add' % container_type.__name__},
+        @docval({'name': attr_name, 'type': (list, tuple, dict, container_type),
+                 'doc': 'the %s to add' % container_type.__name__},
                 func_name=func_name, doc=doc)
         def _func(self, **kwargs):
             container = getargs(attr_name, kwargs)
             if isinstance(container, container_type):
-                container = [container,]
+                container = [container]
             elif isinstance(container, dict):
                 container = container.values()
             d = getattr(self, attr_name)


### PR DESCRIPTION
## Motivation
improve usability.

dynamically created add methods in MultiContainerInterface subclasses now can take list, tuple, and dict
## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
