### PR TITLE
change device argument to take Device object

### DIFF
--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -5,6 +5,7 @@ from .form.utils import docval, popargs, fmt_docval_args
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .core import NWBContainer
+from .ecephys import Device
 
 
 @register_class('OptogeneticStimulusSite', CORE_NAMESPACE)
@@ -19,7 +20,7 @@ class OptogeneticStimulusSite(NWBContainer):
 
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this stimulus site'},
             {'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'device', 'type': str, 'doc': 'Name of device in /general/devices'},
+            {'name': 'device', 'type': Device, 'doc': 'the device that was used'},
             {'name': 'description', 'type': str, 'doc': 'Description of site.'},
             {'name': 'excitation_lambda', 'type': str, 'doc': 'Excitation wavelength.'},
             {'name': 'location', 'type': str, 'doc': 'Location of stimulation site.'})

--- a/tests/unit/pynwb_tests/test_ogen.py
+++ b/tests/unit/pynwb_tests/test_ogen.py
@@ -1,12 +1,14 @@
 import unittest
 
 from pynwb.ogen import OptogeneticSeries, OptogeneticStimulusSite
+from pynwb.ecephys import Device
 
 
 class OptogeneticSeriesConstructor(unittest.TestCase):
 
     def test_init(self):
-        oS = OptogeneticStimulusSite('site1', 'a test source', 'device', 'description', 'excitation_lambda', 'location')
+        device = Device('name', 'source')
+        oS = OptogeneticStimulusSite('site1', 'a test source', device, 'description', 'excitation_lambda', 'location')
         self.assertEqual(oS.name, 'site1')
         self.assertEqual(oS.device, 'device')
         self.assertEqual(oS.description, 'description')

--- a/tests/unit/pynwb_tests/test_ogen.py
+++ b/tests/unit/pynwb_tests/test_ogen.py
@@ -10,7 +10,7 @@ class OptogeneticSeriesConstructor(unittest.TestCase):
         device = Device('name', 'source')
         oS = OptogeneticStimulusSite('site1', 'a test source', device, 'description', 'excitation_lambda', 'location')
         self.assertEqual(oS.name, 'site1')
-        self.assertEqual(oS.device, 'device')
+        self.assertEqual(oS.device, device)
         self.assertEqual(oS.description, 'description')
         self.assertEqual(oS.excitation_lambda, 'excitation_lambda')
         self.assertEqual(oS.location, 'location')


### PR DESCRIPTION
## Motivation

fix #380 

## How to test the behavior?
```python
ophys_device = nwbfile.create_device('ophys_device', source=source)
ogen_site = nwbfile.create_ogen_site('oPhys', source, ophys_device,
                                     description='unknown',
                                     excitation_lambda='unknown',
                                     location='unknown')
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
