### PR TITLE
MultiContainerInterface supports __getitem__ when possible

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -288,8 +288,16 @@ class PatchedPythonDomain(PythonDomain):
         return super(PatchedPythonDomain, self).resolve_xref(
             env, fromdocname, builder, typ, target, node, contnode)
 
+from abc import abstractmethod, abstractproperty
+def skip(app, what, name, obj, skip, options):
+    if isinstance(obj, abstractproperty) or getattr(obj, '__isabstractmethod__', False):
+        return False
+    elif name == "__getitem__":
+        return False
+    return skip
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)
     app.add_stylesheet("theme_overrides.css")  # overrides for wide tables in RTD theme
     app.override_domain(PatchedPythonDomain)
+    app.connect("autodoc-skip-member", skip)

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -464,7 +464,9 @@ class DataIO(with_metaclass(ABCMeta, object)):
 
 class RegionSlicer(with_metaclass(ABCMeta, object)):
     '''
-    A class to control getting using a region
+    A abstract base class to control getting using a region
+
+    Subclasses must implement `__getitem__` and `__len__`
     '''
 
     @abstractproperty

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -1,3 +1,5 @@
+import unittest2 as unittest
+
 from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder
 
 from pynwb.ecephys import *  # noqa: F403
@@ -133,6 +135,115 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
         nwbfile.add_electrode_group(self.group)
         nwbfile.set_electrode_table(self.table)
         nwbfile.add_acquisition(self.container)
+
+class TestMultiElectricalSeries(TestElectricalSeriesIO):
+
+    def setUpElectricalSeriesContainers(self):
+        self.make_electrode_table()
+        region1 = ElectrodeTableRegion(self.table, [0, 2], 'the first and third electrodes')  # noqa: F405
+        region2 = ElectrodeTableRegion(self.table, [1, 3], 'the second and fourth electrodes')  # noqa: F405
+        data1 = list(zip(range(10), range(10, 20)))
+        data2 = list(zip(reversed(range(10)), reversed(range(10, 20))))
+        timestamps = list(map(lambda x: x/10, range(10)))
+        es1 = ElectricalSeries('test_eS1', 'a hypothetical source', data1, region1, timestamps=timestamps)  # noqa: F405
+        es2 = ElectricalSeries('test_eS2', 'a hypothetical source', data2, region2, timestamps=timestamps)  # noqa: F405
+        return (es1, es2)
+
+    def setUpElectricalSeriesBuilders(self):
+        table_builder = self.get_table_builder()
+        data = list(zip(range(10), range(10, 20)))
+        timestamps = list(map(lambda x: x/10, range(10)))
+        es1 = GroupBuilder('test_eS1',
+                            attributes={'source': 'a hypothetical source',
+                                        'namespace': base.CORE_NAMESPACE,
+                                        'comments': 'no comments',
+                                        'description': 'no description',
+                                        'neurodata_type': 'ElectricalSeries',
+                                        'help': 'Stores acquired voltage data from extracellular recordings'},
+                            datasets={'data': DatasetBuilder('data',
+                                                             data,
+                                                             attributes={'unit': 'volt',
+                                                                         'conversion': 1.0,
+                                                                         'resolution': 0.0}),
+                                      'timestamps': DatasetBuilder('timestamps',
+                                                                   timestamps,
+                                                                   attributes={'unit': 'Seconds', 'interval': 1}),
+                                      'electrodes': RegionBuilder('electrodes', [0, 2],
+                                                                  table_builder,
+                                                                  attributes={
+                                                                      'neurodata_type': 'ElectrodeTableRegion',
+                                                                      'namespace': 'core',
+                                                                      'description': 'the first and third electrodes',
+                                                                      'help': 'a subset (i.e. slice or region) of an ElectrodeTable'})})  # noqa: E501
+        data = list(zip(reversed(range(10)), reversed(range(10, 20))))
+        es2 = GroupBuilder('test_eS2',
+                            attributes={'source': 'a hypothetical source',
+                                        'namespace': base.CORE_NAMESPACE,
+                                        'comments': 'no comments',
+                                        'description': 'no description',
+                                        'neurodata_type': 'ElectricalSeries',
+                                        'help': 'Stores acquired voltage data from extracellular recordings'},
+                            datasets={'data': DatasetBuilder('data',
+                                                             data,
+                                                             attributes={'unit': 'volt',
+                                                                         'conversion': 1.0,
+                                                                         'resolution': 0.0}),
+                                      'timestamps': DatasetBuilder('timestamps',
+                                                                   timestamps,
+                                                                   attributes={'unit': 'Seconds', 'interval': 1}),
+                                      'electrodes': RegionBuilder('electrodes', [1, 3],
+                                                                  table_builder,
+                                                                  attributes={
+                                                                      'neurodata_type': 'ElectrodeTableRegion',
+                                                                      'namespace': 'core',
+                                                                      'description': 'the second and fourth electrodes',
+                                                                      'help': 'a subset (i.e. slice or region) of an ElectrodeTable'})})  # noqa: E501
+        return (es1, es2)
+
+    def setUpContainer(self):
+        raise unittest.SkipTest('Cannot run test unless addContainer is implemented')
+
+    def setUpBuilder(self):
+        raise unittest.SkipTest('Cannot run test unless addContainer is implemented')
+
+
+class TestLFP(TestMultiElectricalSeries):
+
+    def setUpContainer(self):
+        es = self.setUpElectricalSeriesContainers()
+        ret = LFP('LFP roundtrip test', es)
+        return ret
+
+    def setUpBuilder(self):
+        es = self.setUpElectricalSeriesBuilders()
+        ret = GroupBuilder('LFP',
+                           attributes={'source': 'LFP roundtrip test',
+                                       'namespace': base.CORE_NAMESPACE,
+                                       'neurodata_type': 'LFP',
+                                       'help': ('LFP data from one or more channels. Filter properties should be noted in '
+                                                'the ElectricalSeries')},
+                           groups={'test_es1': es[0], 'test_es2': es[1]})
+        return ret
+
+
+class TestFilteredEphys(TestMultiElectricalSeries):
+
+    def setUpContainer(self):
+        es = self.setUpElectricalSeriesContainers()
+        ret = FilteredEphys('FilteredEphys roundtrip test', es)
+        return ret
+
+    def setUpBuilder(self):
+        es = self.setUpElectricalSeriesBuilders()
+        ret = GroupBuilder('FilteredEphys',
+                           attributes={'source': 'FilteredEphys roundtrip test',
+                                       'namespace': base.CORE_NAMESPACE,
+                                       'neurodata_type': 'FilteredEphys',
+                                       'help': ('Ephys data from one or more channels that is subjected to filtering, such '
+                                                'as for gamma or theta oscillations (LFP has its own interface). Filter properties '
+                                                'should be noted in the ElectricalSeries')},
+                           groups={'test_es1': es[0], 'test_es2': es[1]})
+        return ret
 
 
 class TestClusteringIO(base.TestDataInterfaceIO):

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -136,6 +136,7 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
         nwbfile.set_electrode_table(self.table)
         nwbfile.add_acquisition(self.container)
 
+
 class TestMultiElectricalSeries(TestElectricalSeriesIO):
 
     def setUpElectricalSeriesContainers(self):
@@ -211,7 +212,7 @@ class TestLFP(TestMultiElectricalSeries):
 
     def setUpContainer(self):
         es = self.setUpElectricalSeriesContainers()
-        ret = LFP('LFP roundtrip test', es)
+        ret = LFP('LFP roundtrip test', es)  # noqa: F405
         return ret
 
     def setUpBuilder(self):
@@ -220,8 +221,8 @@ class TestLFP(TestMultiElectricalSeries):
                            attributes={'source': 'LFP roundtrip test',
                                        'namespace': base.CORE_NAMESPACE,
                                        'neurodata_type': 'LFP',
-                                       'help': ('LFP data from one or more channels. Filter properties should be noted in '
-                                                'the ElectricalSeries')},
+                                       'help': ('LFP data from one or more channels. Filter properties should be '
+                                                'noted in the ElectricalSeries')},
                            groups={'test_es1': es[0], 'test_es2': es[1]})
         return ret
 
@@ -230,7 +231,7 @@ class TestFilteredEphys(TestMultiElectricalSeries):
 
     def setUpContainer(self):
         es = self.setUpElectricalSeriesContainers()
-        ret = FilteredEphys('FilteredEphys roundtrip test', es)
+        ret = FilteredEphys('FilteredEphys roundtrip test', es)  # noqa: F405
         return ret
 
     def setUpBuilder(self):
@@ -239,9 +240,9 @@ class TestFilteredEphys(TestMultiElectricalSeries):
                            attributes={'source': 'FilteredEphys roundtrip test',
                                        'namespace': base.CORE_NAMESPACE,
                                        'neurodata_type': 'FilteredEphys',
-                                       'help': ('Ephys data from one or more channels that is subjected to filtering, such '
-                                                'as for gamma or theta oscillations (LFP has its own interface). Filter properties '
-                                                'should be noted in the ElectricalSeries')},
+                                       'help': ('Ephys data from one or more channels that is subjected to filtering, '
+                                                'such as for gamma or theta oscillations (LFP has its own interface). '
+                                                'Filter properties should be noted in the ElectricalSeries')},
                            groups={'test_es1': es[0], 'test_es2': es[1]})
         return ret
 

--- a/tests/unit/pynwb_tests/test_ephys.py
+++ b/tests/unit/pynwb_tests/test_ephys.py
@@ -83,6 +83,7 @@ class EventWaveformConstructor(unittest.TestCase):
         ew = EventWaveform('test_ew', sES)  # noqa: F405
         self.assertEqual(ew.source, 'test_ew')
         self.assertEqual(ew.spike_event_series['test_sES'], sES)
+        self.assertEqual(ew['test_sES'], ew.spike_event_series['test_sES'])
 
 
 class ClusteringConstructor(unittest.TestCase):
@@ -129,6 +130,7 @@ class LFPTest(unittest.TestCase):
         lfp = LFP('test_lfp', eS)  # noqa: F405
         self.assertEqual(lfp.source, 'test_lfp')
         self.assertEqual(lfp.electrical_series.get('test_eS'), eS)
+        self.assertEqual(lfp['test_eS'], lfp.electrical_series.get('test_eS'))
 
     def test_add_electrical_series(self):
         lfp = LFP('test_lfp')  # noqa: F405
@@ -141,6 +143,7 @@ class LFPTest(unittest.TestCase):
             'test_eS', 'a hypothetical source', [0, 1, 2, 3], region, timestamps=[0.1, 0.2, 0.3, 0.4])
         lfp.add_electrical_series(eS)
         self.assertEqual(lfp.electrical_series.get('test_eS'), eS)
+        self.assertEqual(lfp['test_eS'], lfp.electrical_series.get('test_eS'))
 
 
 class FilteredEphysTest(unittest.TestCase):
@@ -155,6 +158,7 @@ class FilteredEphysTest(unittest.TestCase):
         fe = FilteredEphys('test_fe', eS)  # noqa: F405
         self.assertEqual(fe.source, 'test_fe')
         self.assertEqual(fe.electrical_series.get('test_eS'), eS)
+        self.assertEqual(fe['test_eS'], fe.electrical_series.get('test_eS'))
 
     def test_add_electrical_series(self):
         fe = FilteredEphys('test_fe')  # noqa: F405
@@ -167,6 +171,7 @@ class FilteredEphysTest(unittest.TestCase):
             'test_eS', 'a hypothetical source', [0, 1, 2, 3], region, timestamps=[0.1, 0.2, 0.3, 0.4])
         fe.add_electrical_series(eS)
         self.assertEqual(fe.electrical_series.get('test_eS'), eS)
+        self.assertEqual(fe['test_eS'], fe.electrical_series.get('test_eS'))
 
 
 class FeatureExtractionConstructor(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -100,6 +100,7 @@ class FluorescenceConstructor(unittest.TestCase):
         ff = Fluorescence('test_ff', ts)
         self.assertEqual(ff.source, 'test_ff')
         self.assertEqual(ff.roi_response_series['test_ts'], ts)
+        self.assertEqual(ff.roi_response_series['test_ts'], ts)
 
 
 class ImageSegmentationConstructor(unittest.TestCase):
@@ -122,12 +123,13 @@ class ImageSegmentationConstructor(unittest.TestCase):
         ip = ImagingPlane('test_imaging_plane', 'test source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        ps = PlaneSegmentation('test source', 'description', ip, 'name', rois, iSS)
+        ps = PlaneSegmentation('test source', 'description', ip, 'test_pS', rois, iSS)
 
         iS = ImageSegmentation('test_source', ps, name='test_iS')
         self.assertEqual(iS.name, 'test_iS')
         self.assertEqual(iS.source, 'test_source')
-        self.assertEqual(iS.plane_segmentations['name'], ps)
+        self.assertEqual(iS.plane_segmentations['test_pS'], ps)
+        self.assertEqual(iS['test_pS'], iS.plane_segmentations['test_pS'])
 
 
 class PlaneSegmentationConstructor(unittest.TestCase):
@@ -148,12 +150,16 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        iS = PlaneSegmentation('test source', 'description', ip, 'test_name', rois.values(), iSS)
-        self.assertEqual(iS.description, 'description')
-        self.assertEqual(iS.source, 'test source')
-        self.assertEqual(iS.roi, rois)
-        self.assertEqual(iS.imaging_plane, ip)
-        self.assertEqual(iS.reference_images, iSS)
+        pS = PlaneSegmentation('test source', 'description', ip, 'test_name', rois.values(), iSS)
+        self.assertEqual(pS.description, 'description')
+        self.assertEqual(pS.source, 'test source')
+        self.assertEqual(pS.roi, rois)
+        self.assertEqual(pS.imaging_plane, ip)
+        self.assertEqual(pS.reference_images, iSS)
+        self.assertEqual(pS.get_roi('roi1'), roi1)
+        self.assertEqual(pS.get_roi('roi1'), pS.roi['roi1'])
+        self.assertEqual(pS.get_roi('roi1'), pS['roi1'])
+
 
 
 if __name__ == '__main__':

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -161,6 +161,5 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         self.assertEqual(pS.get_roi('roi1'), pS['roi1'])
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Motivation

MultiContainerInterfaces with a single container need a standard interface for retrieving their underlying sub-containers. To accomplish this, MultiContainerInterface objects now support \_\_getitem\_\_ if they contain only a single sub Container type (i.e. NWBFile will not support this)

## How to test behavior
For example, getting an the underlying SpikeEventSeries of EventWaveform can be done like so:

```python
ew = EventWaveForm(..., SpikeEventSeries(name='test_series'),...)
ses = ew['test_series']

# this is equivalent to
ses = ew.get_spike_event_series('test_series')
```

Additionally, when a MultiContainerInterface contains a single sub container, this sub container can be retrieved like so:
```python
ew = EventWaveForm(..., SpikeEventSeries(name='test_series'),...)
ses = ew[None]

# this is equivalent to
ses = ew.get_spike_event_series()
```

Classes that behave like this are:

- EventWaveform
- LFP
- FilteredEphys
- MotionCorrection
- ImageSegmentation
- PlaneSegmentation
- DfOverF
- Fluorescence
- Position
- CompassDirection
- BehavioralTimeSeries
- BehavioralEvents
- BehavioralEpochs
- PupilTracking
- EyeTracking


## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
