### PR TITLE
Enh/spike restructure

### DIFF
--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1,5 +1,6 @@
 from collections import Iterable
 from h5py import RegionReference
+import numpy as np
 
 from .form.utils import docval, getargs, ExtenderMeta, call_docval_func, popargs, get_docval, fmt_docval_args
 from .form import Container, Data, DataRegion, get_region_slicer
@@ -178,6 +179,71 @@ class NWBData(NWBBaseType, Data):
     @property
     def data(self):
         return self.__data
+
+    def __len__(self):
+        return len(self.__data)
+
+    def __getitem__(self, args):
+        return self.data[args]
+
+    def append(self, arg):
+        if isinstance(self.data, list):
+            self.data.append(arg)
+        elif isinstance(self.data, np.ndarray):
+            self.__data = np.append(self.__data, [arg])
+        else:
+            msg = "NWBData cannot append to object of type '%s'" % type(self.__data)
+            raise ValueError(msg)
+
+    def extend(self, arg):
+        if isinstance(self.data, list):
+            self.data.extend(arg)
+        elif isinstance(self.data, np.ndarray):
+            self.__data = np.append(self.__data, [arg])
+        else:
+            msg = "NWBData cannot extend object of type '%s'" % type(self.__data)
+            raise ValueError(msg)
+
+
+@register_class('VectorData', CORE_NAMESPACE)
+class VectorData(NWBData):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this VectorData'},
+            {'name': 'data', 'type': ('array_data', 'data'),
+             'doc': 'a dataset where the first dimension is a concatenation of multiple vectors'},
+            {'name': 'parent', 'type': 'NWBContainer',
+             'doc': 'the parent Container for this Container', 'default': None},
+            {'name': 'container_source', 'type': object,
+            'doc': 'the source of this Container e.g. file name', 'default': None})
+    def __init__(self, **kwargs):
+        call_docval_func(super(VectorData, self).__init__, kwargs)
+
+
+@register_class('VectorIndex', CORE_NAMESPACE)
+class VectorIndex(NWBData):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this VectorIndex'},
+            {'name': 'data', 'type': ('array_data', 'data'),
+             'doc': 'a 1D dataset containing indexes that apply to VectorData object'},
+            {'name': 'parent', 'type': 'NWBContainer',
+             'doc': 'the parent Container for this Container', 'default': None},
+            {'name': 'container_source', 'type': object,
+            'doc': 'the source of this Container e.g. file name', 'default': None})
+    def __init__(self, **kwargs):
+        call_docval_func(super(VectorIndex, self).__init__, kwargs)
+
+
+@register_class('ElementIdentifiers', CORE_NAMESPACE)
+class ElementIdentifiers(NWBData):
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this ElementIdentifiers'},
+            {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'a 1D dataset containing identifiers'},
+            {'name': 'parent', 'type': 'NWBContainer',
+             'doc': 'the parent Container for this Container', 'default': None},
+            {'name': 'container_source', 'type': object,
+            'doc': 'the source of this Container e.g. file name', 'default': None})
+    def __init__(self, **kwargs):
+        call_docval_func(super(ElementIdentifiers, self).__init__, kwargs)
 
 
 class NWBTable(NWBData):

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -167,7 +167,7 @@ class NWBData(NWBBaseType, Data):
     __nwbfields__ = ('help',)
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'},
-            {'name': 'data', 'type': (Iterable, Data), 'doc': 'the source of the data'},
+            {'name': 'data', 'type': ('array_data', 'data', Data), 'doc': 'the source of the data'},
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'the parent Container for this Container', 'default': None},
             {'name': 'container_source', 'type': object,

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -5,6 +5,42 @@ datasets:
     name: help
   doc: The attributes specified here are included in all interfaces.
   neurodata_type_def: NWBData
+- default_name: vector_data
+  attributes:
+  - doc: a help string
+    dtype: text
+    name: help
+    value: Values for each element in id
+  doc: Data values indexed by pointer
+  dtype: any
+  neurodata_type_def: VectorData
+  neurodata_type_inc: NWBData
+- default_name: vector_index
+  attributes:
+  - doc: a help string
+    dtype: text
+    name: help
+    value: reference for each item in id into data
+  doc: Pointers that index data values
+  dtype:
+    target_type: VectorData
+    reftype: region
+  shape:
+  - null
+  neurodata_type_def: VectorIndex
+  neurodata_type_inc: NWBData
+- default_name: element_id
+  attributes:
+  - doc: a help string
+    dtype: text
+    name: help
+    value: identifiers for each element stored VectorDataInterface
+  doc: a unique identifier for each element
+  dtype: int
+  shape:
+  - null
+  neurodata_type_def: ElementIdentifiers
+  neurodata_type_inc: NWBData
 groups:
 - attributes:
   - doc: Short description of what this type of NWBContainer contains.

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -10,7 +10,7 @@ datasets:
   - doc: a help string
     dtype: text
     name: help
-    value: Values for each element in id
+    value: Values for a list of elements
   doc: Data values indexed by pointer
   dtype: any
   neurodata_type_def: VectorData
@@ -20,7 +20,7 @@ datasets:
   - doc: a help string
     dtype: text
     name: help
-    value: reference for each item in id into data
+    value: indexes into a list of values for a list of elements
   doc: Pointers that index data values
   dtype:
     target_type: VectorData
@@ -34,7 +34,7 @@ datasets:
   - doc: a help string
     dtype: text
     name: help
-    value: identifiers for each element stored VectorDataInterface
+    value: unique identifiers for a list of elements
   doc: a unique identifier for each element
   dtype: int
   shape:

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -227,6 +227,7 @@ groups:
         doc: One of possibly many. Information about device and device description.
         neurodata_type_def: Device
         neurodata_type_inc: NWBContainer
+        quantity: '+'
       name: devices
       quantity: '?'
     - datasets:

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -227,7 +227,6 @@ groups:
         doc: One of possibly many. Information about device and device description.
         neurodata_type_def: Device
         neurodata_type_inc: NWBContainer
-        quantity: '*'
       name: devices
       quantity: '?'
     - datasets:

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -117,36 +117,20 @@ groups:
     a machine-readable way.
   neurodata_type_def: IntervalSeries
   neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Estimated spike times from a single unit'
-    dtype: text
-    name: help
-    value: Estimated spike times from a single unit
+- datasets:
+  - name: unit_ids
+    doc: a unique identifier for each element
+    neurodata_type_inc: ElementIdentifiers
+  - name: spike_times_index
+    doc: the index into the spike times dataset
+    neurodata_type_inc: VectorIndex
+  - name: spike_times
+    doc: the index into the vector data
+    neurodata_type_inc: VectorData
   doc: Event times of observed units (e.g. cell, synapse, etc.). The UnitTimes group
     contains a group for each unit. The name of the group should match the value in
     the source module, if that is possible/relevant (e.g., name of ROIs from Segmentation
     module).
-  groups:
-  - attributes:
-    - doc: Store times for a particulare UnitTime
-      dtype: text
-      name: help
-      value: Times for a particular UnitTime object
-    - doc: Description of the unit (eg, cell type).
-      dtype: text
-      name: unit_description
-    datasets:
-    - dims:
-      - num_events
-      doc: Spike time for the units (exact or estimated)
-      dtype: float64
-      name: times
-      shape:
-      - null
-    doc: Group storing times for &lt;unit_N&gt;.
-    neurodata_type_def: SpikeUnit
-    neurodata_type_inc: NWBDataInterface
-    quantity: +
   default_name: UnitTimes
   neurodata_type_def: UnitTimes
   neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -117,7 +117,12 @@ groups:
     a machine-readable way.
   neurodata_type_def: IntervalSeries
   neurodata_type_inc: TimeSeries
-- datasets:
+- attributes:
+  - doc: Value is 'Estimated spike times from a single unit'
+    dtype: text
+    name: help
+    value: Estimated spike times from a single unit
+  datasets:
   - name: unit_ids
     doc: a unique identifier for each element
     neurodata_type_inc: ElementIdentifiers

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -3,7 +3,7 @@ from dateutil.parser import parse as parse_date
 from collections import Iterable
 
 from .form.utils import docval, getargs, fmt_docval_args, call_docval_func, get_docval
-from .form.data_utils import JITDataset
+from .form.query import FORMDataset
 from .form import Container
 
 from . import register_class, CORE_NAMESPACE
@@ -163,7 +163,7 @@ class NWBFile(MultiContainerInterface):
              'doc': 'a description of the session where this data was generated'},
             {'name': 'identifier', 'type': str, 'doc': 'a unique text identifier for the file'},
             {'name': 'session_start_time', 'type': (datetime, str), 'doc': 'the start time of the recording session'},
-            {'name': 'file_create_date', 'type': (list, datetime, str, JITDataset),
+            {'name': 'file_create_date', 'type': (list, datetime, str, FORMDataset),
              'doc': 'the time the file was created and subsequent modifications made', 'default': None},
             {'name': 'version', 'type': str, 'doc': 'the NWB version', 'default': None},
             {'name': 'experimenter', 'type': str, 'doc': 'name of person who performed experiment', 'default': None},

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -3,6 +3,7 @@ from dateutil.parser import parse as parse_date
 from collections import Iterable
 
 from .form.utils import docval, getargs, fmt_docval_args, call_docval_func, get_docval
+from .form.data_utils import JITDataset
 from .form import Container
 
 from . import register_class, CORE_NAMESPACE
@@ -162,7 +163,7 @@ class NWBFile(MultiContainerInterface):
              'doc': 'a description of the session where this data was generated'},
             {'name': 'identifier', 'type': str, 'doc': 'a unique text identifier for the file'},
             {'name': 'session_start_time', 'type': (datetime, str), 'doc': 'the start time of the recording session'},
-            {'name': 'file_create_date', 'type': (list, datetime, str),
+            {'name': 'file_create_date', 'type': (list, datetime, str, JITDataset),
              'doc': 'the time the file was created and subsequent modifications made', 'default': None},
             {'name': 'version', 'type': str, 'doc': 'the NWB version', 'default': None},
             {'name': 'experimenter', 'type': str, 'doc': 'name of person who performed experiment', 'default': None},

--- a/src/pynwb/form/array.py
+++ b/src/pynwb/form/array.py
@@ -1,0 +1,192 @@
+import numpy as np
+from abc import abstractmethod, ABCMeta
+from six import with_metaclass
+
+
+class Array(object):
+
+    def __init__(self, data):
+        self.__data = data
+        if hasattr(data, 'dtype'):
+            self.dtype = data.dtype
+        else:
+            tmp = data
+            while isinstance(tmp, (list, tuple)):
+                tmp = tmp[0]
+            self.dtype = type(tmp)
+
+    @property
+    def data(self):
+        return self.__data
+
+    def __len__(self):
+        return len(self.__data)
+
+    def get_data(self):
+        return self.__data
+
+    def __getidx__(self, arg):
+        return self.__data[arg]
+
+    def __getitem__(self, arg):
+        if isinstance(arg, list):
+            idx = list()
+            for i in arg:
+                if isinstance(i, slice):
+                    idx.extend()
+                else:
+                    idx.append(i)
+            return np.fromiter((self.__getidx__(x) for x in idx), dtype=self.dtype)
+        elif isinstance(arg, slice):
+            return np.fromiter((self.__getidx__(x) for x in range(*arg.indices(len(self)))), dtype=self.dtype)
+        else:
+            return self.__getidx__(arg)
+
+
+class AbstractSortedArray(with_metaclass(ABCMeta, Array)):
+    '''
+    An abstract class for representing sorted array
+    '''
+
+    @abstractmethod
+    def find_point(self, val):
+        pass
+
+    def get_data(self):
+        return self
+
+    def __lower(self, other):
+        ins = self.find_point(other)
+        return ins
+
+    def __upper(self, other):
+        ins = self.__lower(other)
+        while self[ins] == other:
+            ins += 1
+        return ins
+
+    def __lt__(self, other):
+        ins = self.__lower(other)
+        return slice(0, ins)
+
+    def __le__(self, other):
+        ins = self.__upper(other)
+        return slice(0, ins)
+
+    def __gt__(self, other):
+        ins = self.__upper(other)
+        return slice(ins, len(self))
+
+    def __ge__(self, other):
+        ins = self.__lower(other)
+        return slice(ins, len(self))
+
+    @staticmethod
+    def __sort(a):
+        if isinstance(a, tuple):
+            return a[0]
+        else:
+            return a
+
+    def __eq__(self, other):
+        if isinstance(other, list):
+            ret = list()
+            for i in other:
+                eq = self == i
+                ret.append(eq)
+            ret = sorted(ret, key=self.__sort)
+            tmp = list()
+            for i in range(1, len(ret)):
+                a, b = ret[i-1], ret[i]
+                if isinstance(a, tuple):
+                    if isinstance(b, tuple):
+                        if a[1] >= b[0]:
+                            b[0] = a[0]
+                        else:
+                            tmp.append(slice(*a))
+                    else:
+                        if b > a[1]:
+                            tmp.append(slice(*a))
+                        elif b == a[1]:
+                            a[1] == b+1
+                        else:
+                            ret[i] = a
+                else:
+                    if isinstance(b, tuple):
+                        if a < b[0]:
+                            tmp.append(a)
+                    else:
+                        if b - a == 1:
+                            ret[i] = (a, b)
+                        else:
+                            tmp.append(a)
+            if isinstance(ret[-1], tuple):
+                tmp.append(slice(*ret[-1]))
+            else:
+                tmp.append(ret[-1])
+            ret = tmp
+            return ret
+        elif isinstance(other, tuple):
+            ge = self >= other
+            ge = ge[0]
+            lt = self < other
+            lt = lt[1]
+            if ge == lt:
+                return ge
+            else:
+                return (ge, lt)
+        else:
+            lower = self.__lower(other)
+            upper = self.__upper(other)
+            d = upper - lower
+            if d == 1:
+                return lower
+            elif d == 0:
+                return None
+            else:
+                return (lower, upper)
+
+    def __ne__(self, other):
+        eq = self == other
+        if isinstance(eq, tuple):
+            return [slice(0, eq[0]), slice(eq[1], len(self))]
+        else:
+            return [slice(0, eq), slice(eq+1, len(self))]
+
+
+class SortedArray(AbstractSortedArray):
+    '''
+    A class for wrapping sorted arrays. This class overrides
+    <,>,<=,>=,==, and != to leverage the sorted content for
+    efficiency.
+    '''
+
+    def __init__(self, array):
+        super(SortedArray, self).__init__(array)
+
+    def find_point(self, val):
+        return np.searchsorted(self.data, val)
+
+
+class LinSpace(SortedArray):
+
+    def __init__(self, start, stop, step):
+        self.start = start
+        self.stop = stop
+        self.step = step
+        self.dtype = float if any(isinstance(s, float) for s in (start, stop, step)) else int
+        self.__len = int((stop - start)/step)
+
+    def __len__(self):
+        return self.__len
+
+    def find_point(self, val):
+        nsteps = (val-self.start)/self.step
+        fl = int(nsteps)
+        if fl == nsteps:
+            return int(fl)
+        else:
+            return int(fl+1)
+
+    def __getidx__(self, arg):
+        return self.start + self.step*arg

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -8,7 +8,8 @@ import warnings
 from ...container import Container
 
 from ...utils import docval, getargs, popargs, call_docval_func
-from ...data_utils import DataChunkIterator, get_shape, JITDataset
+from ...data_utils import DataChunkIterator, get_shape
+from ...query import FORMDataset
 from ...build import Builder, GroupBuilder, DatasetBuilder, LinkBuilder, BuildManager,\
                      RegionBuilder, ReferenceBuilder, TypeMap
 from ...spec import RefSpec, DtypeSpec, NamespaceCatalog, SpecWriter, SpecReader, GroupSpec
@@ -262,11 +263,11 @@ class HDF5IO(FORMIO):
             elem1 = h5obj[0]
             d = None
             if isinstance(elem1, text_type):
-                d = JITDataset(h5obj)
+                d = FORMDataset(h5obj)
             elif isinstance(elem1, RegionReference):
-                d = JITRegionDataset(h5obj, self)
+                d = H5RegionDataset(h5obj, self)
             elif isinstance(elem1, Reference):
-                d = JITReferenceDataset(h5obj, self)
+                d = H5ReferenceDataset(h5obj, self)
             kwargs["data"] = d
         else:
             kwargs["data"] = h5obj
@@ -738,32 +739,32 @@ class HDF5IO(FORMIO):
         return ret
 
 
-class JITReferenceDataset(JITDataset):
+class H5ReferenceDataset(FORMDataset):
 
     @docval({'name': 'dataset', 'type': Dataset, 'doc': 'the HDF5 file lazily evaluate'},
             {'name': 'io', 'type': FORMIO, 'doc': 'the IO object that was used to read the underlying dataset'})
     def __init__(self, **kwargs):
         self.__io = popargs('io', kwargs)
-        call_docval_func(super(JITReferenceDataset, self).__init__, kwargs)
+        call_docval_func(super(H5ReferenceDataset, self).__init__, kwargs)
 
     @property
     def io(self):
         return self.__io
 
     def __getitem__(self, arg):
-        ref = super(JITReferenceDataset, self).__getitem__(arg)
+        ref = super(H5ReferenceDataset, self).__getitem__(arg)
         return self.__io.get_container(self.dataset.file[ref])
 
 
-class JITRegionDataset(JITReferenceDataset):
+class H5RegionDataset(H5ReferenceDataset):
 
     @docval({'name': 'dataset', 'type': Dataset, 'doc': 'the HDF5 file lazily evaluate'},
             {'name': 'io', 'type': FORMIO, 'doc': 'the IO object that was used to read the underlying dataset'})
     def __init__(self, **kwargs):
-        call_docval_func(super(JITRegionDataset, self).__init__, kwargs)
+        call_docval_func(super(H5RegionDataset, self).__init__, kwargs)
 
     def __getitem__(self, arg):
-        obj = super(JITRegionDataset, self).__getitem__(arg)
+        obj = super(H5RegionDataset, self).__getitem__(arg)
         ref = self.dataset[arg]
         return obj[ref]
 

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -238,12 +238,10 @@ class HDF5IO(FORMIO):
 
             # print scalar, isinstance(scalar, bytes)
             if isinstance(scalar, RegionReference):
-                cls = RegionBuilder
                 target = h5obj.file[scalar]
                 target_builder = self.__read_dataset(target)
                 self.__set_built(target.file.filename, target.name, target_builder)
-                kwargs['builder'] = target_builder
-                kwargs['region'] = scalar
+                kwargs['data'] = RegionBuilder(scalar, target_builder)
                 kwargs.pop('dtype')
                 kwargs.pop('maxshape')
             else:

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -235,7 +235,6 @@ class HDF5IO(FORMIO):
             "dtype": h5obj.dtype,
             "maxshape": h5obj.maxshape
         }
-
         for key, val in kwargs['attributes'].items():
             if isinstance(val, bytes):
                 kwargs['attributes'][key] = val.decode('UTF-8')
@@ -262,7 +261,7 @@ class HDF5IO(FORMIO):
         elif ndims == 1 and h5obj.dtype == np.dtype('O'):    # read list of strings
             elem1 = h5obj[0]
             d = None
-            if isinstance(elem1, str):
+            if isinstance(elem1, text_type):
                 d = JITDataset(h5obj)
             elif isinstance(elem1, RegionReference):
                 d = JITRegionDataset(h5obj, self)

--- a/src/pynwb/form/build/__init__.py
+++ b/src/pynwb/form/build/__init__.py
@@ -2,6 +2,7 @@
 from .builders import Builder
 from .builders import GroupBuilder
 from .builders import DatasetBuilder
+from .builders import ReferenceBuilder
 from .builders import RegionBuilder
 from .builders import LinkBuilder
 

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -457,24 +457,13 @@ class LinkBuilder(Builder):
         return self['builder']
 
 
-class RegionBuilder(DatasetBuilder):
+class RegionBuilder(dict):
 
-    @docval({'name': 'name', 'type': str, 'doc': 'the name of the dataset'},
-            {'name': 'region', 'type': (slice, tuple, list, RegionReference),
+    @docval({'name': 'region', 'type': (slice, tuple, list, RegionReference),
              'doc': 'the region i.e. slice or indices into the target Dataset'},
-            {'name': 'builder', 'type': DatasetBuilder, 'doc': 'the Dataset this region applies to'},
-            {'name': 'attributes', 'type': dict,
-             'doc': 'a dictionary of attributes to create in this dataset', 'default': dict()},
-            {'name': 'parent', 'type': GroupBuilder, 'doc': 'the parent builder of this Builder', 'default': None},
-            {'name': 'source', 'type': str, 'doc': 'the source of the data in this builder', 'default': None})
+            {'name': 'builder', 'type': DatasetBuilder, 'doc': 'the Dataset this region applies to'})
     def __init__(self, **kwargs):
         region, builder = getargs('region', 'builder', kwargs)
-        skwargs = {'data': builder}
-        for key in ('name', 'parent', 'source'):
-            skwargs[key] = kwargs[key]
-        skwargs['attributes'] = getargs('attributes', kwargs)
-        skwargs['dtype'] = self.REGION_REF_TYPE
-        call_docval_func(super(RegionBuilder, self).__init__, skwargs)
         self['region'] = region
 
     @property

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -7,7 +7,7 @@ from abc import ABCMeta
 import warnings
 from collections import Iterable
 
-from ..utils import docval, getargs, call_docval_func, fmt_docval_args
+from ..utils import docval, getargs, popargs, call_docval_func, fmt_docval_args
 from six import with_metaclass
 
 
@@ -378,7 +378,7 @@ class DatasetBuilder(BaseBuilder):
     REGION_REF_TYPE = 'region'
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of the dataset'},
-            {'name': 'data', 'type': ('array_data', 'scalar_data', 'data', 'DatasetBuilder', Iterable),
+            {'name': 'data', 'type': ('array_data', 'scalar_data', 'data', 'DatasetBuilder', 'RegionBuilder', Iterable),
              'doc': 'the data in this dataset', 'default': None},
             {'name': 'dtype', 'type': (type, np.dtype, str, list),
              'doc': 'the datatype of this dataset', 'default': None},
@@ -457,13 +457,27 @@ class LinkBuilder(Builder):
         return self['builder']
 
 
-class RegionBuilder(dict):
+class ReferenceBuilder(dict):
+
+    @docval({'name': 'builder', 'type': (DatasetBuilder, GroupBuilder), 'doc': 'the Dataset this region applies to'})
+    def __init__(self, **kwargs):
+        builder = getargs('builder', kwargs)
+        self['builder'] = builder
+
+    @property
+    def builder(self):
+        ''' The target builder object '''
+        return self['builder']
+
+
+class RegionBuilder(ReferenceBuilder):
 
     @docval({'name': 'region', 'type': (slice, tuple, list, RegionReference),
              'doc': 'the region i.e. slice or indices into the target Dataset'},
             {'name': 'builder', 'type': DatasetBuilder, 'doc': 'the Dataset this region applies to'})
     def __init__(self, **kwargs):
-        region, builder = getargs('region', 'builder', kwargs)
+        region = popargs('region', kwargs)
+        call_docval_func(super(RegionBuilder, self).__init__, kwargs)
         self['region'] = region
 
     @property

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -446,7 +446,8 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                 if not isinstance(container, DataRegion):
                     msg = "'container' must be of type DataRegion if spec represents region reference"
                     raise ValueError(msg)
-                builder = RegionBuilder(name, container.region, manager.build(container.data))
+                builder = DatasetBuilder(name, RegionBuilder(container.region, manager.build(container.data)),
+                                         parent=parent, source=source)
             else:
                 builder = DatasetBuilder(name, data=container.data, parent=parent,
                                          dtype=self.convert_dtype(self.__spec.dtype), source=source)

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -4,6 +4,7 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from six import with_metaclass
 from .utils import docval, getargs, popargs, docval_macro
 from operator import itemgetter
+from .container import Data
 
 
 def __get_shape_helper(data):
@@ -494,7 +495,7 @@ class RegionSlicer(with_metaclass(ABCMeta, object)):
 
 class ListSlicer(RegionSlicer):
 
-    @docval({'name': 'dataset', 'type': (list, tuple), 'doc': 'the HDF5 dataset to slice'},
+    @docval({'name': 'dataset', 'type': (list, tuple, Data), 'doc': 'the HDF5 dataset to slice'},
             {'name': 'region', 'type': (list, tuple, slice), 'doc': 'the region reference to use to slice'})
     def __init__(self, **kwargs):
         self.__dataset, self.__region = getargs('dataset', 'region', kwargs)
@@ -517,7 +518,7 @@ class ListSlicer(RegionSlicer):
         if isinstance(idx, (list, tuple)):
             getter = itemgetter(*idx)
         else:
-            return itemgetter(idx)
+            getter = itemgetter(idx)
         return getter(self._read)
 
     def __len__(self):
@@ -533,7 +534,7 @@ import h5py  # noqa: E402
         is_method=False)
 def get_region_slicer(**kwargs):
     dataset, region = getargs('dataset', 'region', kwargs)
-    if isinstance(dataset, (list, tuple)):
+    if isinstance(dataset, (list, tuple, Data)):
         return ListSlicer(dataset, region)
     elif isinstance(dataset, h5py.Dataset):
         return H5RegionSlicer(dataset, region)

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -463,25 +463,6 @@ class DataIO(with_metaclass(ABCMeta, object)):
         return self.__data
 
 
-@docval_macro('data')
-class JITDataset(object):
-
-    @docval({'name': 'dataset', 'type': 'array_data', 'doc': 'the HDF5 file lazily evaluate'})
-    def __init__(self, **kwargs):
-        super(JITDataset, self).__init__()
-        self.__dataset = getargs('dataset', kwargs)
-
-    @property
-    def dataset(self):
-        return self.__dataset
-
-    def __getitem__(self, arg):
-        return self.__dataset[arg]
-
-    def __len__(self):
-        return len(self.__dataset)
-
-
 class RegionSlicer(with_metaclass(ABCMeta, object)):
     '''
     A abstract base class to control getting using a region

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -463,6 +463,25 @@ class DataIO(with_metaclass(ABCMeta, object)):
         return self.__data
 
 
+@docval_macro('data')
+class JITDataset(object):
+
+    @docval({'name': 'dataset', 'type': 'array_data', 'doc': 'the HDF5 file lazily evaluate'})
+    def __init__(self, **kwargs):
+        super(JITDataset, self).__init__()
+        self.__dataset = getargs('dataset', kwargs)
+
+    @property
+    def dataset(self):
+        return self.__dataset
+
+    def __getitem__(self, arg):
+        return self.__dataset[arg]
+
+    def __len__(self):
+        return len(self.__dataset)
+
+
 class RegionSlicer(with_metaclass(ABCMeta, object)):
     '''
     A abstract base class to control getting using a region

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -469,6 +469,20 @@ class RegionSlicer(with_metaclass(ABCMeta, object)):
     Subclasses must implement `__getitem__` and `__len__`
     '''
 
+    @docval({'name': 'target', 'type': None, 'doc': 'the target to slice'},
+            {'name': 'slice', 'type': None, 'doc': 'the region to slice'})
+    def __init__(self, **kwargs):
+        self.__target = getargs('target', kwargs)
+        self.__slice = getargs('slice', kwargs)
+
+    @property
+    def target(self):
+        return self.__target
+
+    @property
+    def slice(self):
+        return self.__slice
+
     @abstractproperty
     def __getitem__(self, idx):
         pass
@@ -484,9 +498,10 @@ class ListSlicer(RegionSlicer):
             {'name': 'region', 'type': (list, tuple, slice), 'doc': 'the region reference to use to slice'})
     def __init__(self, **kwargs):
         self.__dataset, self.__region = getargs('dataset', 'region', kwargs)
+        super(ListSlicer, self).__init__(self.__dataset, self.__region)
         if isinstance(self.__region, slice):
             self.__getter = itemgetter(self.__region)
-            self.__len = slice_len(self.__region)  # noqa: F821
+            self.__len = len(range(*self.__region.indices(len(self.__dataset))))
         else:
             self.__getter = itemgetter(*self.__region)
             self.__len = len(self.__region)

--- a/src/pynwb/form/query.py
+++ b/src/pynwb/form/query.py
@@ -1,0 +1,103 @@
+from six import with_metaclass
+from .core import ExtenderMeta
+
+class Query(with_metaclass(ExtenderMeta, object)):
+
+    __operations__ = (
+        '__lt__',
+        '__gt__',
+        '__le__',
+        '__ge__',
+        '__eq__',
+        '__ne__',
+    )
+
+    @classmethod
+    def __build_operation(cls, op):
+        def __func(self, arg):
+            return cls(self, op, arg)
+
+    @ExtenderMeta.pre_init
+    def __make_operators(cls, name, bases, classdict):
+        if not isinstance(cls.__operations__, tuple):
+            raise TypeError("'__operations__' must be of type tuple")
+        # add any new operations
+        if len(bases) and 'Query' in globals() and issubclass(bases[-1], NWBContainer) \
+           and bases[-1].__operations__ is not cls.__operations__:
+                new_operations = list(cls.__operations__)
+                new_operations[0:0] = bases[-1].__operations__
+                cls.__operations__ = tuple(new_operations)
+        for op in cls.__operations__:
+            if not hasattr(cls, op):
+                setattr(cls, op, cls.__build_operation(op))
+
+    def __init__(self, obj, op, arg):
+        self.obj = obj
+        self.op = op
+        self.arg = arg
+        self.result = None
+
+    def evaluate(self):
+        if self.result is None:
+            obj = self.obj
+            if isinstance(obj, Query):
+                obj = obj.evaluate()
+            elif isinstance(obj, AbstractDataset):
+                obj = obj.get_array()
+            self.result = getattr(obj, self.op)(self.arg)
+        return self.result
+
+    def __and__(self, other):
+        pass
+
+    def __or__(self, other):
+        pass
+
+    def __xor__(self, other):
+        pass
+
+    def __contains__(self, other)
+        pass
+
+
+class AbstractDataset(with_metaclass(ABCMeta, object)):
+
+    __operations__ = (
+        '__lt__',
+        '__gt__',
+        '__le__',
+        '__ge__',
+        '__eq__',
+        '__ne__',
+    )
+
+    @classmethod
+    def __build_operation(cls, op):
+        def __func(self, arg):
+            return Query(self, op, arg)
+
+    @ExtenderMeta.pre_init
+    def __make_operators(cls, name, bases, classdict):
+        if not isinstance(cls.__operations__, tuple):
+            raise TypeError("'__operations__' must be of type tuple")
+        # add any new operations
+        if len(bases) and 'Query' in globals() and issubclass(bases[-1], NWBContainer) \
+           and bases[-1].__operations__ is not cls.__operations__:
+                new_operations = list(cls.__operations__)
+                new_operations[0:0] = bases[-1].__operations__
+                cls.__operations__ = tuple(new_operations)
+        for op in cls.__operations__:
+            if not hasattr(cls, op):
+                setattr(cls, op, cls.__build_operation(op))
+
+    @abstractmethod
+    def get_array(self):
+        pass
+
+class H5Dataset(AbstractDataset):
+
+    def get_array(self):
+        if not self.cache:
+            self.cache = self.data[:]
+        return self.cache
+

--- a/src/pynwb/form/query.py
+++ b/src/pynwb/form/query.py
@@ -1,7 +1,5 @@
 from six import with_metaclass
-from abc import abstractmethod
 import numpy as np
-import math
 
 from .utils import ExtenderMeta, docval_macro
 
@@ -45,10 +43,13 @@ class Query(with_metaclass(ExtenderMeta, object)):
     def evaluate(self):
         if self.result is None:
             obj = self.obj
+            arg = self.arg
             if isinstance(obj, Query):
                 obj = obj.evaluate()
             elif isinstance(obj, FORMDataset):
-                obj = obj.get_array()
+                obj = obj.get_dataset()
+            if isinstance(arg, Query):
+                arg = self.arg.evaluate()
             self.result = getattr(obj, self.op)(self.arg)
         return self.result
 
@@ -108,174 +109,10 @@ class FORMDataset(with_metaclass(ExtenderMeta, object)):
 
     def __getitem__(self, key):
         idx = self.__evaluate_key(key)
-        return self.get_array()[idx]
+        return self.get_dataset()[idx]
 
     def __init__(self, h5_dataset):
         self.data = h5_dataset
 
-    def get_array(self):
+    def get_dataset(self):
         return self.data
-
-
-class AbstractSortedDataset(object):
-
-    @abstractmethod
-    def find_point(self, val):
-        pass
-
-    def __lower(self, other):
-        ins = self.find_point(other)
-        return ins
-
-    def __upper(self, other):
-        ins = self.__lower(other)
-        while self[ins] == other:
-            ins += 1
-        return ins
-
-    def __lt__(self, other):
-        ins = self.__lower(other)
-        return slice(0, ins)
-
-    def __le__(self, other):
-        ins = self.__upper(other)
-        return slice(0, ins)
-
-    def __gt__(self, other):
-        ins = self.__upper(other)
-        return slice(ins, len(self))
-
-    def __ge__(self, other):
-        ins = self.__lower(other)
-        return slice(ins, len(self))
-
-    @staticmethod
-    def __sort(self, a):
-        if isinstance(a, tuple):
-            return a[0]
-        else:
-            return a
-
-    def __eq__(self, other):
-        if isinstance(other, list):
-            ret = list()
-            for i in other:
-                eq = self == i
-                ret.append(eq)
-            # TODO: sort this and collapse
-            ret = sorted(ret, key=self.__sort)
-            tmp = list()
-            for i in range(1, len(ret)):
-                a, b = ret[i-1], ret[i]
-                if isinstance(a, tuple):
-                    if isinstance(b, tuple):
-                        if a[1] >= b[0]:
-                            b[0] = a[0]
-                        else:
-                            tmp.append(slice(*a))
-                    else:
-                        if b > a[1]:
-                            tmp.append(slice(*a))
-                        elif b == a[1]:
-                            a[1] == b+1
-                        else:
-                            ret[i] = a
-                else:
-                    if isinstance(b, tuple):
-                        if a < b[0]:
-                            tmp.append(a)
-                    else:
-                        if b - a == 1:
-                            ret[i] = (a, b)
-                        else:
-                            tmp.append(a)
-            if isinstance(ret[-1], tuple):
-                tmp.append(slice(*ret[-1]))
-            else:
-                tmp.append(ret[-1])
-            ret = tmp
-            return ret
-        elif isinstance(other, tuple):
-            ge = self >= other
-            ge = ge[0]
-            lt = self < other
-            lt = lt[1]
-            if ge == lt:
-                return ge
-            else:
-                return (ge, lt)
-        else:
-            lower = self.__lower(other)
-            upper = self.__upper(other)
-            d = upper - lower
-            if d == 1:
-                return lower
-            elif d == 0:
-                return None
-            else:
-                return (lower, upper)
-
-    def __ne__(self, other):
-        eq = self == other
-        if isinstance(eq, tuple):
-            return [slice(0, eq[0]), slice(eq[1], len(self))]
-        else:
-            return [slice(0, eq), slice(eq+1, len(self))]
-
-
-class SortedDataset(AbstractSortedDataset):
-
-    def __init__(self, array):
-        self.array = array
-
-    def get_array(self):
-        return self.array
-
-    def find_point(self, val):
-        return np.searchsorted(self.get_array(), val)
-
-    def __getitem__(self, arg):
-        return self.array.__getitem__(arg)
-
-    def __len__(self):
-        return len(self.array)
-
-
-class LinSpace(SortedDataset):
-
-    def __init__(self, start, stop, step):
-        self.start = start
-        self.stop = stop
-        self.step = step
-        self.__len = int((stop - start)/step)
-
-    def __len__(self):
-        return self.__len
-
-    def find_point(self, val):
-        nsteps = (val-self.start)/self.step
-        fl = math.floor(nsteps)
-        if fl == nsteps:
-            return int(fl)
-        else:
-            return int(fl+1)
-
-    def __calcidx(self, arg):
-        return self.start + self.step*arg
-
-    def __gendata(self, arg):
-        for i in arg:
-            if isinstance(i, slice):
-                for j in map(self.__calcidx, range(i.start, i.stop, 1)):
-                    yield j
-            elif isinstance(i, int):
-                yield self.__calcidx(i)
-
-    def __getitem__(self, arg):
-        if isinstance(arg, int):
-            return self.__calcidx(arg)
-        else:
-            tmp = arg
-            if isinstance(tmp, slice):
-                tmp = [tmp]
-            return list(self.__gendata(tmp))

--- a/src/pynwb/form/query.py
+++ b/src/pynwb/form/query.py
@@ -1,6 +1,7 @@
 from six import with_metaclass
 from abc import abstractmethod
 import numpy as np
+import math
 
 from .utils import ExtenderMeta, docval_macro
 
@@ -46,7 +47,7 @@ class Query(with_metaclass(ExtenderMeta, object)):
             obj = self.obj
             if isinstance(obj, Query):
                 obj = obj.evaluate()
-            elif isinstance(obj, AbstractDataset):
+            elif isinstance(obj, FORMDataset):
                 obj = obj.get_array()
             self.result = getattr(obj, self.op)(self.arg)
         return self.result
@@ -65,7 +66,7 @@ class Query(with_metaclass(ExtenderMeta, object)):
 
 
 @docval_macro('data')
-class AbstractDataset(with_metaclass(ExtenderMeta, object)):
+class FORMDataset(with_metaclass(ExtenderMeta, object)):
 
     __operations__ = (
         '__lt__',
@@ -97,10 +98,6 @@ class AbstractDataset(with_metaclass(ExtenderMeta, object)):
         for op in cls.__operations__:
             setattr(cls, op, cls.__build_operation(op))
 
-    @abstractmethod
-    def get_array(self):
-        pass
-
     def __evaluate_key(self, key):
         if isinstance(key, (tuple, list, np.ndarray)):
             return tuple(map(self.__evaluate_key, key))
@@ -113,23 +110,18 @@ class AbstractDataset(with_metaclass(ExtenderMeta, object)):
         idx = self.__evaluate_key(key)
         return self.get_array()[idx]
 
-
-class H5Dataset(AbstractDataset):
-
     def __init__(self, h5_dataset):
         self.data = h5_dataset
-        self.cache = None
 
     def get_array(self):
-        if self.cache is None:
-            self.cache = self.data[:]
-        return self.cache
+        return self.data
 
-class AbstractSortedDataset(AbstractDataset):
+
+class AbstractSortedDataset(object):
 
     @abstractmethod
     def find_point(self, val):
-        ...
+        pass
 
     def __lower(self, other):
         ins = self.find_point(other)
@@ -137,57 +129,153 @@ class AbstractSortedDataset(AbstractDataset):
 
     def __upper(self, other):
         ins = self.__lower(other)
-        while d[ins] == other:
+        while self[ins] == other:
             ins += 1
         return ins
 
     def __lt__(self, other):
         ins = self.__lower(other)
-        return (0, ins)
+        return slice(0, ins)
 
     def __le__(self, other):
         ins = self.__upper(other)
-        return (0, ins)
+        return slice(0, ins)
 
     def __gt__(self, other):
         ins = self.__upper(other)
-        return (ins, len(self))
+        return slice(ins, len(self))
 
     def __ge__(self, other):
         ins = self.__lower(other)
-        return (ins, len(self))
+        return slice(ins, len(self))
+
+    @staticmethod
+    def __sort(self, a):
+        if isinstance(a, tuple):
+            return a[0]
+        else:
+            return a
+
+    def __eq__(self, other):
+        if isinstance(other, list):
+            ret = list()
+            for i in other:
+                eq = self == i
+                ret.append(eq)
+            # TODO: sort this and collapse
+            ret = sorted(ret, key=self.__sort)
+            tmp = list()
+            for i in range(1, len(ret)):
+                a, b = ret[i-1], ret[i]
+                if isinstance(a, tuple):
+                    if isinstance(b, tuple):
+                        if a[1] >= b[0]:
+                            b[0] = a[0]
+                        else:
+                            tmp.append(slice(*a))
+                    else:
+                        if b > a[1]:
+                            tmp.append(slice(*a))
+                        elif b == a[1]:
+                            a[1] == b+1
+                        else:
+                            ret[i] = a
+                else:
+                    if isinstance(b, tuple):
+                        if a < b[0]:
+                            tmp.append(a)
+                    else:
+                        if b - a == 1:
+                            ret[i] = (a, b)
+                        else:
+                            tmp.append(a)
+            if isinstance(ret[-1], tuple):
+                tmp.append(slice(*ret[-1]))
+            else:
+                tmp.append(ret[-1])
+            ret = tmp
+            return ret
+        elif isinstance(other, tuple):
+            ge = self >= other
+            ge = ge[0]
+            lt = self < other
+            lt = lt[1]
+            if ge == lt:
+                return ge
+            else:
+                return (ge, lt)
+        else:
+            lower = self.__lower(other)
+            upper = self.__upper(other)
+            d = upper - lower
+            if d == 1:
+                return lower
+            elif d == 0:
+                return None
+            else:
+                return (lower, upper)
+
+    def __ne__(self, other):
+        eq = self == other
+        if isinstance(eq, tuple):
+            return [slice(0, eq[0]), slice(eq[1], len(self))]
+        else:
+            return [slice(0, eq), slice(eq+1, len(self))]
 
 
 class SortedDataset(AbstractSortedDataset):
 
+    def __init__(self, array):
+        self.array = array
+
+    def get_array(self):
+        return self.array
+
     def find_point(self, val):
-        return np.searchsorted(self.get_array())
+        return np.searchsorted(self.get_array(), val)
+
+    def __getitem__(self, arg):
+        return self.array.__getitem__(arg)
+
+    def __len__(self):
+        return len(self.array)
 
 
-class LinSpace(AbstractSortedDataset):
+class LinSpace(SortedDataset):
+
+    def __init__(self, start, stop, step):
+        self.start = start
+        self.stop = stop
+        self.step = step
+        self.__len = int((stop - start)/step)
+
+    def __len__(self):
+        return self.__len
 
     def find_point(self, val):
         nsteps = (val-self.start)/self.step
         fl = math.floor(nsteps)
         if fl == nsteps:
-            return fl
+            return int(fl)
         else:
-            return fl+1
+            return int(fl+1)
 
     def __calcidx(self, arg):
         return self.start + self.step*arg
 
     def __gendata(self, arg):
         for i in arg:
-            if isinstance(i, tuple):
-                yield from range(*i)
+            if isinstance(i, slice):
+                for j in map(self.__calcidx, range(i.start, i.stop, 1)):
+                    yield j
             elif isinstance(i, int):
                 yield self.__calcidx(i)
 
     def __getitem__(self, arg):
         if isinstance(arg, int):
             return self.__calcidx(arg)
-        elif isinstance(arg, list):
-            return np.fromiter(self.__gendata(arg), self.dtype)
-
-
+        else:
+            tmp = arg
+            if isinstance(tmp, slice):
+                tmp = [tmp]
+            return list(self.__gendata(tmp))

--- a/src/pynwb/form/query.py
+++ b/src/pynwb/form/query.py
@@ -69,25 +69,24 @@ class Query(with_metaclass(ExtenderMeta, object)):
             ret = list()
             for idx in result:
                 if isinstance(idx, slice) and (idx.step is None or idx.step == 1):
-                    ret.append((idx.start, idx,stop))
+                    ret.append((idx.start, idx.stop))
                 else:
                     ret.append(idx)
             return ret
         else:
             return result
 
-
     def __and__(self, other):
-        pass
+        return NotImplemented
 
     def __or__(self, other):
-        pass
+        return NotImplemented
 
     def __xor__(self, other):
-        pass
+        return NotImplemented
 
     def __contains__(self, other):
-        pass
+        return NotImplemented
 
 
 @docval_macro('data')

--- a/src/pynwb/form/validate/validator.py
+++ b/src/pynwb/form/validate/validator.py
@@ -65,9 +65,6 @@ class Validator(with_metaclass(ABCMeta, object)):
         stack = list()
         tmp = spec
         while tmp is not None:
-            if isinstance(tmp, str):
-                import pdb
-                pdb.set_trace()
             name = tmp.name
             if name is None:
                 name = tmp.data_type_def

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -20,10 +20,10 @@ class NWBTableRegionMap(NWBDataMap):
 
     @ObjectMapper.constructor_arg('table')
     def carg_table(self, builder, manager):
-        return manager.construct(builder.data)
+        return manager.construct(builder.data.builder)
 
     @ObjectMapper.constructor_arg('region')
     def carg_region(self, builder, manager):
-        if not isinstance(builder, RegionBuilder):
+        if not isinstance(builder.data, RegionBuilder):
             raise ValueError("'builder' must be a RegionBuilder")
-        return builder.region
+        return builder.data.region

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -231,8 +231,7 @@ class UnitTimes(NWBDataInterface):
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'})
     def get_unit_spike_times(self, **kwargs):
         index = getargs('index', kwargs)
-        idx = self.spike_times_index[index]
-        return self.spike_times[idx]
+        return self.spike_times_index[index][:]
 
     @docval({'name': 'unit_id', 'type': int, 'doc': 'the unit to add spike times for'},
             {'name': 'spike_times', 'type': ('array_data',), 'doc': 'the spike times for the unit'})

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -1,11 +1,12 @@
 import numpy as np
 from collections import Iterable
 
+from .form import get_region_slicer
 from .form.utils import docval, getargs, popargs, call_docval_func
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_conversion, _default_resolution
-from .core import NWBContainer, MultiContainerInterface
+from .core import NWBContainer, NWBDataInterface, MultiContainerInterface
 
 
 @register_class('AnnotationSeries', CORE_NAMESPACE)
@@ -203,7 +204,9 @@ class UnitTimes(NWBDataInterface):
         )
 
 
-    @docval({'name': 'unit_ids', 'type': ('array_data', 'data'),
+    @docval({'name': 'source', 'type': str,
+             'doc': 'Name, path or description of where unit times originated.'},
+            {'name': 'unit_ids', 'type': ('array_data', 'data'),
              'doc': 'the identifiers for the units stored in this interface', 'default': list()},
             {'name': 'spike_times', 'type': ('array_data', 'data'),
              'doc': 'a concatenated list of spike times for the units stored in this interface',
@@ -211,11 +214,9 @@ class UnitTimes(NWBDataInterface):
             {'name': 'spike_times_idx', 'type': ('array_data', 'data'),
              'doc': 'the indices in spike_times that correspond to each unit in unit_ids',
              'default': list()},
-            {'name': 'source', 'type': str,
-             'doc': 'Name, path or description of where unit times originated.'},
             {'name': 'name', 'type': str, 'doc': 'Name of this UnitTimes interface', 'default': 'UnitTimes'})
     def __init__(self, **kwargs):
-        unit_ids, spike_times, spike_times_idx = popargs('spike_times', 'spike_times', 'spike_times_idx', kwargs)
+        unit_ids, spike_times, spike_times_idx = popargs('unit_ids', 'spike_times', 'spike_times_idx', kwargs)
         call_docval_func(super(UnitTimes, self).__init__, kwargs)
         self.unit_ids = unit_ids
         self.spike_times = spike_times
@@ -231,9 +232,9 @@ class UnitTimes(NWBDataInterface):
 
     @docval({'name': 'unit_id', 'type': int, 'doc': 'the unit to add spike times for'},
             {'name': 'spike_times', 'type': ('array_data',), 'doc': 'the spike times for the unit'})
-    def add_spike_times(self, **kwarg):
+    def add_spike_times(self, **kwargs):
         unit_id, spike_times = getargs('unit_id', 'spike_times', kwargs)
         self.unit_ids.append(unit_id)
         l = len(self.spike_times)
         self.spike_times_idx.append(get_region_slicer(self.spike_times, slice(l, l+len(spike_times))))
-        self.spike_times.append(spike_times)
+        self.spike_times.extend(spike_times)

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -88,8 +88,13 @@ class TestMapNWBContainer(unittest.TestCase):
                             self.assertContainerEqual(f1[k], f2[k])
                 elif isinstance(f1, NWBContainer):
                     self.assertContainerEqual(f1, f2)
-                elif isinstance(f1, NWBData):
-                    self.assertDataEqual(f1, f2)
+                elif isinstance(f1, NWBData) or isinstance(f2, NWBData):
+                    if isinstance(f1, NWBData) and isinstance(f2, NWBData):
+                        self.assertDataEqual(f1, f2)
+                    elif isinstance(f1, NWBData):
+                        self.assertTrue(np.array_equal(f1.data, f2))
+                    elif isinstance(f2, NWBData):
+                        self.assertTrue(np.array_equal(f1.data, f2))
                 else:
                     self.assertEqual(f1, f2)
 

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -116,10 +116,10 @@ class TestMapRoundTrip(TestMapNWBContainer):
         self.io = None
 
     def tearDown(self):
-        if os.path.exists(self.filename):
-            os.remove(self.filename)
         if self.io is not None:
             self.io.close()
+        if os.path.exists(self.filename):
+            os.remove(self.filename)
 
     def roundtripContainer(self):
         description = 'a file to test writing and reading a %s' % self.container_type

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -1,5 +1,7 @@
 import unittest2 as unittest
 
+import numpy as np
+
 from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder
 
 from pynwb.ecephys import *  # noqa: F403
@@ -40,6 +42,13 @@ class TestUnitTimesIO(base.TestDataInterfaceIO):
                             datasets={'unit_ids': ids_builder,
                                       'spike_times': st_builder,
                                       'spike_times_index': sti_builder})
+
+    def test_get_spike_times(self):
+        ut = self.roundtripContainer()
+        received = ut.get_unit_spike_times(0)
+        self.assertTrue(np.array_equal(received, [0, 1, 2]))
+        received = ut.get_unit_spike_times(1)
+        self.assertTrue(np.array_equal(received, [3, 4, 5]))
 
 
 class TestElectrodeGroupIO(base.TestMapRoundTrip):

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -3,7 +3,7 @@ import unittest2 as unittest
 from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder
 
 from pynwb.ecephys import *  # noqa: F403
-from pynwb.misc import UnitTimes, SpikeUnit
+from pynwb.misc import UnitTimes
 
 from . import base
 
@@ -11,33 +11,35 @@ from . import base
 class TestUnitTimesIO(base.TestDataInterfaceIO):
 
     def setUpContainer(self):
-        self.spike_unit1 = SpikeUnit('unit1', [0, 1, 2], 'spike unit1 description', 'spike units source')
-        self.spike_unit2 = SpikeUnit('unit2', [3, 4, 5], 'spike unit2 description', 'spike units source')
-        return UnitTimes('unit times source', [self.spike_unit1, self.spike_unit2], name='UnitTimesTest')
+        # self.spike_unit1 = SpikeUnit('unit1', [0, 1, 2], 'spike unit1 description', 'spike units source')
+        # self.spike_unit2 = SpikeUnit('unit2', [3, 4, 5], 'spike unit2 description', 'spike units source')
+        ut = UnitTimes('UnitTimes integration test', name='UnitTimesTest')
+        ut.add_spike_times(0, [0, 1, 2])
+        ut.add_spike_times(1, [3, 4, 5])
+        return ut
+
 
     def setUpBuilder(self):
-        su1_builder = GroupBuilder('unit1',
-                                   datasets={'times': DatasetBuilder('times', [0, 1, 2])},
-                                   attributes={'neurodata_type': 'SpikeUnit',
-                                               'namespace': 'core',
-                                               'unit_description': 'spike unit1 description',
-                                               'help': 'Times for a particular UnitTime object',
-                                               'source': 'spike units source'})
-
-        su2_builder = GroupBuilder('unit2',
-                                   datasets={'times': DatasetBuilder('times', [3, 4, 5])},
-                                   attributes={'neurodata_type': 'SpikeUnit',
-                                               'namespace': 'core',
-                                               'unit_description': 'spike unit2 description',
-                                               'help': 'Times for a particular UnitTime object',
-                                               'source': 'spike units source'})
-
+        ids_builder = DatasetBuilder('unit_ids', [0, 1],
+                                     attributes={'neurodata_type': 'ElementIdentifiers',
+                                                 'namespace': 'core',
+                                                 'help': 'unique identifiers for a list of elements'})
+        st_builder = DatasetBuilder('spike_times', [0, 1, 2, 3, 4, 5],
+                                    attributes={'neurodata_type': 'VectorData',
+                                                'namespace': 'core',
+                                                'help': 'Values for a list of elements'})
+        sti_builder = DatasetBuilder('spike_times_index', [RegionBuilder(slice(0,3), st_builder), RegionBuilder(slice(3,6), st_builder)],
+                                     attributes={'neurodata_type': 'VectorIndex',
+                                                 'namespace': 'core',
+                                                 'help': 'indexes into a list of values for a list of elements'})
         return GroupBuilder('UnitTimesTest',
                             attributes={'neurodata_type': 'UnitTimes',
                                         'namespace': 'core',
                                         'help': 'Estimated spike times from a single unit',
                                         'source': 'unit times source'},
-                            groups={'unit1': su1_builder, 'unit2': su2_builder})
+                            datasets={'unit_ids': ids_builder,
+                                      'spike_times': st_builder,
+                                      'spike_times_index': sti_builder})
 
 
 class TestElectrodeGroupIO(base.TestMapRoundTrip):

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -18,7 +18,6 @@ class TestUnitTimesIO(base.TestDataInterfaceIO):
         ut.add_spike_times(1, [3, 4, 5])
         return ut
 
-
     def setUpBuilder(self):
         ids_builder = DatasetBuilder('unit_ids', [0, 1],
                                      attributes={'neurodata_type': 'ElementIdentifiers',
@@ -28,7 +27,8 @@ class TestUnitTimesIO(base.TestDataInterfaceIO):
                                     attributes={'neurodata_type': 'VectorData',
                                                 'namespace': 'core',
                                                 'help': 'Values for a list of elements'})
-        sti_builder = DatasetBuilder('spike_times_index', [RegionBuilder(slice(0,3), st_builder), RegionBuilder(slice(3,6), st_builder)],
+        sti_builder = DatasetBuilder('spike_times_index',
+                                     [RegionBuilder(slice(0, 3), st_builder), RegionBuilder(slice(3, 6), st_builder)],
                                      attributes={'neurodata_type': 'VectorIndex',
                                                  'namespace': 'core',
                                                  'help': 'indexes into a list of values for a list of elements'})
@@ -36,7 +36,7 @@ class TestUnitTimesIO(base.TestDataInterfaceIO):
                             attributes={'neurodata_type': 'UnitTimes',
                                         'namespace': 'core',
                                         'help': 'Estimated spike times from a single unit',
-                                        'source': 'unit times source'},
+                                        'source': 'UnitTimes integration test'},
                             datasets={'unit_ids': ids_builder,
                                       'spike_times': st_builder,
                                       'spike_times_index': sti_builder})
@@ -123,8 +123,7 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
                                       'timestamps': DatasetBuilder('timestamps',
                                                                    timestamps,
                                                                    attributes={'unit': 'Seconds', 'interval': 1}),
-                                      'electrodes': RegionBuilder('electrodes', [0, 2],
-                                                                  table_builder,
+                                      'electrodes': DatasetBuilder('electrodes', RegionBuilder([0, 2], table_builder),
                                                                   attributes={
                                                                       'neurodata_type': 'ElectrodeTableRegion',
                                                                       'namespace': 'core',
@@ -171,9 +170,8 @@ class TestMultiElectricalSeries(TestElectricalSeriesIO):
                                       'timestamps': DatasetBuilder('timestamps',
                                                                    timestamps,
                                                                    attributes={'unit': 'Seconds', 'interval': 1}),
-                                      'electrodes': RegionBuilder('electrodes', [0, 2],
-                                                                  table_builder,
-                                                                  attributes={
+                                      'electrodes': DatasetBuilder('electrodes', RegionBuilder([0, 2], table_builder),
+                                                                   attributes={
                                                                       'neurodata_type': 'ElectrodeTableRegion',
                                                                       'namespace': 'core',
                                                                       'description': 'the first and third electrodes',
@@ -194,9 +192,8 @@ class TestMultiElectricalSeries(TestElectricalSeriesIO):
                                       'timestamps': DatasetBuilder('timestamps',
                                                                    timestamps,
                                                                    attributes={'unit': 'Seconds', 'interval': 1}),
-                                      'electrodes': RegionBuilder('electrodes', [1, 3],
-                                                                  table_builder,
-                                                                  attributes={
+                                      'electrodes': DatasetBuilder('electrodes', RegionBuilder([1, 3], table_builder),
+                                                                   attributes={
                                                                       'neurodata_type': 'ElectrodeTableRegion',
                                                                       'namespace': 'core',
                                                                       'description': 'the second and fourth electrodes',

--- a/tests/unit/form_tests/test_query.py
+++ b/tests/unit/form_tests/test_query.py
@@ -29,6 +29,9 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(np.array_equal(array, self.d))
 
     def test___gt__(self):
+        '''
+        Test wrapper greater than magic method
+        '''
         q = self.wrapper > 5
         self.assertIsInstance(q, Query)
         result = q.evaluate()
@@ -37,6 +40,9 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(np.array_equal(result, expected))
 
     def test___ge__(self):
+        '''
+        Test wrapper greater than or equal magic method
+        '''
         q = self.wrapper >= 5
         self.assertIsInstance(q, Query)
         result = q.evaluate()
@@ -45,6 +51,9 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(np.array_equal(result, expected))
 
     def test___lt__(self):
+        '''
+        Test wrapper less than magic method
+        '''
         q = self.wrapper < 5
         self.assertIsInstance(q, Query)
         result = q.evaluate()
@@ -53,6 +62,9 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(np.array_equal(result, expected))
 
     def test___le__(self):
+        '''
+        Test wrapper less than or equal magic method
+        '''
         q = self.wrapper <= 5
         self.assertIsInstance(q, Query)
         result = q.evaluate()
@@ -61,6 +73,9 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(np.array_equal(result, expected))
 
     def test___eq__(self):
+        '''
+        Test wrapper equals magic method
+        '''
         q = self.wrapper == 5
         self.assertIsInstance(q, Query)
         result = q.evaluate()
@@ -69,6 +84,9 @@ class QueryTest(unittest.TestCase):
         self.assertTrue(np.array_equal(result, expected))
 
     def test___ne__(self):
+        '''
+        Test wrapper not equal magic method
+        '''
         q = self.wrapper != 5
         self.assertIsInstance(q, Query)
         result = q.evaluate()
@@ -76,7 +94,19 @@ class QueryTest(unittest.TestCase):
                     False, True, True, True, True]
         self.assertTrue(np.array_equal(result, expected))
 
+    def test___getitem__(self):
+        '''
+        Test wrapper getitem using slice
+        '''
+        q = self.wrapper < 5
+        result = self.wrapper[0:5]
+        expected = [0, 1, 2, 3, 4]
+        self.assertTrue(np.array_equal(result, expected))
+
     def test___getitem__query(self):
+        '''
+        Test wrapper getitem using query
+        '''
         q = self.wrapper < 5
         result = self.wrapper[q]
         expected = [0, 1, 2, 3, 4]

--- a/tests/unit/form_tests/test_query.py
+++ b/tests/unit/form_tests/test_query.py
@@ -4,6 +4,7 @@ from h5py import File
 import numpy as np
 
 from pynwb.form.query import *  # noqa: F403
+from pynwb.form.array import *  # noqa: F403
 
 
 class AbstractQueryTest(unittest.TestCase):
@@ -15,9 +16,9 @@ class AbstractQueryTest(unittest.TestCase):
         self.dset = self.getDataset()
         self.wrapper = FORMDataset(self.dset)  # noqa: F405
 
-    def test_get_array(self):
-        array = self.wrapper.get_array()
-        self.assertIsInstance(array, SortedDataset)  # noqa: F405
+    def test_get_dataset(self):
+        array = self.wrapper.get_dataset()
+        self.assertIsInstance(array, SortedArray)  # noqa: F405
 
     def test___gt__(self):
         '''
@@ -117,7 +118,7 @@ class SortedQueryTest(AbstractQueryTest):
         self.f = File(self.path, 'w')
         self.input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         self.d = self.f.create_dataset('dset', data=self.input)
-        return SortedDataset(self.d)  # noqa: F405
+        return SortedArray(self.d)  # noqa: F405
 
     def tearDown(self):
         self.f.close()

--- a/tests/unit/form_tests/test_query.py
+++ b/tests/unit/form_tests/test_query.py
@@ -133,35 +133,27 @@ class LinspaceQueryTest(AbstractQueryTest):
     def getDataset(self):
         return LinSpace(0, 10, 1)  # noqa: F405
 
+
 class CompoundQueryTest(unittest.TestCase):
 
     def getM(self):
-        print("M: %s" % str(np.arange(10, 20, 1)))
         return SortedArray(np.arange(10, 20, 1))
 
     def getN(self):
-        print("N: %s" % (np.arange(10.0, 20.0, 0.5)))
         return SortedArray(np.arange(10.0, 20.0, 0.5))
 
     def setUp(self):
-        print("\n\n")
         self.m = FORMDataset(self.getM())
         self.n = FORMDataset(self.getN())
 
+    @unittest.skip('not implemented')
     def test_map(self):
-        q = self.m == (12,16)            # IN operation
-        q.evaluate()      # [2,3,4,5]
-        q.evaluate(False) # RangeResult(2,6)
-        print('expanded: %s' % str(q.evaluate()))
-        print('collapsed: %s' % str(q.evaluate(False)))
-        r = self.m[q]
-        r = self.m[q.evaluate()]
-        print('expanded getitem: %s' % str(r))
-        r = self.m[q.evaluate(False)]
-        print('collapsed getitem: %s' % str(r))
-        print(r)
+        q = self.m == (12, 16)                # IN operation
+        q.evaluate()                          # [2,3,4,5]
+        q.evaluate(False)                     # RangeResult(2,6)
+        r = self.m[q]                         # noqa: F841
+        r = self.m[q.evaluate()]              # noqa: F841
+        r = self.m[q.evaluate(False)]         # noqa: F841
 
     def tearDown(self):
-        print("\n\n")
-
-
+        pass

--- a/tests/unit/form_tests/test_query.py
+++ b/tests/unit/form_tests/test_query.py
@@ -17,7 +17,7 @@ class AbstractQueryTest(unittest.TestCase):
         self.wrapper = FORMDataset(self.dset)  # noqa: F405
 
     def test_get_dataset(self):
-        array = self.wrapper.get_dataset()
+        array = self.wrapper.dataset
         self.assertIsInstance(array, SortedArray)  # noqa: F405
 
     def test___gt__(self):

--- a/tests/unit/form_tests/test_query.py
+++ b/tests/unit/form_tests/test_query.py
@@ -1,11 +1,10 @@
 import unittest
-from datetime import datetime
 import os
-from h5py import File, Dataset, Reference
+from h5py import File
 import numpy as np
-from six import text_type
 
 from pynwb.form.query import Query, H5Dataset
+
 
 class QueryTest(unittest.TestCase):
 
@@ -18,7 +17,6 @@ class QueryTest(unittest.TestCase):
         # self.f = File(self.path, 'r')
         # self.d = self.f['dset']
         self.wrapper = H5Dataset(self.d)
-
 
     def tearDown(self):
         self.f.close()
@@ -83,4 +81,3 @@ class QueryTest(unittest.TestCase):
         result = self.wrapper[q]
         expected = [0, 1, 2, 3, 4]
         self.assertTrue(np.array_equal(result, expected))
-

--- a/tests/unit/form_tests/test_query.py
+++ b/tests/unit/form_tests/test_query.py
@@ -1,0 +1,86 @@
+import unittest
+from datetime import datetime
+import os
+from h5py import File, Dataset, Reference
+import numpy as np
+from six import text_type
+
+from pynwb.form.query import Query, H5Dataset
+
+class QueryTest(unittest.TestCase):
+
+    path = 'QueryTest.h5'
+
+    def setUp(self):
+        self.f = File(self.path, 'w')
+        self.input = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        self.d = self.f.create_dataset('dset', data=self.input)
+        # self.f = File(self.path, 'r')
+        # self.d = self.f['dset']
+        self.wrapper = H5Dataset(self.d)
+
+
+    def tearDown(self):
+        self.f.close()
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def test_get_array(self):
+        array = self.wrapper.get_array()
+        self.assertIsInstance(array, np.ndarray)
+        self.assertTrue(np.array_equal(array, self.d))
+
+    def test___gt__(self):
+        q = self.wrapper > 5
+        self.assertIsInstance(q, Query)
+        result = q.evaluate()
+        expected = [False, False, False, False, False,
+                    False, True, True, True, True]
+        self.assertTrue(np.array_equal(result, expected))
+
+    def test___ge__(self):
+        q = self.wrapper >= 5
+        self.assertIsInstance(q, Query)
+        result = q.evaluate()
+        expected = [False, False, False, False, False,
+                    True, True, True, True, True]
+        self.assertTrue(np.array_equal(result, expected))
+
+    def test___lt__(self):
+        q = self.wrapper < 5
+        self.assertIsInstance(q, Query)
+        result = q.evaluate()
+        expected = [True, True, True, True, True,
+                    False, False, False, False, False]
+        self.assertTrue(np.array_equal(result, expected))
+
+    def test___le__(self):
+        q = self.wrapper <= 5
+        self.assertIsInstance(q, Query)
+        result = q.evaluate()
+        expected = [True, True, True, True, True,
+                    True, False, False, False, False]
+        self.assertTrue(np.array_equal(result, expected))
+
+    def test___eq__(self):
+        q = self.wrapper == 5
+        self.assertIsInstance(q, Query)
+        result = q.evaluate()
+        expected = [False, False, False, False, False,
+                    True, False, False, False, False]
+        self.assertTrue(np.array_equal(result, expected))
+
+    def test___ne__(self):
+        q = self.wrapper != 5
+        self.assertIsInstance(q, Query)
+        result = q.evaluate()
+        expected = [True, True, True, True, True,
+                    False, True, True, True, True]
+        self.assertTrue(np.array_equal(result, expected))
+
+    def test___getitem__query(self):
+        q = self.wrapper < 5
+        result = self.wrapper[q]
+        expected = [0, 1, 2, 3, 4]
+        self.assertTrue(np.array_equal(result, expected))
+

--- a/tests/unit/form_tests/test_query.py
+++ b/tests/unit/form_tests/test_query.py
@@ -3,8 +3,8 @@ import os
 from h5py import File
 import numpy as np
 
-from pynwb.form.query import *  # noqa: F403
-from pynwb.form.array import *  # noqa: F403
+from pynwb.form.query import FORMDataset, Query
+from pynwb.form.array import SortedArray, LinSpace
 
 
 class AbstractQueryTest(unittest.TestCase):
@@ -132,3 +132,36 @@ class LinspaceQueryTest(AbstractQueryTest):
 
     def getDataset(self):
         return LinSpace(0, 10, 1)  # noqa: F405
+
+class CompoundQueryTest(unittest.TestCase):
+
+    def getM(self):
+        print("M: %s" % str(np.arange(10, 20, 1)))
+        return SortedArray(np.arange(10, 20, 1))
+
+    def getN(self):
+        print("N: %s" % (np.arange(10.0, 20.0, 0.5)))
+        return SortedArray(np.arange(10.0, 20.0, 0.5))
+
+    def setUp(self):
+        print("\n\n")
+        self.m = FORMDataset(self.getM())
+        self.n = FORMDataset(self.getN())
+
+    def test_map(self):
+        q = self.m == (12,16)            # IN operation
+        q.evaluate()      # [2,3,4,5]
+        q.evaluate(False) # RangeResult(2,6)
+        print('expanded: %s' % str(q.evaluate()))
+        print('collapsed: %s' % str(q.evaluate(False)))
+        r = self.m[q]
+        r = self.m[q.evaluate()]
+        print('expanded getitem: %s' % str(r))
+        r = self.m[q.evaluate(False)]
+        print('collapsed getitem: %s' % str(r))
+        print(r)
+
+    def tearDown(self):
+        print("\n\n")
+
+

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -51,21 +51,22 @@ class UnitTimesConstructor(unittest.TestCase):
         ut = UnitTimes('UnitTimes constructor unit test')
         self.assertEqual(ut.source, 'UnitTimes constructor unit test')
         self.assertEqual(ut.name, 'UnitTimes')
-        self.assertEqual(ut.unit_ids, list())
-        self.assertEqual(ut.spike_times, list())
-        self.assertEqual(ut.spike_times_idx, list())
+        self.assertEqual(ut.unit_ids.data, list())
+        self.assertEqual(ut.spike_times.data, list())
+        self.assertEqual(ut.spike_times_index.data, list())
 
     def test_add_spike_times(self):
         ut = UnitTimes('UnitTimes add_spike_times unit test')
         ut.add_spike_times(0, [0, 1, 2])
         ut.add_spike_times(1, [3, 4, 5])
-        self.assertEqual(ut.unit_ids, [0, 1])
-        self.assertEqual(ut.spike_times, [0, 1, 2, 3, 4, 5])
-        self.assertEqual(len(ut.spike_times_idx), 2)
-        self.assertEqual(ut.spike_times_idx[0].target, [0, 1, 2, 3, 4, 5])
-        self.assertEqual(ut.spike_times_idx[0].slice, slice(0,3))
-        self.assertEqual(ut.spike_times_idx[1].target, [0, 1, 2, 3, 4, 5])
-        self.assertEqual(ut.spike_times_idx[1].slice, slice(3,6))
+        self.assertEqual(ut.unit_ids.data, [0, 1])
+        self.assertEqual(ut.spike_times.data, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(len(ut.spike_times_index), 2)
+        self.assertEqual(ut.spike_times_index[0].target.data, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(ut.spike_times_index[0].slice, slice(0, 3))
+        self.assertEqual(ut.spike_times_index[1].target.data, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(ut.spike_times_index[1].slice, slice(3, 6))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -65,7 +65,13 @@ class UnitTimesConstructor(unittest.TestCase):
         self.assertEqual(ut.spike_times_index[0].target.data, [0, 1, 2, 3, 4, 5])
         self.assertEqual(ut.spike_times_index[0].slice, slice(0, 3))
         self.assertEqual(ut.spike_times_index[1].target.data, [0, 1, 2, 3, 4, 5])
-        self.assertEqual(ut.spike_times_index[1].slice, slice(3, 6))
+
+    def test_get_spike_times(self):
+        ut = UnitTimes('UnitTimes add_spike_times unit test')
+        ut.add_spike_times(0, [0, 1, 2])
+        ut.add_spike_times(1, [3, 4, 5])
+        self.assertEqual(ut.get_unit_spike_times(0), [0, 1, 2])
+        self.assertEqual(ut.get_unit_spike_times(1), [3, 4, 5])
 
 
 if __name__ == '__main__':

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -1,6 +1,6 @@
 import unittest
 
-from pynwb.misc import AnnotationSeries, AbstractFeatureSeries, IntervalSeries, SpikeUnit, UnitTimes
+from pynwb.misc import AnnotationSeries, AbstractFeatureSeries, IntervalSeries, UnitTimes
 
 
 class AnnotationSeriesConstructor(unittest.TestCase):
@@ -48,23 +48,24 @@ class IntervalSeriesConstructor(unittest.TestCase):
 
 class UnitTimesConstructor(unittest.TestCase):
     def test_init(self):
-        unit_times = [1.0, 2.0]
+        ut = UnitTimes('UnitTimes constructor unit test')
+        self.assertEqual(ut.source, 'UnitTimes constructor unit test')
+        self.assertEqual(ut.name, 'UnitTimes')
+        self.assertEqual(ut.unit_ids, list())
+        self.assertEqual(ut.spike_times, list())
+        self.assertEqual(ut.spike_times_idx, list())
 
-        su1 = SpikeUnit('su1', unit_times, 'unit_description_1', 'unit_source_1')
-        self.assertEqual(su1.times, unit_times)
-        self.assertEqual(su1.unit_description, 'unit_description_1')
-        self.assertEqual(su1.source, 'unit_source_1')
-
-        su2 = SpikeUnit('su2', unit_times, 'unit_description_2', 'unit_source_2')
-        self.assertEqual(su2.times, unit_times)
-        self.assertEqual(su2.unit_description, 'unit_description_2')
-        self.assertEqual(su2.source, 'unit_source_2')
-
-        sul = {'su1': su1, 'su2': su2}
-        ut = UnitTimes('test_ut', sul)
-        self.assertEqual(ut.source, 'test_ut')
-        self.assertEqual(ut.spike_units, sul)
-
+    def test_add_spike_times(self):
+        ut = UnitTimes('UnitTimes add_spike_times unit test')
+        ut.add_spike_times(0, [0, 1, 2])
+        ut.add_spike_times(1, [3, 4, 5])
+        self.assertEqual(ut.unit_ids, [0, 1])
+        self.assertEqual(ut.spike_times, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(len(ut.spike_times_idx), 2)
+        self.assertEqual(ut.spike_times_idx[0].target, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(ut.spike_times_idx[0].slice, slice(0,3))
+        self.assertEqual(ut.spike_times_idx[1].target, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(ut.spike_times_idx[1].slice, slice(3,6))
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Motivation

Restructure UnitTimes to store spike data more efficiently

See https://github.com/NeurodataWithoutBorders/nwb-schema/issues/117

## How to test the behavior?
```python
from pynwb.misc import UnitTimes
ut = UnitTimes('example use of UnitTimes')
ut.add_spike_times(0, [0, 1, 2])
ut.add_spike_times(1, [3, 4, 5])
assert ut.get_unit_spike_times(0) == [0, 1, 2]
assert ut.get_unit_spike_times(1)  == [3, 4, 5]
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
