### PR TITLE
Enh/multi mci

### DIFF
--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -66,8 +66,8 @@ class TestElectrodeGroupIO(base.TestMapRoundTrip):
 
     def addContainer(self, nwbfile):
         ''' Should take an NWBFile object and add the container to it '''
-        nwbfile.set_device(self.dev1)
-        nwbfile.set_electrode_group(self.container)
+        nwbfile.add_device(self.dev1)
+        nwbfile.add_electrode_group(self.container)
 
     def getContainer(self, nwbfile):
         ''' Should take an NWBFile object and return the Container'''
@@ -129,8 +129,8 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
 
     def addContainer(self, nwbfile):
         ''' Should take an NWBFile object and add the container to it '''
-        nwbfile.set_device(self.dev1)
-        nwbfile.set_electrode_group(self.group)
+        nwbfile.add_device(self.dev1)
+        nwbfile.add_electrode_group(self.group)
         nwbfile.set_electrode_table(self.table)
         nwbfile.add_acquisition(self.container)
 

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -112,5 +112,6 @@ class TestNWBFileIO(base.TestMapNWBContainer):
         self.assertIsInstance(container, NWBFile)
         raw_ts = container.acquisition
         self.assertEqual(len(raw_ts), 1)
-        self.assertIsInstance(raw_ts[0], TimeSeries)
+        for v in raw_ts.values():
+            self.assertIsInstance(v, TimeSeries)
         hdf5io.close()

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -53,7 +53,7 @@ class TestImagingPlaneIO(base.TestMapRoundTrip):
 
     def addContainer(self, nwbfile):
         """Should take an NWBFile object and add the container to it"""
-        nwbfile.set_imaging_plane(self.container)
+        nwbfile.add_imaging_plane(self.container)
 
     def getContainer(self, nwbfile):
         """Should take an NWBFile object and return the Container"""
@@ -142,5 +142,5 @@ class TestTwoPhotonSeries(base.TestDataInterfaceIO):
 
     def addContainer(self, nwbfile):
         """Should take an NWBFile object and add the container to it"""
-        nwbfile.set_imaging_plane(self.imaging_plane)
+        nwbfile.add_imaging_plane(self.imaging_plane)
         nwbfile.add_acquisition(self.container)


### PR DESCRIPTION
## Motivation
Allow a MultiContainerInterface to hold more than one container type. For example, NWBFile holds more than one Container type, and has multiple locations for storing multiple containers e.g. /acquisition and /processing

## How to test the behavior?
Use NWBFile getters.

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
