### PR TITLE
Enh/ref attribute

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PYTHON = python
+FLAKE = flake8
 COVERAGE = coverage
 
 help:
@@ -35,6 +36,13 @@ develop: build
 test:
 	pip install -r requirements-dev.txt
 	tox
+
+flake:
+	$(FLAKE) src/
+	$(FLAKE) tests/
+
+devtest:
+	$(PYTHON) -W ignore test.py && $(MAKE) flake
 
 apidoc:
 	pip install -r requirements-doc.txt

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -378,7 +378,6 @@ class HDF5IO(FORMIO):
             else:
                 obj.attrs[key] = value                   # a regular scalar
 
-
     def _make_attr_ref_filler(self, obj, key, value):
         '''
             Make the callable for setting references to attributes

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -630,20 +630,19 @@ class HDF5IO(FORMIO):
             raise e
         return dset
 
-    def __get_ref_filler(self, dset, sl, f):
-        def _call():
-            dset[sl] = f()
-        return _call
-
-    def __get_ref(self, container, region=None):
-        if isinstance(container, Container):
-            builder = self.manager.build(container)
+    @docval({'name': 'container', 'type': (Builder, Container), 'doc': 'the object to reference'},
+            {'name': 'region', 'type': (slice, list, tuple), 'doc': 'the region reference indexing object',
+             'default': None},
+            returns='the reference', rtype=Reference)
+    def __get_ref(self, **kwargs):
+        container, region = getargs('container', 'region', kwargs)
+        if isinstance(container, Builder):
+            if isinstance(container, LinkBuilder):
+                builder = container.target_builder
+            else:
+                builder = container
         else:
-            if isinstance(container, Builder):
-                if isinstance(container, LinkBuilder):
-                    builder = container.target_builder
-                else:
-                    builder = container
+            builder = self.manager.build(container)
         path = self.__get_path(builder)
         if region is not None:
             dset = self.__file[path]

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -219,9 +219,6 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         self.__carg2spec = dict()
         self.__map_spec(spec)
 
-    def hack_get_subspec_values(self, *args, **kwargs):
-        return self.__get_subspec_values(*args, **kwargs)
-
     @property
     def spec(self):
         ''' the Spec used in this ObjectMapper '''

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -472,8 +472,9 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
 
             if attr_value is None:
                 if spec.required:
-                    warnings.warn("missing required attribute '%s' for '%s' of type '%s'"
-                                  % (spec.name, builder.name, self.spec.data_type_def))
+                    msg = "missing required attribute '%s' for '%s' of type '%s'"\
+                                  % (spec.name, builder.name, self.spec.data_type_def)
+                    warnings.warn(msg)
                 continue
             builder.set_attribute(spec.name, attr_value)
 
@@ -765,7 +766,7 @@ class TypeMap(object):
                 else:
                     return Container
             else:
-                return ('array_data',)
+                return ('array_data', 'data',)
 
     @classmethod
     def __get_constructor(self, base, addl_fields):

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -93,15 +93,51 @@ class Spec(ConstructableDict):
 #        return id(self) == id(other)
 
 
+_target_type_key = 'target_type'
+
+_ref_args = [
+    {'name': _target_type_key, 'type': str, 'doc': 'the target type GroupSpec or DatasetSpec'},
+    {'name': 'reftype', 'type': str, 'doc': 'the type of references this is i.e. region or object'},
+]
+
+
+class RefSpec(ConstructableDict):
+
+    __allowable_types = ('object', 'region')
+
+    @docval(*_ref_args)
+    def __init__(self, **kwargs):
+        target_type, reftype = getargs(_target_type_key, 'reftype', kwargs)
+        self[_target_type_key] = target_type
+        if reftype not in self.__allowable_types:
+            msg = "reftype must be one of the following: %s" % ", ".join(self.__allowable_types)
+            raise ValueError(msg)
+        self['reftype'] = reftype
+
+    @property
+    def target_type(self):
+        '''The data_type of the target of the reference'''
+        return self[_target_type_key]
+
+    @property
+    def reftype(self):
+        '''The type of reference'''
+        return self['reftype']
+
+    @docval(rtype=bool, returns='True if this RefSpec specifies a region reference, False otherwise')
+    def is_region(self):
+        return self['reftype'] == 'region'
+
+
 _attr_args = [
         {'name': 'name', 'type': str, 'doc': 'The name of this attribute'},
         {'name': 'doc', 'type': str, 'doc': 'a description about what this specification represents'},
-        {'name': 'dtype', 'type': str, 'doc': 'The data type of this attribute'},
+        {'name': 'dtype', 'type': (str, RefSpec), 'doc': 'The data type of this attribute'},
         {'name': 'shape', 'type': (list, tuple), 'doc': 'the shape of this dataset', 'default': None},
         {'name': 'dims', 'type': (list, tuple), 'doc': 'the dimensions of this dataset', 'default': None},
         {'name': 'required', 'type': bool,
          'doc': 'whether or not this attribute is required. ignored when "value" is specified', 'default': True},
-        {'name': 'parent', 'type': 'AttributeSpec', 'doc': 'the parent of this spec', 'default': None},
+        {'name': 'parent', 'type': 'BaseStorageSpec', 'doc': 'the parent of this spec', 'default': None},
         {'name': 'value', 'type': None, 'doc': 'a constant value for this attribute', 'default': None},
         {'name': 'default_value', 'type': None, 'doc': 'a default value for this attribute', 'default': None}
 ]
@@ -403,42 +439,6 @@ class BaseStorageSpec(Spec):
         if 'attributes' in ret:
             ret['attributes'] = [AttributeSpec.build_spec(sub_spec) for sub_spec in ret['attributes']]
         return ret
-
-
-_target_type_key = 'target_type'
-
-_ref_args = [
-    {'name': _target_type_key, 'type': str, 'doc': 'the target type GroupSpec or DatasetSpec'},
-    {'name': 'reftype', 'type': str, 'doc': 'the type of references this is i.e. region or object'},
-]
-
-
-class RefSpec(ConstructableDict):
-
-    __allowable_types = ('object', 'region')
-
-    @docval(*_ref_args)
-    def __init__(self, **kwargs):
-        target_type, reftype = getargs(_target_type_key, 'reftype', kwargs)
-        self[_target_type_key] = target_type
-        if reftype not in self.__allowable_types:
-            msg = "reftype must be one of the following: %s" % ", ".join(self.__allowable_types)
-            raise ValueError(msg)
-        self['reftype'] = reftype
-
-    @property
-    def target_type(self):
-        '''The data_type of the target of the reference'''
-        return self[_target_type_key]
-
-    @property
-    def reftype(self):
-        '''The type of reference'''
-        return self['reftype']
-
-    @docval(rtype=bool, returns='True if this RefSpec specifies a region reference, False otherwise')
-    def is_region(self):
-        return self['reftype'] == 'region'
 
 
 _dt_args = [


### PR DESCRIPTION
## Motivation

Attributes can store references, but HDF5IO did not have support this. 

## How to test the behavior?
see test_write_attribute_reference_container and test_write_attribute_reference_builder in tests/unit/form_tests/test_io_hdf5.py

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
