### PR TITLE
Conda on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,25 @@ ci-steps: &ci-steps
     - run:
         <<: *publish-prerelease-on-github
 
+conda-steps: &conda-steps
+  steps:
+    - checkout
+    - run:
+        name: Configure conda
+        command: |
+          conda config --set always_yes yes --set changeps1 no
+          conda config --add channels conda-forge
+          conda install virtualenv
+          pip install tox
+    - run:
+        name: Build wheel and source distribution
+        command: |
+          tox -e $BUILD_TOX_ENV
+    - run:
+        name: Test installation from a wheel
+        command: |
+          tox -e $TEST_TOX_ENV recreate --installpkg dist/*-none-any.whl
+
 version: 2
 jobs:
   flake8:
@@ -97,6 +116,30 @@ jobs:
      - UPLOAD_WHEELS: "true"
     <<: *ci-steps
 
+  miniconda27:
+    docker:
+      - image: continuumio/miniconda:latest
+    environment:
+      - TEST_TOX_ENV: "py27"
+      - BUILD_TOX_ENV: "build-py27"
+    <<: *conda-steps
+
+  miniconda35:
+    docker:
+      - image: continuumio/miniconda3:4.1.11
+    environment:
+      - TEST_TOX_ENV: "py35"
+      - BUILD_TOX_ENV: "build-py35"
+    <<: *conda-steps
+
+  miniconda36:
+    docker:
+      - image: continuumio/miniconda3:latest
+    environment:
+      - TEST_TOX_ENV: "py36"
+      - BUILD_TOX_ENV: "build-py36"
+    <<: *conda-steps
+
 workflows:
   version: 2
   test-package-publish:
@@ -105,3 +148,6 @@ workflows:
       - python27
       - python35
       - python36
+      - miniconda27
+      - miniconda35
+      - miniconda36

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,44 +6,21 @@ branches:
 
 environment:
   matrix:
-    - PYTHON_VERSION: 2.7
-      PYTHON: C:\Miniconda-x64
-      ENV: miniconda
-      TEST_TOX_ENV: py27
-      COVERAGE_TOX_ENV: coverage-py27
-      BUILD_TOX_ENV: build-py27
-
-    - PYTHON_VERSION: 3.5
-      PYTHON: C:\Miniconda35-x64
-      ENV: miniconda
-      TEST_TOX_ENV: py35
-      COVERAGE_TOX_ENV: coverage-py35
-      BUILD_TOX_ENV: build-py35
-
-    - PYTHON_VERSION: 3.6
-      PYTHON: C:\Miniconda36-x64
-      ENV: miniconda
-      TEST_TOX_ENV: py36
-      COVERAGE_TOX_ENV: coverage-py36
-      BUILD_TOX_ENV: build-py36
 
     - PYTHON_VERSION: 2.7
       PYTHON: C:\\Python27-x64
-      ENV: python
       TEST_TOX_ENV: py27
       COVERAGE_TOX_ENV: coverage-py27
       BUILD_TOX_ENV: build-py27
 
     - PYTHON_VERSION: 3.5
       PYTHON: C:\\Python35-x64
-      ENV: python
       TEST_TOX_ENV: py35
       COVERAGE_TOX_ENV: coverage-py35
       BUILD_TOX_ENV: build-py35
 
     - PYTHON_VERSION: 3.6
       PYTHON: C:\\Python36-x64
-      ENV: python
       TEST_TOX_ENV: py36
       COVERAGE_TOX_ENV: coverage-py36
       BUILD_TOX_ENV: build-py36
@@ -51,13 +28,7 @@ environment:
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION%"
   - "set PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
-  - if [%ENV%]==[miniconda] (
-      conda config --set always_yes yes --set changeps1 no &&
-      conda update -q conda &&
-      conda info -a &&
-      conda install -c anaconda numpy)
-  - if [%ENV%]==[python] (
-      pip install wheel)
+  - pip install wheel
   - pip install tox
 
 test_script:


### PR DESCRIPTION
## Motivation

Make CI process faster by running conda tests on circle.

@ajtritt Before Appveyor took approximately 30 minutes and now it takes around 10.