### PR TITLE
Bug/read device

### DIFF
--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -227,6 +227,7 @@ groups:
         doc: One of possibly many. Information about device and device description.
         neurodata_type_def: Device
         neurodata_type_inc: NWBContainer
+        quantity: '*'
       name: devices
       quantity: '?'
     - datasets:

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -41,8 +41,8 @@ class NWBFileMap(ObjectMapper):
             self.spec.get_group('processing').get_neurodata_type('ProcessingModule'))
         self.unmap(general_spec.get_dataset('stimulus'))
 
-        subject_spec = general_spec.get_group('subject')
-        self.map_spec('subject', subject_spec)
+        self.map_spec('subject', general_spec.get_group('subject'))
+        self.map_spec('devices', general_spec.get_group('devices').get_neurodata_type('Device'))
 
     @ObjectMapper.constructor_arg('file_name')
     def name(self, builder, manager):


### PR DESCRIPTION
## Motivation

devices were not being read 

## How to test the behavior?
NWBFile.devices should be populated when an NWB file is read

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
