### PR TITLE
Pin miniconda versions as opposed to fetching the latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
 
   miniconda27:
     docker:
-      - image: continuumio/miniconda:latest
+      - image: continuumio/miniconda:4.3.14
     environment:
       - TEST_TOX_ENV: "py27"
       - BUILD_TOX_ENV: "build-py27"
@@ -134,7 +134,7 @@ jobs:
 
   miniconda36:
     docker:
-      - image: continuumio/miniconda3:latest
+      - image: continuumio/miniconda3:4.3.14
     environment:
       - TEST_TOX_ENV: "py36"
       - BUILD_TOX_ENV: "build-py36"


### PR DESCRIPTION
## Motivation

Fixes broken miniconda builds. Miniconda updated their latest docker images 19 hours ago which seemed to break virtualenv for us. I think pinning to a relatively new miniconda version serves our purpose of testing pynwb against miniconda users. 

Fixes #385 
