### PR TITLE
Fix typo on method call to load given extensions

### DIFF
--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -69,14 +69,14 @@ def get_manager(**kwargs):
         if isinstance(extensions, list):
             for ext in extensions:
                 if isinstance(ext, str):
-                    type_map.load_namespace(ext)
+                    type_map.load_namespaces(ext)
                 elif isinstance(ext, TypeMap):
                     type_map.merge(ext)
                 else:
                     msg = 'extensions must be a list of paths to namespace specs or a TypeMaps'
                     raise ValueError(msg)
         elif isinstance(extensions, str):
-            type_map.load_namespace(extensions)
+            type_map.load_namespaces(extensions)
         elif isinstance(extensions, TypeMap):
             type_map.merge(extensions)
     manager = BuildManager(type_map)


### PR DESCRIPTION
## Motivation

When extensions keyword argument is a string or a list, namespace tries to be load via the load_namespace method (See [here](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/src/pynwb/__init__.py#L72) and [here](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/src/pynwb/__init__.py#L79)). Though the TypeMap object has a "load_namespaces" method (see [here](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/src/pynwb/form/build/map.py#L730)).

Also I realized this part of the code is not covered by the tests (see [here](https://codecov.io/gh/NeurodataWithoutBorders/pynwb/src/dev/src/pynwb/__init__.py#L68)).  

Should we add tests to ensure written files can be read back using the extension files? 

## How to test the behavior?
```
mynwb = NWBHDF5IO('somefile.nwb', extensions='somepath.yaml')
```
