### PR TITLE
Enh/roi refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ test:
 flake:
 	$(FLAKE) src/
 	$(FLAKE) tests/
+	$(FLAKE) docs/code/
 
 checkpdb:
 	find {src,tests} -name "*.py" -exec grep -Hn pdb {} \;

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,13 @@ flake:
 	$(FLAKE) src/
 	$(FLAKE) tests/
 
+checkpdb:
+	find {src,tests} -name "*.py" -exec grep -Hn pdb {} \;
+
 devtest:
-	$(PYTHON) -W ignore test.py && $(MAKE) flake
+	$(PYTHON) -W ignore test.py
+	$(MAKE) flake
+	$(MAKE) checkpdb
 
 apidoc:
 	pip install -r requirements-doc.txt

--- a/docs/code/write-read-ophys.py
+++ b/docs/code/write-read-ophys.py
@@ -1,69 +1,97 @@
+import os
+from datetime import datetime
 
-        # create your NWBFile object
-        nwbfile = NWBFile(...)
+from pynwb import NWBFile, NWBHDF5IO
+from pynwb.ophys import TwoPhotonSeries, OpticalChannel, ImageSegmentation, Fluorescence
 
-        # set up some fake data
-        nwbfile.add_acquisition(ImageSeries(name='test_iS', source='a hypothetical source', dimension=[2],
-                                external_file=['images.tiff'],
-                                starting_frame=[1, 2, 3], format='tiff', timestamps=list()))
+def main():
+    nwb_path = 'ophys_example.nwb'
+    # create your NWBFile object
+    nwbfile = NWBFile('the PyNWB tutorial', 'my first synthetic recording', 'EXAMPLE_ID', datetime.now(),
+                      experimenter='Dr. Bilbo Baggins',
+                      lab='Bag End Laboratory',
+                      institution='University of Middle Earth at the Shire',
+                      experiment_description='I went on an adventure with thirteen dwarves to reclaim vast treasures.',
+                      session_id='LONELYMTN')
 
-        optical_channel = OpticalChannel('test_optical_channel', 'optical channel source',
-                                         'optical channel description', '3.14')
-        imaging_plane = nwbfile.create_imaging_plane('test_imaging_plane',
-                                                     'ophys integration tests',
-                                                     optical_channel,
-                                                     'imaging plane description',
-                                                     'imaging_device_1',
-                                                     '6.28', '2.718', 'GFP', 'somewhere in the brain',
-                                                     (1, 2, 1, 2, 3), 4.0, 'manifold unit', 'A frame to refer to')
+    # create acquisition metadata
+    optical_channel = OpticalChannel('test_optical_channel', 'optical channel source',
+                                     'optical channel description', '3.14')
+    imaging_plane = nwbfile.create_imaging_plane('test_imaging_plane',
+                                                 'ophys integration tests',
+                                                 optical_channel,
+                                                 'imaging plane description',
+                                                 'imaging_device_1',
+                                                 '6.28', '2.718', 'GFP', 'somewhere in the brain',
+                                                 (1, 2, 1, 2, 3), 4.0, 'manifold unit', 'A frame to refer to')
 
-        mod = nwbfile.create_processing_module('img_seg_example', 'a module for demoing ImageSegmentation')
-        img_seg = ImageSegmentation('a toy image segmentation container')
-        mod.add_data_interface(img_seg)
-        pS = img_seg.create_plane_segmentation('integration test PlaneSegmentation', 'plane segmentation description',
-                                               imaging_plane, 'test_plane_seg_name', image_series)
-        # add two ROIs
-        # - first argument is the pixel mask i.e. a list of pixels and their weights
-        # - second argument is the image mask
-        w, h = 5, 5
-        pix_mask1 = [(1, 2, 1.1), (3, 4, 1.2), (5, 6, 1.3)]
-        img_mask1 = [[0.0 for x in range(w)] for y in range(h)]
-        img_mask1[1][2] = 1.1
-        img_mask1[3][4] = 1.2
-        img_mask1[5][6] = 1.3
-        pS.add_roi(pix_mask1, img_mask1)
-
-        pix_mask2 = [(7, 8, 2.1), (9, 10, 2.2)]
-        img_mask2 = [[0.0 for x in range(w)] for y in range(h)]
-        img_mask2[7][8] = 2.1
-        img_mask2[9][10] = 2.2
-        pS.add_roi(pix_mask2, img_mask2)
-
-        # get an ROI table region i.e. a subset of ROIs to create a RoiResponseSeries from
-        rt_region = plane_segmentation.create_roi_table_region([0], 'the first of two ROIs')
-        # make some fake timeseries data
-        data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-        timestamps = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
-        # add an ROI response series
-        mod.add_data_interface(RoiResponseSeries('test_roi_response_series', 'RoiResponseSeries integration test',
-                                                 data, 'lumens', rt_region, timestamps=timestamps))
-
-        with NWBHDF5IO('test.nwb', 'w') as io:
-            io.write(nwbfile)
-
-        # read data back in
-
-        with NWBHDF5IO('test.nwb', 'r') as io:
-            nwbfile = io.read()
-
-        mod = nwbfile.get_processing_module('img_seg_example')
-        pS = mod.get_data_interface('ImageSegmentation')
-        img_mask1 = pS.get_image_mask(0)
-        pix_mask1 = pS.get_pixel_mask(0)
-        img_mask2 = pS.get_image_mask(1)
-        pix_mask2 = pS.get_pixel_mask(1)
-        rrs = mod.get_data_interface('test_roi_response_series')
-        rrs_data = rrs.data
-        rrs_timestamps = rrs.timestamps
+    # create acquisition data
+    image_series = TwoPhotonSeries(name='test_iS', source='a hypothetical source', dimension=[2],
+                                   external_file=['images.tiff'], imaging_plane=imaging_plane,
+                                   starting_frame=[1, 2, 3], format='tiff', timestamps=list())
+    nwbfile.add_acquisition(image_series)
 
 
+    mod = nwbfile.create_processing_module('img_seg_example', 'ophys demo', 'an example of writing Ca2+ imaging data')
+    img_seg = ImageSegmentation('a toy image segmentation container')
+    mod.add_data_interface(img_seg)
+    ps = img_seg.create_plane_segmentation('integration test PlaneSegmentation', 'plane segmentation description',
+                                           imaging_plane, 'test_plane_seg_name', image_series)
+    # add two ROIs
+    # - first argument is the pixel mask i.e. a list of pixels and their weights
+    # - second argument is the image mask
+    w, h = 3, 3
+    pix_mask1 = [(0, 0, 1.1), (1, 1, 1.2), (2, 2, 1.3)]
+    img_mask1 = [[0.0 for x in range(w)] for y in range(h)]
+    img_mask1[0][0] = 1.1
+    img_mask1[1][1] = 1.2
+    img_mask1[2][2] = 1.3
+    ps.add_roi(pix_mask1, img_mask1)
+
+    pix_mask2 = [(0, 0, 2.1), (1, 1, 2.2)]
+    img_mask2 = [[0.0 for x in range(w)] for y in range(h)]
+    img_mask2[0][0] = 2.1
+    img_mask2[1][1] = 2.2
+    ps.add_roi(pix_mask2, img_mask2)
+
+    # add a Fluorescence container
+    fl = Fluorescence('a toy fluorescence container')
+    mod.add_data_interface(fl)
+    # get an ROI table region i.e. a subset of ROIs to create a RoiResponseSeries from
+    rt_region = ps.create_roi_table_region([0], 'the first of two ROIs')
+    # make some fake timeseries data
+    data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+    timestamps = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+    rrs = fl.create_roi_response_series('test_roi_response_series', 'RoiResponseSeries integration test',
+                                        data, 'lumens', rt_region, timestamps=timestamps)
+    # write data
+    with NWBHDF5IO(nwb_path, 'w') as io:
+        io.write(nwbfile)
+
+    # read data back in
+    io = NWBHDF5IO(nwb_path, 'r')
+    nwbfile = io.read()
+
+    # get the processing module
+    mod = nwbfile.get_processing_module('img_seg_example')
+
+    # get the PlaneSegmentation from the ImageSegmentation data interface
+    ps = mod['ImageSegmentation'].get_plane_segmentation()
+    img_mask1 = ps.get_image_mask(0)
+    pix_mask1 = ps.get_pixel_mask(0)
+    img_mask2 = ps.get_image_mask(1)
+    pix_mask2 = ps.get_pixel_mask(1)
+
+    # get the RoiResponseSeries from the Fluorescence data interface
+    rrs = mod['Fluorescence'].get_roi_response_series()
+    # get the data...
+    rrs_data = rrs.data
+    rrs_timestamps = rrs.timestamps
+    # and now do something cool!
+
+    io.close()
+    if os.path.exists(nwb_path):
+        os.remove(nwb_path)
+
+if __name__ == '__main__':
+    main()

--- a/docs/code/write-read-ophys.py
+++ b/docs/code/write-read-ophys.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.ophys import TwoPhotonSeries, OpticalChannel, ImageSegmentation, Fluorescence
 
+
 def main():
     nwb_path = 'ophys_example.nwb'
     # create your NWBFile object
@@ -30,7 +31,6 @@ def main():
                                    external_file=['images.tiff'], imaging_plane=imaging_plane,
                                    starting_frame=[1, 2, 3], format='tiff', timestamps=list())
     nwbfile.add_acquisition(image_series)
-
 
     mod = nwbfile.create_processing_module('img_seg_example', 'ophys demo', 'an example of writing Ca2+ imaging data')
     img_seg = ImageSegmentation('a toy image segmentation container')
@@ -85,13 +85,14 @@ def main():
     # get the RoiResponseSeries from the Fluorescence data interface
     rrs = mod['Fluorescence'].get_roi_response_series()
     # get the data...
-    rrs_data = rrs.data
-    rrs_timestamps = rrs.timestamps
+    rrs_data = rrs.data                           # noqa: F841
+    rrs_timestamps = rrs.timestamps               # noqa: F841
     # and now do something cool!
 
     io.close()
     if os.path.exists(nwb_path):
         os.remove(nwb_path)
+
 
 if __name__ == '__main__':
     main()

--- a/docs/code/write-read-ophys.py
+++ b/docs/code/write-read-ophys.py
@@ -1,0 +1,69 @@
+
+        # create your NWBFile object
+        nwbfile = NWBFile(...)
+
+        # set up some fake data
+        nwbfile.add_acquisition(ImageSeries(name='test_iS', source='a hypothetical source', dimension=[2],
+                                external_file=['images.tiff'],
+                                starting_frame=[1, 2, 3], format='tiff', timestamps=list()))
+
+        optical_channel = OpticalChannel('test_optical_channel', 'optical channel source',
+                                         'optical channel description', '3.14')
+        imaging_plane = nwbfile.create_imaging_plane('test_imaging_plane',
+                                                     'ophys integration tests',
+                                                     optical_channel,
+                                                     'imaging plane description',
+                                                     'imaging_device_1',
+                                                     '6.28', '2.718', 'GFP', 'somewhere in the brain',
+                                                     (1, 2, 1, 2, 3), 4.0, 'manifold unit', 'A frame to refer to')
+
+        mod = nwbfile.create_processing_module('img_seg_example', 'a module for demoing ImageSegmentation')
+        img_seg = ImageSegmentation('a toy image segmentation container')
+        mod.add_data_interface(img_seg)
+        pS = img_seg.create_plane_segmentation('integration test PlaneSegmentation', 'plane segmentation description',
+                                               imaging_plane, 'test_plane_seg_name', image_series)
+        # add two ROIs
+        # - first argument is the pixel mask i.e. a list of pixels and their weights
+        # - second argument is the image mask
+        w, h = 5, 5
+        pix_mask1 = [(1, 2, 1.1), (3, 4, 1.2), (5, 6, 1.3)]
+        img_mask1 = [[0.0 for x in range(w)] for y in range(h)]
+        img_mask1[1][2] = 1.1
+        img_mask1[3][4] = 1.2
+        img_mask1[5][6] = 1.3
+        pS.add_roi(pix_mask1, img_mask1)
+
+        pix_mask2 = [(7, 8, 2.1), (9, 10, 2.2)]
+        img_mask2 = [[0.0 for x in range(w)] for y in range(h)]
+        img_mask2[7][8] = 2.1
+        img_mask2[9][10] = 2.2
+        pS.add_roi(pix_mask2, img_mask2)
+
+        # get an ROI table region i.e. a subset of ROIs to create a RoiResponseSeries from
+        rt_region = plane_segmentation.create_roi_table_region([0], 'the first of two ROIs')
+        # make some fake timeseries data
+        data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        timestamps = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        # add an ROI response series
+        mod.add_data_interface(RoiResponseSeries('test_roi_response_series', 'RoiResponseSeries integration test',
+                                                 data, 'lumens', rt_region, timestamps=timestamps))
+
+        with NWBHDF5IO('test.nwb', 'w') as io:
+            io.write(nwbfile)
+
+        # read data back in
+
+        with NWBHDF5IO('test.nwb', 'r') as io:
+            nwbfile = io.read()
+
+        mod = nwbfile.get_processing_module('img_seg_example')
+        pS = mod.get_data_interface('ImageSegmentation')
+        img_mask1 = pS.get_image_mask(0)
+        pix_mask1 = pS.get_pixel_mask(0)
+        img_mask2 = pS.get_image_mask(1)
+        pix_mask2 = pS.get_pixel_mask(1)
+        rrs = mod.get_data_interface('test_roi_response_series')
+        rrs_data = rrs.data
+        rrs_timestamps = rrs.timestamps
+
+

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -58,6 +58,9 @@ class ProcessingModule(NWBContainer):
         container_name = getargs('container_name', kwargs)
         return self.__containers.get(container_name)
 
+    def __getitem__(self, arg):
+        return self.get_data_interface(arg)
+
     @docval({'name': 'container', 'type': NWBDataInterface, 'doc': 'the NWBDataInterface to add to this Module'})
     def add_container(self, **kwargs):
         '''

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -109,8 +109,9 @@ class TimeSeries(NWBDataInterface):
                      'contained here. It can also be the name of a device, for stimulus or '
                      'acquisition data')},
             {'name': 'data', 'type': ('array_data', 'data', 'TimeSeries'),
-             'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
-            {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)'},
+             'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames',
+             'default': None},
+            {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)', 'default': None},
             {'name': 'resolution', 'type': (str, float),
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
              'default': _default_resolution},
@@ -161,6 +162,8 @@ class TimeSeries(NWBDataInterface):
         elif isinstance(data, DataIO):
             this_data = data.data
             self.fields['num_samples'] = len(this_data)
+        elif data is None:
+            self.fields['num_samples'] = 0
         else:
             self.fields['num_samples'] = len(data)
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -233,6 +233,27 @@ class VectorIndex(NWBData):
         call_docval_func(super(VectorIndex, self).__init__, kwargs)
 
 
+class IndexedVector(object):
+
+    @docval({'name': 'data', 'type': VectorData,
+             'doc': 'the VectorData to maintain'},
+            {'name': 'index', 'type': VectorIndex,
+             'doc': 'a VectorIndex object that indexes this VectorData', 'default': None})
+    def __init__(self, **kwargs):
+        self.__data = popargs('data', kwargs)
+        self.__index = popargs('index', kwargs)
+
+    def add_vector(self, arg):
+        before = len(self.__data)
+        self.__data.extend(arg)
+        rs = get_region_slicer(self.__data, slice(before, before+len(arg)))
+        self.__index.append(rs)
+        return len(self.__index)-1
+
+    def get_vector(self, arg):
+        return self.__index[arg][:]
+
+
 @register_class('ElementIdentifiers', CORE_NAMESPACE)
 class ElementIdentifiers(NWBData):
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1,4 +1,3 @@
-from collections import Iterable
 from h5py import RegionReference
 import numpy as np
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -271,7 +271,7 @@ class NWBTable(NWBData):
 
     @docval({'name': 'columns', 'type': (list, tuple), 'doc': 'a list of the columns in this table'},
             {'name': 'name', 'type': str, 'doc': 'the name of this container'},
-            {'name': 'data', 'type': Iterable, 'doc': 'the source of the data', 'default': list()},
+            {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the source of the data', 'default': list()},
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'the parent Container for this Container', 'default': None},
             {'name': 'container_source', 'type': object,

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -12,7 +12,6 @@ datasets:
     name: help
     value: Values for a list of elements
   doc: Data values indexed by pointer
-  dtype: any
   neurodata_type_def: VectorData
   neurodata_type_inc: NWBData
 - default_name: vector_index
@@ -122,7 +121,6 @@ groups:
     doc: 'Data values. Can also store binary data (eg, image frames) COMMENT: This
       field may be a link to data stored in an external file, especially in the case
       of raw data.'
-    dtype: any
     name: data
     shape:
     - null

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -343,13 +343,13 @@ datasets:
     dtype: utf8
     doc: a brief description of what this electrode is
   - name: group
-    dtype: ascii
-    doc: the name of the ElectrodeGroup this electrode is a part of
-  - name: group_ref
     dtype:
         target_type: ElectrodeGroup
         reftype: object
     doc: a reference to the ElectrodeGroup this electrode is a part of
+  - name: group_name
+    dtype: ascii
+    doc: the name of the ElectrodeGroup this electrode is a part of
   attributes:
     - doc: Value is 'a table for storing data about extracellular electrodes'
       dtype: text

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -54,11 +54,17 @@ datasets:
   neurodata_type_inc: NWBData
   neurodata_type_def: ROITable
 - doc: A region reference for subsetting an ROITable
+  dtype:
+    target_type: ROITable
+    reftype: region
   attributes:
   - doc: a help string
     name: help
     dtype: text
-    value: A region referene to an ROITable
+    value: A region reference to an ROITable
+  - name: description
+    doc: 'a description of this subset of ROIs'
+    dtype: utf8
   neurodata_type_inc: NWBData
   neurodata_type_def: ROITableRegion
 groups:
@@ -94,12 +100,12 @@ groups:
   neurodata_type_def: TwoPhotonSeries
   neurodata_type_inc: ImageSeries
 - attributes:
-  - doc: Value is 'ROI responses over an imaging plane. Each row in data[] should
-      correspond to the signal from one ROI'
+  - doc: Value is 'ROI responses over an imaging plane. Each element on the second dimension of data[]
+      should correspond to the signal from one ROI'
     dtype: text
     name: help
-    value: ROI responses over an imaging plane. Each row in data[] should correspond
-      to the signal from one ROI
+    value: ROI responses over an imaging plane. Each element on the second dimension of data[]
+      should correspond to the signal from one ROI
   datasets:
   - dims:
     - num_times

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -1,5 +1,10 @@
 datasets:
 - doc: ROI mask, represented in 2D ([y][x]) intensity image
+  attributes:
+  - doc: a help string
+    name: help
+    dtype: text
+    value: an array of image masks
   dims:
   - num_roi
   - num_x
@@ -12,6 +17,11 @@ datasets:
   neurodata_type_inc: NWBData
   neurodata_type_def: ImageMasks
 - doc: a table for storing pixel masks
+  attributes:
+  - doc: a help string
+    name: help
+    dtype: text
+    value: a concatenated array of pixel masks
   dtype:
   - name: x
     dtype: uint

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -132,7 +132,8 @@ groups:
         dtype: float
         doc: the weight of the pixel
       neurodata_type_inc: VectorData
-    - name: img_mask
+      neurodata_type_def: PixelMasks
+    - name: image_mask
       doc: ROI mask, represented in 2D ([y][x]) intensity image
       dims:
       - num_roi
@@ -144,13 +145,27 @@ groups:
       - null
       - null
       neurodata_type_inc: NWBData
-      neurodata_type_def: ROIImageMasks
-    - name: pixel_mask_index
-      doc: Pixel Mask regions
-      neurodata_type+inc: VectorIndex
-    - name: roi_ids
-      doc: Unique identifiers for each ROI
-      neurodata_type+inc: ElementIndentifiers
+      neurodata_type_def: ImageMasks
+    - default_name: roi_table
+      doc: A table for storing references to the image mask and pixel mask for each ROI
+      attributes:
+      - doc: a help string
+        name: help
+        dtype: text
+        value: A table for storing ROI data
+      dtype:
+      - name: pixel_mask
+        dtype:
+          reftype: region
+          target_type: PixelMasks
+        doc: a reference into a the dataset of pixel masks
+      - name: image_mask
+        dtype:
+          reftype: region
+          target_type: ImageMasks
+        doc: a reference into a the dataset of image masks
+      neurodata_type_inc: NWBData
+      neurodata_type_def: ROITable
     doc: Group name is human-readable description of imaging plane
     groups:
     - doc: Stores image stacks segmentation mask apply to.

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -47,13 +47,11 @@ groups:
     shape:
     - null
     - null
-  - dims:
-    - num_ROIs
-    doc: List of ROIs represented, one name for each row of data[].
-    dtype: text
-    name: roi_names
-    shape:
-    - null
+  - doc: 'a dataset referencing into an ROITable containing information on the ROIs stored in this timeseries'
+    dtype:
+      target_type: ROITable
+      reftype: region
+    name: rois
   doc: ROI responses over an imaging plane. Each row in data[] should correspond to
     the signal from one ROI.
   links:
@@ -121,46 +119,40 @@ groups:
       dtype: text
       name: description
       quantity: '?'
+    - doc: a table for storing pixel masks
+      name: pixel_mask
+      dtype:
+      - name: x
+        dtype: uint
+        doc: the pixel x-coordinate
+      - name: y
+        dtype: uint
+        doc: the pixel y-coordinate
+      - name: weight
+        dtype: float
+        doc: the weight of the pixel
+      neurodata_type_inc: VectorData
+    - name: img_mask
+      doc: ROI mask, represented in 2D ([y][x]) intensity image
+      dims:
+      - num_roi
+      - num_x
+      - num_y
+      dtype: float
+      shape:
+      - null
+      - null
+      - null
+      neurodata_type_inc: NWBData
+      neurodata_type_def: ROIImageMasks
+    - name: pixel_mask_index
+      doc: Pixel Mask regions
+      neurodata_type+inc: VectorIndex
+    - name: roi_ids
+      doc: Unique identifiers for each ROI
+      neurodata_type+inc: ElementIndentifiers
     doc: Group name is human-readable description of imaging plane
     groups:
-    - attributes:
-      - doc: Value is 'Region of interest, as determined by image segmentation'
-        dtype: text
-        name: help
-        value: 'Region of interest, as determined by image segmentation'
-      datasets:
-      - dims:
-        - num_x
-        - num_y
-        doc: ROI mask, represented in 2D ([y][x]) intensity image
-        dtype: float32
-        name: img_mask
-        shape:
-        - null
-        - null
-      - dims:
-        - num_pixels
-        - '2'
-        doc: List of pixels (x,y) that compose the mask
-        dtype: uint16
-        name: pix_mask
-        shape:
-        - null
-        - null
-      - dims:
-        - num_pixels
-        doc: Weight of each pixel listed in pix_mask
-        dtype: float32
-        name: pix_mask_weight
-        shape:
-        - null
-      - doc: Description of this ROI.
-        dtype: text
-        name: roi_description
-      doc: Name of ROI
-      neurodata_type_def: ROI
-      neurodata_type_inc: NWBContainer
-      quantity: '*'
     - doc: Stores image stacks segmentation mask apply to.
       groups:
       - doc: One or more image stacks that the masks apply to (can be one-element

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -146,7 +146,7 @@ groups:
       - null
       neurodata_type_inc: NWBData
       neurodata_type_def: ImageMasks
-    - default_name: roi_table
+    - name: roi_table
       doc: A table for storing references to the image mask and pixel mask for each ROI
       attributes:
       - doc: a help string

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -1,3 +1,56 @@
+datasets:
+- doc: ROI mask, represented in 2D ([y][x]) intensity image
+  dims:
+  - num_roi
+  - num_x
+  - num_y
+  dtype: float
+  shape:
+  - null
+  - null
+  - null
+  neurodata_type_inc: NWBData
+  neurodata_type_def: ImageMasks
+- doc: a table for storing pixel masks
+  dtype:
+  - name: x
+    dtype: uint
+    doc: the pixel x-coordinate
+  - name: y
+    dtype: uint
+    doc: the pixel y-coordinate
+  - name: weight
+    dtype: float
+    doc: the weight of the pixel
+  neurodata_type_inc: VectorData
+  neurodata_type_def: PixelMasks
+- doc: A table for storing references to the image mask and pixel mask for each ROI
+  attributes:
+  - doc: a help string
+    name: help
+    dtype: text
+    value: A table for storing ROI data
+  dtype:
+  - name: pixel_mask
+    dtype:
+      reftype: region
+      target_type: PixelMasks
+    doc: a reference into a the dataset of pixel masks
+  - name: image_mask
+    dtype:
+      reftype: region
+      target_type: ImageMasks
+    doc: a reference into a the dataset of image masks
+  neurodata_type_inc: NWBData
+  neurodata_type_def: ROITable
+- doc: A region reference for subsetting an ROITable
+  attributes:
+  - doc: a help string
+    name: help
+    dtype: text
+    value: A region referene to an ROITable
+  neurodata_type_inc: NWBData
+  neurodata_type_def: ROITableRegion
 groups:
 - attributes:
   - doc: Value is 'Image stack recorded from 2-photon microscope'
@@ -48,16 +101,10 @@ groups:
     - null
     - null
   - doc: 'a dataset referencing into an ROITable containing information on the ROIs stored in this timeseries'
-    dtype:
-      target_type: ROITable
-      reftype: region
+    neurodata_type_inc: ROITableRegion
     name: rois
   doc: ROI responses over an imaging plane. Each row in data[] should correspond to
     the signal from one ROI.
-  links:
-  - doc: HDF5 link to image segmentation module defining ROIs.
-    name: segmentation_interface
-    target_type: ImageSegmentation
   neurodata_type_def: RoiResponseSeries
   neurodata_type_inc: TimeSeries
 - attributes:
@@ -119,53 +166,16 @@ groups:
       dtype: text
       name: description
       quantity: '?'
-    - doc: a table for storing pixel masks
-      name: pixel_mask
-      dtype:
-      - name: x
-        dtype: uint
-        doc: the pixel x-coordinate
-      - name: y
-        dtype: uint
-        doc: the pixel y-coordinate
-      - name: weight
-        dtype: float
-        doc: the weight of the pixel
-      neurodata_type_inc: VectorData
-      neurodata_type_def: PixelMasks
-    - name: image_mask
-      doc: ROI mask, represented in 2D ([y][x]) intensity image
-      dims:
-      - num_roi
-      - num_x
-      - num_y
-      dtype: float
-      shape:
-      - null
-      - null
-      - null
-      neurodata_type_inc: NWBData
-      neurodata_type_def: ImageMasks
-    - name: roi_table
-      doc: A table for storing references to the image mask and pixel mask for each ROI
-      attributes:
-      - doc: a help string
-        name: help
-        dtype: text
-        value: A table for storing ROI data
-      dtype:
-      - name: pixel_mask
-        dtype:
-          reftype: region
-          target_type: PixelMasks
-        doc: a reference into a the dataset of pixel masks
-      - name: image_mask
-        dtype:
-          reftype: region
-          target_type: ImageMasks
-        doc: a reference into a the dataset of image masks
-      neurodata_type_inc: NWBData
-      neurodata_type_def: ROITable
+    - name: pixel_masks
+      doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this dataset is
+        maintained by the ROITable
+      neurodata_type_inc: PixelMasks
+    - name: image_masks
+      doc: ROI masks for each ROI
+      neurodata_type_inc: ImageMasks
+    - name: rois
+      doc: ROIs resulting from the segmentation of the imaging plane linked in this PlaneSegmentation
+      neurodata_type_inc: ROITable
     doc: Group name is human-readable description of imaging plane
     groups:
     - doc: Stores image stacks segmentation mask apply to.

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -72,13 +72,12 @@ class ElectrodeTable(NWBTable):
     def __init__(self, **kwargs):
         data, name = getargs('data', 'name', kwargs)
         colnames = [i['name'] for i in _et_docval]
-        colnames.append('group_ref')
+        colnames.append('group_name')
         super(ElectrodeTable, self).__init__(colnames, name, data)
 
     @docval(*_et_docval)
     def add_row(self, **kwargs):
-        kwargs['group_ref'] = kwargs['group']
-        kwargs['group'] = kwargs['group'].name
+        kwargs['group_name'] = kwargs['group'].name
         super(ElectrodeTable, self).add_row(kwargs)
 
 

--- a/src/pynwb/form/__init__.py
+++ b/src/pynwb/form/__init__.py
@@ -1,3 +1,17 @@
 # flake8: noqa: F401
 from .container import Container, Data, DataRegion
-from .data_utils import get_region_slicer
+from .utils import docval, getargs
+from .data_utils import ListSlicer
+from .backends.hdf5.h5_utils import H5RegionSlicer, H5Dataset
+
+
+@docval({'name': 'dataset', 'type': None, 'doc': 'the HDF5 dataset to slice'},
+        {'name': 'region', 'type': None, 'doc': 'the region reference to use to slice'},
+        is_method=False)
+def get_region_slicer(**kwargs):
+    dataset, region = getargs('dataset', 'region', kwargs)
+    if isinstance(dataset, (list, tuple, Data)):
+        return ListSlicer(dataset, region)
+    elif isinstance(dataset, H5Dataset):
+        return H5RegionSlicer(dataset, region)
+    return None

--- a/src/pynwb/form/backends/hdf5/__init__.py
+++ b/src/pynwb/form/backends/hdf5/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa: F401
+from . import h5_utils
 from .h5tools import HDF5IO
 from .h5_utils import H5RegionSlicer, H5DataIO
 from . import h5tools

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -1,17 +1,145 @@
-import h5py
+from copy import copy
+from six import binary_type, text_type
+from h5py import Group, Dataset, RegionReference, Reference, special_dtype
 
+from ...query import FORMDataset
+from ...array import Array
 from ...utils import docval, getargs, popargs, call_docval_func
 from ...data_utils import RegionSlicer, DataIO
+
+from ...spec import SpecWriter, SpecReader
+
+
+class H5Dataset(FORMDataset):
+    @docval({'name': 'dataset', 'type': (Dataset, Array), 'doc': 'the HDF5 file lazily evaluate'},
+            {'name': 'io', 'type': 'HDF5IO', 'doc': 'the IO object that was used to read the underlying dataset'})
+    def __init__(self, **kwargs):
+        self.__io = popargs('io', kwargs)
+        call_docval_func(super(H5Dataset, self).__init__, kwargs)
+
+    @property
+    def io(self):
+        return self.__io
+
+    @property
+    def regionref(self):
+        return self.dataset.regionref
+
+    @property
+    def ref(self):
+        return self.dataset.ref
+
+
+class H5TableDataset(H5Dataset):
+
+    @docval({'name': 'dataset', 'type': (Dataset, Array), 'doc': 'the HDF5 file lazily evaluate'},
+            {'name': 'io', 'type': 'HDF5IO', 'doc': 'the IO object that was used to read the underlying dataset'},
+            {'name': 'types', 'type': (list, tuple), 'doc': 'the IO object that was used to read the underlying dataset'})
+    def __init__(self, **kwargs):
+        types = popargs('types', kwargs)
+        call_docval_func(super(H5TableDataset, self).__init__, kwargs)
+        self.__refgetters = dict()
+        for i, t in enumerate(types):
+            if t is RegionReference:
+                self.__refgetters[i] = self.__get_regref
+            elif t is Reference:
+                self.__refgetters[i] = self.__get_ref
+
+    def __getitem__(self, arg):
+        idx = arg
+        rows = copy(super(H5TableDataset, self).__getitem__(arg))
+        if isinstance(arg, int):
+            self.__swap_refs(rows)
+        for row in rows:
+            self.__swap_refs(row)
+        return rows
+
+    def __swap_refs(self, row):
+        for i in self.__refgetters:
+            getref = self.__refgetters[i]
+            row[i] = getref(row[i])
+
+    def __get_ref(self, ref):
+        return self.io.get_container(self.dataset.file[ref])
+
+    def __get_regref(self, ref):
+        obj = self.__get_ref(ref)
+        return obj[ref]
+
+
+class H5ReferenceDataset(H5Dataset):
+
+    def __getitem__(self, arg):
+        ref = super(H5ReferenceDataset, self).__getitem__(arg)
+        return self.io.get_container(self.dataset.file[ref])
+
+
+class H5RegionDataset(H5ReferenceDataset):
+
+    def __getitem__(self, arg):
+        obj = super(H5RegionDataset, self).__getitem__(arg)
+        ref = self.dataset[arg]
+        return obj[ref]
+
+
+class H5SpecWriter(SpecWriter):
+
+    __str_type = special_dtype(vlen=binary_type)
+
+    @docval({'name': 'group', 'type': Group, 'doc': 'the HDF5 file to write specs to'})
+    def __init__(self, **kwargs):
+        self.__group = getargs('group', kwargs)
+
+    @staticmethod
+    def stringify(spec):
+        '''
+        Converts a spec into a JSON string to write to a dataset
+        '''
+        return json.dumps(spec, separators=(',', ':'))
+
+    def __write(self, d, name):
+        data = self.stringify(d)
+        dset = self.__group.create_dataset(name, data=data, dtype=self.__str_type)
+        return dset
+
+    def write_spec(self, spec, path):
+        return self.__write(spec, path)
+
+    def write_namespace(self, namespace, path):
+        return self.__write({'namespaces': [namespace]}, path)
+
+
+class H5SpecReader(SpecReader):
+
+    @docval({'name': 'group', 'type': Group, 'doc': 'the HDF5 file to read specs from'})
+    def __init__(self, **kwargs):
+        self.__group = getargs('group', kwargs)
+
+    def __read(self, path):
+        s = self.__group[path][()]
+        if isinstance(s, bytes):
+            s = s.decode('UTF-8')
+        d = json.loads(s)
+        return d
+
+    def read_spec(self, spec_path):
+        return self.__read(spec_path)
+
+    def read_namespace(self, ns_path):
+        ret = self.__read(ns_path)
+        ret = ret['namespaces']
+        return ret
 
 
 class H5RegionSlicer(RegionSlicer):
 
-    @docval({'name': 'dataset', 'type': h5py.Dataset, 'doc': 'the HDF5 dataset to slice'},
-            {'name': 'region', 'type': h5py.RegionReference, 'doc': 'the region reference to use to slice'})
+    @docval({'name': 'dataset', 'type': (Dataset, H5Dataset), 'doc': 'the HDF5 dataset to slice'},
+            {'name': 'region', 'type': RegionReference, 'doc': 'the region reference to use to slice'})
     def __init__(self, **kwargs):
         self.__dataset = getargs('dataset', kwargs)
         self.__regref = getargs('region', kwargs)
         self.__len = self.__dataset.regionref.selection(self.__regref)[0]
+        self.__region = None
 
     def __read_region(self):
         if self.__region is None:

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -51,14 +51,16 @@ class H5TableDataset(H5Dataset):
         rows = copy(super(H5TableDataset, self).__getitem__(arg))
         if isinstance(arg, int):
             self.__swap_refs(rows)
-        for row in rows:
-            self.__swap_refs(row)
+        else:
+            for row in rows:
+                self.__swap_refs(row)
         return rows
 
     def __swap_refs(self, row):
         for i in self.__refgetters:
             getref = self.__refgetters[i]
-            row[i] = getref(row[i])
+            if isinstance(row[i], Reference):
+                row[i] = getref(row[i])
 
     def __get_ref(self, ref):
         return self.io.get_container(self.dataset.file[ref])

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -59,8 +59,7 @@ class H5TableDataset(H5Dataset):
     def __swap_refs(self, row):
         for i in self.__refgetters:
             getref = self.__refgetters[i]
-            if isinstance(row[i], Reference):
-                row[i] = getref(row[i])
+            row[i] = getref(row[i])
 
     def __get_ref(self, ref):
         return self.io.get_container(self.dataset.file[ref])

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -1,6 +1,7 @@
 from copy import copy
 from six import binary_type, text_type
 from h5py import Group, Dataset, RegionReference, Reference, special_dtype
+import json
 
 from ...query import FORMDataset
 from ...array import Array

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -1,5 +1,5 @@
 from copy import copy
-from six import binary_type, text_type
+from six import binary_type
 from h5py import Group, Dataset, RegionReference, Reference, special_dtype
 import json
 
@@ -35,7 +35,8 @@ class H5TableDataset(H5Dataset):
 
     @docval({'name': 'dataset', 'type': (Dataset, Array), 'doc': 'the HDF5 file lazily evaluate'},
             {'name': 'io', 'type': 'HDF5IO', 'doc': 'the IO object that was used to read the underlying dataset'},
-            {'name': 'types', 'type': (list, tuple), 'doc': 'the IO object that was used to read the underlying dataset'})
+            {'name': 'types', 'type': (list, tuple),
+             'doc': 'the IO object that was used to read the underlying dataset'})
     def __init__(self, **kwargs):
         types = popargs('types', kwargs)
         call_docval_func(super(H5TableDataset, self).__init__, kwargs)
@@ -47,7 +48,6 @@ class H5TableDataset(H5Dataset):
                 self.__refgetters[i] = self.__get_ref
 
     def __getitem__(self, arg):
-        idx = arg
         rows = copy(super(H5TableDataset, self).__getitem__(arg))
         if isinstance(arg, int):
             self.__swap_refs(rows)

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -1,22 +1,22 @@
 from collections import Iterable, deque
+from copy import copy
 import json
 import numpy as np
 import os.path
-from h5py import File, Group, Dataset, special_dtype, SoftLink, ExternalLink, Reference, RegionReference
+from h5py import File, Group, Dataset, special_dtype, SoftLink, ExternalLink, Reference, RegionReference, check_dtype
 from six import raise_from, text_type, string_types, binary_type
 import warnings
 from ...container import Container
 
 from ...utils import docval, getargs, popargs, call_docval_func
 from ...data_utils import DataChunkIterator, get_shape
-from ...query import FORMDataset
-from ...array import Array
 from ...build import Builder, GroupBuilder, DatasetBuilder, LinkBuilder, BuildManager,\
                      RegionBuilder, ReferenceBuilder, TypeMap
-from ...spec import RefSpec, DtypeSpec, NamespaceCatalog, SpecWriter, SpecReader, GroupSpec
+from ...spec import RefSpec, DtypeSpec, NamespaceCatalog, GroupSpec
 from ...spec import NamespaceBuilder
 
-from .h5_utils import H5DataIO
+from .h5_utils import H5Dataset, H5ReferenceDataset, H5RegionDataset, H5TableDataset,\
+                      H5DataIO, H5SpecReader, H5SpecWriter
 
 from ..io import FORMIO
 
@@ -267,15 +267,22 @@ class HDF5IO(FORMIO):
                     kwargs['data'] = ReferenceBuilder(target_builder)
             else:
                 kwargs["data"] = scalar
-        elif ndims == 1 and h5obj.dtype == np.dtype('O'):    # read list of strings
-            elem1 = h5obj[0]
+        elif ndims == 1:
             d = None
-            if isinstance(elem1, text_type):
-                d = H5Dataset(h5obj, self)
-            elif isinstance(elem1, RegionReference):
-                d = H5RegionDataset(h5obj, self)
-            elif isinstance(elem1, Reference):
-                d = H5ReferenceDataset(h5obj, self)
+            if h5obj.dtype.kind == 'O':    # read list of strings or list of references
+                elem1 = h5obj[0]
+                if isinstance(elem1, text_type):
+                    d = H5Dataset(h5obj, self)
+                elif isinstance(elem1, RegionReference):
+                    d = H5RegionDataset(h5obj, self)
+                elif isinstance(elem1, Reference):
+                    d = H5ReferenceDataset(h5obj, self)
+            elif h5obj.dtype.kind == 'V':    # table
+                cpd_dt = h5obj.dtype
+                ref_cols = [check_dtype(ref=cpd_dt[i]) for i in range(len(cpd_dt))]
+                d = H5TableDataset(h5obj, self, ref_cols)
+            else:
+                d = h5obj
             kwargs["data"] = d
         else:
             kwargs["data"] = h5obj
@@ -744,80 +751,4 @@ class HDF5IO(FORMIO):
                 ret.append(self.__get_ref(elem))
             else:
                 ret.append(elem)
-        return ret
-
-
-class H5Dataset(FORMDataset):
-    @docval({'name': 'dataset', 'type': (Dataset, Array), 'doc': 'the HDF5 file lazily evaluate'},
-            {'name': 'io', 'type': FORMIO, 'doc': 'the IO object that was used to read the underlying dataset'})
-    def __init__(self, **kwargs):
-        self.__io = popargs('io', kwargs)
-        call_docval_func(super(H5Dataset, self).__init__, kwargs)
-
-    @property
-    def io(self):
-        return self.__io
-
-
-class H5ReferenceDataset(H5Dataset):
-
-    def __getitem__(self, arg):
-        ref = super(H5ReferenceDataset, self).__getitem__(arg)
-        return self.io.get_container(self.dataset.file[ref])
-
-
-class H5RegionDataset(H5ReferenceDataset):
-
-    def __getitem__(self, arg):
-        obj = super(H5RegionDataset, self).__getitem__(arg)
-        ref = self.dataset[arg]
-        return obj[ref]
-
-
-class H5SpecWriter(SpecWriter):
-
-    __str_type = special_dtype(vlen=binary_type)
-
-    @docval({'name': 'group', 'type': Group, 'doc': 'the HDF5 file to write specs to'})
-    def __init__(self, **kwargs):
-        self.__group = getargs('group', kwargs)
-
-    @staticmethod
-    def stringify(spec):
-        '''
-        Converts a spec into a JSON string to write to a dataset
-        '''
-        return json.dumps(spec, separators=(',', ':'))
-
-    def __write(self, d, name):
-        data = self.stringify(d)
-        dset = self.__group.create_dataset(name, data=data, dtype=self.__str_type)
-        return dset
-
-    def write_spec(self, spec, path):
-        return self.__write(spec, path)
-
-    def write_namespace(self, namespace, path):
-        return self.__write({'namespaces': [namespace]}, path)
-
-
-class H5SpecReader(SpecReader):
-
-    @docval({'name': 'group', 'type': Group, 'doc': 'the HDF5 file to read specs from'})
-    def __init__(self, **kwargs):
-        self.__group = getargs('group', kwargs)
-
-    def __read(self, path):
-        s = self.__group[path][()]
-        if isinstance(s, bytes):
-            s = s.decode('UTF-8')
-        d = json.loads(s)
-        return d
-
-    def read_spec(self, spec_path):
-        return self.__read(spec_path)
-
-    def read_namespace(self, ns_path):
-        ret = self.__read(ns_path)
-        ret = ret['namespaces']
         return ret

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -1,6 +1,4 @@
 from collections import Iterable, deque
-from copy import copy
-import json
 import numpy as np
 import os.path
 from h5py import File, Group, Dataset, special_dtype, SoftLink, ExternalLink, Reference, RegionReference, check_dtype

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -404,6 +404,7 @@ class HDF5IO(FORMIO):
                         self.__queue_ref(self._make_attr_ref_filler(obj, key, tmp))
                     else:
                         value = np.array(value)
+                    obj.attrs[key] = value
                 else:
                     msg = "ignoring attribute '%s' from '%s' - value is empty list" % (key, obj.name)
                     warnings.warn(msg)
@@ -705,9 +706,13 @@ class HDF5IO(FORMIO):
                 builder = container.target_builder
             else:
                 builder = container
+        elif isinstance(container, ReferenceBuilder):
+            builder = container.builder
         else:
             builder = self.manager.build(container)
         path = self.__get_path(builder)
+        if isinstance(container, RegionBuilder):
+            region = container.region
         if region is not None:
             dset = self.__file[path]
             if not isinstance(dset, Dataset):

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -402,7 +402,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             if spec.data_type_inc is not None:
                 ret = value
             else:
-                if 'text' in spec.dtype:
+                if spec.dtype is not None and 'text' in spec.dtype:
                     if spec.dims is not None:
                         ret = list(map(str, value))
                     else:

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -4,7 +4,8 @@ from abc import ABCMeta, abstractmethod, abstractproperty
 from six import with_metaclass
 from .utils import docval, getargs, popargs, docval_macro
 from operator import itemgetter
-from .container import Data
+from .container import Data, DataRegion
+
 
 def __get_shape_helper(data):
     shape = list()
@@ -462,7 +463,7 @@ class DataIO(with_metaclass(ABCMeta, object)):
         return self.__data
 
 
-class RegionSlicer(with_metaclass(ABCMeta, object)):
+class RegionSlicer(with_metaclass(ABCMeta, DataRegion)):
     '''
     A abstract base class to control getting using a region
 
@@ -474,6 +475,14 @@ class RegionSlicer(with_metaclass(ABCMeta, object)):
     def __init__(self, **kwargs):
         self.__target = getargs('target', kwargs)
         self.__slice = getargs('slice', kwargs)
+
+    @property
+    def data(self):
+        return self.target
+
+    @property
+    def region(self):
+        return self.slice
 
     @property
     def target(self):

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -6,10 +6,6 @@ from .utils import docval, getargs, popargs, docval_macro
 from operator import itemgetter
 from .container import Data
 
-from .backends.hdf5 import H5RegionSlicer  # noqa: E402
-from .backends.hdf5.h5tools import H5Dataset
-
-
 def __get_shape_helper(data):
     shape = list()
     if hasattr(data, '__len__'):
@@ -526,15 +522,3 @@ class ListSlicer(RegionSlicer):
 
     def __len__(self):
         return self.__len
-
-
-@docval({'name': 'dataset', 'type': None, 'doc': 'the HDF5 dataset to slice'},
-        {'name': 'region', 'type': None, 'doc': 'the region reference to use to slice'},
-        is_method=False)
-def get_region_slicer(**kwargs):
-    dataset, region = getargs('dataset', 'region', kwargs)
-    if isinstance(dataset, (list, tuple, Data)):
-        return ListSlicer(dataset, region)
-    elif isinstance(dataset, H5Dataset):
-        return H5RegionSlicer(dataset, region)
-    return None

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -6,6 +6,9 @@ from .utils import docval, getargs, popargs, docval_macro
 from operator import itemgetter
 from .container import Data
 
+from .backends.hdf5 import H5RegionSlicer  # noqa: E402
+from .backends.hdf5.h5tools import H5Dataset
+
 
 def __get_shape_helper(data):
     shape = list()
@@ -523,11 +526,6 @@ class ListSlicer(RegionSlicer):
 
     def __len__(self):
         return self.__len
-
-
-from .backends.hdf5 import H5RegionSlicer  # noqa: E402
-from .backends.hdf5.h5tools import H5Dataset
-import h5py  # noqa: E402
 
 
 @docval({'name': 'dataset', 'type': None, 'doc': 'the HDF5 dataset to slice'},

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -526,6 +526,7 @@ class ListSlicer(RegionSlicer):
 
 
 from .backends.hdf5 import H5RegionSlicer  # noqa: E402
+from .backends.hdf5.h5tools import H5Dataset
 import h5py  # noqa: E402
 
 
@@ -536,6 +537,6 @@ def get_region_slicer(**kwargs):
     dataset, region = getargs('dataset', 'region', kwargs)
     if isinstance(dataset, (list, tuple, Data)):
         return ListSlicer(dataset, region)
-    elif isinstance(dataset, h5py.Dataset):
+    elif isinstance(dataset, H5Dataset):
         return H5RegionSlicer(dataset, region)
     return None

--- a/src/pynwb/form/query.py
+++ b/src/pynwb/form/query.py
@@ -147,3 +147,12 @@ class FORMDataset(with_metaclass(ExtenderMeta, object)):
 
     def __len__(self):
         return len(self.__dataset)
+
+    def __iter__(self):
+        return iter(self.dataset)
+
+    def __next__(self):
+        return next(self.dataset)
+
+    def next(self):
+        return self.dataset.next()

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -959,6 +959,8 @@ class GroupSpec(BaseStorageSpec):
             else:
                 raise TypeError("must specify 'name' or 'data_type_inc' in Group spec")
         else:
+            if spec.data_type_inc is not None or spec.data_type_def is not None:
+                self.__add_data_type_inc(spec)
             self.__groups[spec.name] = spec
         self.setdefault('groups', list()).append(spec)
         spec.parent = self
@@ -989,6 +991,8 @@ class GroupSpec(BaseStorageSpec):
             else:
                 raise TypeError("must specify 'name' or 'data_type_inc' in Dataset spec")
         else:
+            if spec.data_type_inc is not None or spec.data_type_def is not None:
+                self.__add_data_type_inc(spec)
             self.__datasets[spec.name] = spec
         self.setdefault('datasets', list()).append(spec)
         spec.parent = self

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -1,7 +1,7 @@
 import numpy as np
 from collections import Iterable
 
-from .form.utils import docval, popargs
+from .form.utils import docval, popargs, call_docval_func
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
@@ -29,13 +29,14 @@ class ImageSeries(TimeSeries):
                      'contained here. It can also be the name of a device, for stimulus or '
                      'acquisition data')},
             {'name': 'data', 'type': ('array_data', 'data', TimeSeries),
-             'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
+             'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames',
+             'default': None},
             {'name': 'unit', 'type': str,
              'doc': 'The base unit of measurement (should be SI unit)', 'default': 'None'},
             {'name': 'format', 'type': str,
              'doc': 'Format of image. Three types: 1) Image format; tiff, png, jpg, etc. 2) external 3) raw.',
-             'default': 'None'},
-            {'name': 'external_file', 'type': Iterable,
+             'default': None},
+            {'name': 'external_file', 'type': ('array_data', 'data'),
              'doc': 'Path or URL to one or more external file(s). Field only present if format=external. \
              Either external_file or data must be specified, but not both.', 'default': None},
             {'name': 'starting_frame', 'type': Iterable,
@@ -64,10 +65,9 @@ class ImageSeries(TimeSeries):
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
     def __init__(self, **kwargs):
-        name, source, data, unit = popargs('name', 'source', 'data', 'unit', kwargs)
         bits_per_pixel, dimension, external_file, starting_frame, format = popargs(
             'bits_per_pixel', 'dimension', 'external_file', 'starting_frame', 'format', kwargs)
-        super(ImageSeries, self).__init__(name, source, data, unit, **kwargs)
+        call_docval_func(super(ImageSeries, self).__init__, kwargs)
         self.bits_per_pixel = bits_per_pixel
         self.dimension = dimension
         self.external_file = external_file

--- a/src/pynwb/io/ophys.py
+++ b/src/pynwb/io/ophys.py
@@ -10,8 +10,6 @@ class PlaneSegmentationMap(ObjectMapper):
     # This might be needed for 2.0 as well
     def __init__(self, spec):
         super(PlaneSegmentationMap, self).__init__(spec)
-        roi_spec = self.spec.get_neurodata_type('ROI')
-        self.map_spec('roi_list', roi_spec)
 
         reference_images_spec = self.spec.get_group('reference_images').get_neurodata_type('ImageSeries')
         self.map_spec('reference_images', reference_images_spec)

--- a/src/pynwb/io/ophys.py
+++ b/src/pynwb/io/ophys.py
@@ -1,7 +1,8 @@
 from ..form.build import ObjectMapper
 from .. import register_map
 
-from ..ophys import PlaneSegmentation
+from ..ophys import PlaneSegmentation, ROITable, ROITableRegion
+from .core import NWBDataMap, NWBTableRegionMap
 
 
 @register_map(PlaneSegmentation)
@@ -13,3 +14,14 @@ class PlaneSegmentationMap(ObjectMapper):
 
         reference_images_spec = self.spec.get_group('reference_images').get_neurodata_type('ImageSeries')
         self.map_spec('reference_images', reference_images_spec)
+
+
+@register_map(ROITable)
+class ROITableMap(NWBDataMap):
+    def __init__(self, spec):
+        super(ROITableMap, self).__init__(spec)
+
+
+@register_map(ROITableRegion)
+class ROITableRegionMap(NWBTableRegionMap):
+    pass

--- a/src/pynwb/legacy/io/ophys.py
+++ b/src/pynwb/legacy/io/ophys.py
@@ -11,8 +11,8 @@ class PlaneSegmentationMap(ObjectMapper):
     # This might be needed for 2.0 as well
     def __init__(self, spec):
         super(PlaneSegmentationMap, self).__init__(spec)
-        roi_spec = self.spec.get_neurodata_type('ROI')
-        self.map_spec('roi_list', roi_spec)
+        # roi_spec = self.spec.get_neurodata_type('ROI')
+        # self.map_spec('roi_list', roi_spec)
 
         reference_images_spec = self.spec.get_group('reference_images').get_neurodata_type('ImageSeries')
         self.map_spec('reference_images', reference_images_spec)
@@ -64,16 +64,3 @@ class TwoPhotonSeriesMap(ObjectMapper):
         ip_builder = root['general/optophysiology/%s' % ip_name]
         imaging_plane = manager.construct(ip_builder)
         return imaging_plane
-
-
-@register_map(ROI)
-class ROIMap(ObjectMapper):
-
-    @ObjectMapper.constructor_arg('reference_images')
-    def carg_reference_images(self, *args):
-        return 'None'
-
-    @ObjectMapper.constructor_arg('name')
-    def carg_name(self, *args):
-        builder = args[0]
-        return builder.name

--- a/src/pynwb/legacy/io/ophys.py
+++ b/src/pynwb/legacy/io/ophys.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from pynwb.ophys import PlaneSegmentation, ROI, TwoPhotonSeries
+from pynwb.ophys import PlaneSegmentation, TwoPhotonSeries
 
 from .. import ObjectMapper, register_map
 
@@ -11,8 +11,6 @@ class PlaneSegmentationMap(ObjectMapper):
     # This might be needed for 2.0 as well
     def __init__(self, spec):
         super(PlaneSegmentationMap, self).__init__(spec)
-        # roi_spec = self.spec.get_neurodata_type('ROI')
-        # self.map_spec('roi_list', roi_spec)
 
         reference_images_spec = self.spec.get_group('reference_images').get_neurodata_type('ImageSeries')
         self.map_spec('reference_images', reference_images_spec)

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -6,7 +6,7 @@ from .form.utils import docval, getargs, popargs, call_docval_func
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_conversion, _default_resolution
-from .core import NWBContainer, NWBDataInterface, ElementIdentifiers, VectorData, VectorIndex
+from .core import NWBContainer, NWBDataInterface, ElementIdentifiers, VectorData, VectorIndex, IndexedVector
 
 
 @register_class('AnnotationSeries', CORE_NAMESPACE)
@@ -226,19 +226,18 @@ class UnitTimes(NWBDataInterface):
         self.unit_ids = unit_ids
         self.spike_times = spike_times
         self.spike_times_index = spike_times_index
+        self.__iv = IndexedVector(self.spike_times, self.spike_times_index)
 
     @docval({'name': 'index', 'type': int,
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'})
     def get_unit_spike_times(self, **kwargs):
         index = getargs('index', kwargs)
-        return self.spike_times_index[index][:]
+        return self.__iv.get_vector(index)
 
     @docval({'name': 'unit_id', 'type': int, 'doc': 'the unit to add spike times for'},
-            {'name': 'spike_times', 'type': ('array_data',), 'doc': 'the spike times for the unit'})
+            {'name': 'spike_times', 'type': ('array_data',), 'doc': 'the spike times for the unit'},
+            rtype=int, returns="the index of the added unit in this UnitTimes")
     def add_spike_times(self, **kwargs):
         unit_id, spike_times = getargs('unit_id', 'spike_times', kwargs)
         self.unit_ids.append(unit_id)
-        ntimes = len(self.spike_times)
-        rs = get_region_slicer(self.spike_times, slice(ntimes, ntimes+len(spike_times)))
-        self.spike_times_index.append(rs)
-        self.spike_times.extend(spike_times)
+        return self.__iv.add_vector(spike_times)

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -1,7 +1,6 @@
 import numpy as np
 from collections import Iterable
 
-from .form import get_region_slicer
 from .form.utils import docval, getargs, popargs, call_docval_func
 
 from . import register_class, CORE_NAMESPACE

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -1,14 +1,13 @@
 from collections import Iterable
-from six import with_metaclass
 import numpy as np
 
-from .form.utils import docval, getargs, popargs, fmt_docval_args, call_docval_func
+from .form.utils import docval, getargs, popargs, fmt_docval_args
 from .form.data_utils import RegionSlicer, get_region_slicer
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, MultiContainerInterface, VectorData, VectorIndex, IndexedVector, NWBTable
+from .core import NWBContainer, MultiContainerInterface, VectorData, NWBTable
 
 
 @register_class('OpticalChannel', CORE_NAMESPACE)
@@ -272,14 +271,14 @@ class ImageSegmentation(MultiContainerInterface):
 
     _help = "Stores groups of pixels that define regions of interest from one or more imaging planes"
 
-    @docval({'name': 'imaging_plane', 'type': ImagingPlane,'doc': 'the ImagingPlane this ROI applies to'},
+    @docval({'name': 'imaging_plane', 'type': ImagingPlane, 'doc': 'the ImagingPlane this ROI applies to'},
             {'name': 'description', 'type': str,
              'doc': 'Description of image plane, recording wavelength, depth, etc.', 'default': None},
-            {'name': 'source', 'type': str, 'doc': 'the source of the data','default': None},
+            {'name': 'source', 'type': str, 'doc': 'the source of the data', 'default': None},
             {'name': 'name', 'type': str, 'doc': 'name of PlaneSegmentation.', 'default': None})
     def add_segmentation(self, **kwargs):
         kwargs.setdefault('source', self.source)
-        kwargs.setdefault('description', imaging_plane.description)
+        kwargs.setdefault('description', kwargs['imaging_plane'].description)
         return self.add_plane_segmentation(**kwargs)
 
 

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -113,9 +113,10 @@ class TwoPhotonSeries(ImageSeries):
              'doc': ('Name of TimeSeries or Modules that serve as the source for the data '
                      'contained here. It can also be the name of a device, for stimulus or '
                      'acquisition data')},
-            {'name': 'data', 'type': ('array_data', 'data', TimeSeries),
-             'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
             {'name': 'imaging_plane', 'type': ImagingPlane, 'doc': 'Imaging plane class/pointer.'},
+            {'name': 'data', 'type': ('array_data', 'data', TimeSeries),
+             'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames',
+             'default': None},
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)', 'default': None},
             {'name': 'format', 'type': str,
              'doc': 'Format of image. Three types: 1) Image format; tiff, png, jpg, etc. 2) external 3) raw.',

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -2,7 +2,8 @@ from collections import Iterable
 import numpy as np
 
 from .form.utils import docval, getargs, popargs, fmt_docval_args
-from .form.data_utils import RegionSlicer, get_region_slicer
+from .form.data_utils import RegionSlicer
+from .form import get_region_slicer
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -195,15 +195,11 @@ class ROI(NWBContainer):
 class PlaneSegmentation(MultiContainerInterface):
     """
     """
-    __clsconf__ = {
-        'attr': 'roi',
-        'type': ROI,
-        'add': 'add_roi',
-        'get': 'get_roi',
-        'create': 'create_roi'
-    }
 
     __nwbfields__ = ('description',
+                     'pixel_mask',
+                     'pixel_mask_index',
+                     'image_mask',
                      'imaging_plane',
                      'reference_images')
 
@@ -230,6 +226,13 @@ class PlaneSegmentation(MultiContainerInterface):
         self.roi = dict()
         for roi in roi:
             self.add_roi(roi)
+
+    @docval({'name': 'index', 'type': int,
+             'doc': 'the index of the unit in unit_ids to retrieve spike times for'})
+    def get_pixel_mask(self, **kwargs):
+        index = getargs('index', kwargs)
+        return self.pixel_mask_index[index][:]
+
 
 
 @register_class('ImageSegmentation', CORE_NAMESPACE)

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -152,8 +152,8 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
         read = self.roundtripContainer()
         row1= read.electrodes[0]
         row2= read.electrodes[1]
-        self.assertIsInstance(row1['group_ref'], ElectrodeGroup)
-        self.assertIsInstance(row2['group_ref'], ElectrodeGroup)
+        self.assertIsInstance(row1['group'], ElectrodeGroup)
+        self.assertIsInstance(row2['group'], ElectrodeGroup)
 
 class TestMultiElectricalSeries(base.TestDataInterfaceIO):
 

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -150,10 +150,11 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
 
     def test_eg_ref(self):
         read = self.roundtripContainer()
-        row1= read.electrodes[0]
-        row2= read.electrodes[1]
-        self.assertIsInstance(row1['group'], ElectrodeGroup)
-        self.assertIsInstance(row2['group'], ElectrodeGroup)
+        row1 = read.electrodes[0]
+        row2 = read.electrodes[1]
+        self.assertIsInstance(row1['group'], ElectrodeGroup)  # noqa: F405
+        self.assertIsInstance(row2['group'], ElectrodeGroup)  # noqa: F405
+
 
 class TestMultiElectricalSeries(base.TestDataInterfaceIO):
 
@@ -223,7 +224,6 @@ class TestMultiElectricalSeries(base.TestDataInterfaceIO):
         nwbfile.add_electrode_group(self.group)
         nwbfile.set_electrode_table(self.table)
         nwbfile.add_acquisition(self.container)
-
 
     def setUpContainer(self):
         raise unittest.SkipTest('Cannot run test unless addContainer is implemented')

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -146,6 +146,10 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
         nwbfile.set_electrode_table(self.table)
         nwbfile.add_acquisition(self.container)
 
+    def test_eg_ref(self):
+        read = self.roundtripContainer()
+        import pdb
+        pdb.set_trace()
 
 class TestMultiElectricalSeries(TestElectricalSeriesIO):
 

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -2,7 +2,7 @@ import unittest2 as unittest
 
 import numpy as np
 
-from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder
+from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder, ReferenceBuilder
 
 from pynwb.ecephys import *  # noqa: F403
 from pynwb.misc import UnitTimes
@@ -102,7 +102,33 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
 
     @staticmethod
     def get_table_builder(self):
-        return DatasetBuilder('electrodes', self.table.data,
+        self.device_builder = GroupBuilder('dev1',
+                                           attributes={'neurodata_type': 'Device',
+                                                       'namespace': 'core',
+                                                       'help': 'A recording device e.g. amplifier',
+                                                       'source': 'a test source'})
+        self.eg_builder = GroupBuilder('tetrode1',
+                                       attributes={'neurodata_type': 'ElectrodeGroup',
+                                                   'namespace': 'core',
+                                                   'help': 'A physical grouping of channels',
+                                                   'description': 'tetrode description',
+                                                   'location': 'tetrode location',
+                                                   'source': 'a test source'},
+                                       links={
+                                           'device': LinkBuilder('device', self.device_builder)
+                                       })
+
+        data = [
+            (1, 1.0, 2.0, 3.0, -1.0, 'CA1', 'none', 'first channel of tetrode',
+             ReferenceBuilder(self.eg_builder), 'tetrode1'),
+            (2, 1.0, 2.0, 3.0, -2.0, 'CA1', 'none', 'second channel of tetrode',
+             ReferenceBuilder(self.eg_builder), 'tetrode1'),
+            (3, 1.0, 2.0, 3.0, -3.0, 'CA1', 'none', 'third channel of tetrode',
+             ReferenceBuilder(self.eg_builder), 'tetrode1'),
+            (4, 1.0, 2.0, 3.0, -4.0, 'CA1', 'none', 'fourth channel of tetrode',
+             ReferenceBuilder(self.eg_builder), 'tetrode1')
+        ]
+        return DatasetBuilder('electrodes', data,
                               attributes={'neurodata_type': 'ElectrodeTable',
                                           'namespace': 'core',
                                           'help': 'a table for storing data about extracellular electrodes'})

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -89,6 +89,7 @@ class TestElectrodeGroupIO(base.TestMapRoundTrip):
 
 class TestElectricalSeriesIO(base.TestDataInterfaceIO):
 
+    @staticmethod
     def make_electrode_table(self):
         self.table = ElectrodeTable('electrodes')  # noqa: F405
         self.dev1 = Device('dev1', 'a test source')  # noqa: F405
@@ -99,6 +100,7 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
         self.table.add_row(3, 1.0, 2.0, 3.0, -3.0, 'CA1', 'none', 'third channel of tetrode', self.group)
         self.table.add_row(4, 1.0, 2.0, 3.0, -4.0, 'CA1', 'none', 'fourth channel of tetrode', self.group)
 
+    @staticmethod
     def get_table_builder(self):
         return DatasetBuilder('electrodes', self.table.data,
                               attributes={'neurodata_type': 'ElectrodeTable',
@@ -106,7 +108,7 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
                                           'help': 'a table for storing data about extracellular electrodes'})
 
     def setUpContainer(self):
-        self.make_electrode_table()
+        self.make_electrode_table(self)
         region = ElectrodeTableRegion(self.table, [0, 2], 'the first and third electrodes')  # noqa: F405
         data = list(zip(range(10), range(10, 20)))
         timestamps = list(map(lambda x: x/10, range(10)))
@@ -114,7 +116,7 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
         return ret
 
     def setUpBuilder(self):
-        table_builder = self.get_table_builder()
+        table_builder = self.get_table_builder(self)
         data = list(zip(range(10), range(10, 20)))
         timestamps = list(map(lambda x: x/10, range(10)))
         return GroupBuilder('test_eS',
@@ -148,13 +150,15 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
 
     def test_eg_ref(self):
         read = self.roundtripContainer()
-        import pdb
-        pdb.set_trace()
+        row1= read.electrodes[0]
+        row2= read.electrodes[1]
+        self.assertIsInstance(row1['group_ref'], ElectrodeGroup)
+        self.assertIsInstance(row2['group_ref'], ElectrodeGroup)
 
-class TestMultiElectricalSeries(TestElectricalSeriesIO):
+class TestMultiElectricalSeries(base.TestDataInterfaceIO):
 
     def setUpElectricalSeriesContainers(self):
-        self.make_electrode_table()
+        TestElectricalSeriesIO.make_electrode_table(self)
         region1 = ElectrodeTableRegion(self.table, [0, 2], 'the first and third electrodes')  # noqa: F405
         region2 = ElectrodeTableRegion(self.table, [1, 3], 'the second and fourth electrodes')  # noqa: F405
         data1 = list(zip(range(10), range(10, 20)))
@@ -165,7 +169,7 @@ class TestMultiElectricalSeries(TestElectricalSeriesIO):
         return (es1, es2)
 
     def setUpElectricalSeriesBuilders(self):
-        table_builder = self.get_table_builder()
+        table_builder = TestElectricalSeriesIO.get_table_builder(self)
         data = list(zip(range(10), range(10, 20)))
         timestamps = list(map(lambda x: x/10, range(10)))
         es1 = GroupBuilder('test_eS1',
@@ -212,6 +216,14 @@ class TestMultiElectricalSeries(TestElectricalSeriesIO):
                                                                       'description': 'the second and fourth electrodes',
                                                                       'help': 'a subset (i.e. slice or region) of an ElectrodeTable'})})  # noqa: E501
         return (es1, es2)
+
+    def addContainer(self, nwbfile):
+        ''' Should take an NWBFile object and add the container to it '''
+        nwbfile.add_device(self.dev1)
+        nwbfile.add_electrode_group(self.group)
+        nwbfile.set_electrode_table(self.table)
+        nwbfile.add_acquisition(self.container)
+
 
     def setUpContainer(self):
         raise unittest.SkipTest('Cannot run test unless addContainer is implemented')

--- a/tests/integration/ui_write/test_legacy.py
+++ b/tests/integration/ui_write/test_legacy.py
@@ -10,6 +10,7 @@ class TestLegacy(unittest.TestCase):
     def setUp(self):
         self.src_filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), '496908818s.nwb')
         self.filename = 'test_496908818s.nwb'
+        raise unittest.SkipTest('Backwards compatibility not currently supported')
 
     def tearDown(self):
         if os.path.exists(self.filename):

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -1,10 +1,16 @@
-from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder
+from copy import deepcopy
+
+from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder
 
 from pynwb.ophys import (
     ImagingPlane,
     OpticalChannel,
+    PlaneSegmentation,
+    ImageSegmentation,
     TwoPhotonSeries
 )
+
+from pynwb.image import ImageSeries
 
 from . import base
 
@@ -144,3 +150,150 @@ class TestTwoPhotonSeries(base.TestDataInterfaceIO):
         """Should take an NWBFile object and add the container to it"""
         nwbfile.add_imaging_plane(self.imaging_plane)
         nwbfile.add_acquisition(self.container)
+
+
+class TestPlaneSegmentation(base.TestMapRoundTrip):
+
+    @staticmethod
+    def buildPlaneSegmentation(self):
+        w, h = 5, 5
+        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
+        pix_mask = [(1, 2, 1.0), (3, 4, 1.0), (5, 6, 1.0),
+                    (7, 8, 2.0), (9, 10, 2.)]
+
+        self.image_series = ImageSeries(name='test_iS', source='a hypothetical source', dimension=[2],
+                                        external_file=['images.tiff'],
+                                        starting_frame=[1, 2, 3], format='tiff', timestamps=list())
+
+        self.optical_channel = OpticalChannel('test_optical_channel', 'optical channel source',
+                                              'optical channel description', '3.14')
+        self.imaging_plane = ImagingPlane('test_imaging_plane',
+                                          'ophys integration tests',
+                                          self.optical_channel,
+                                          'imaging plane description',
+                                          'imaging_device_1',
+                                          '6.28', '2.718', 'GFP', 'somewhere in the brain',
+                                          (1, 2, 1, 2, 3), 4.0, 'manifold unit', 'A frame to refer to')
+
+        self.img_mask = deepcopy(img_mask)
+        self.pix_mask = deepcopy(pix_mask)
+        pS = PlaneSegmentation('integration test PlaneSegmentation', 'plane segmentation description',
+                               self.imaging_plane, 'test_plane_seg_name', self.image_series)
+        pS.add_roi(pix_mask[0:3], img_mask[0])
+        pS.add_roi(pix_mask[3:5], img_mask[1])
+        return pS
+
+    @staticmethod
+    def get_plane_segmentation_builder(self):
+        self.optchan_builder = GroupBuilder(
+            'test_optical_channel',
+            attributes={
+                'neurodata_type': 'OpticalChannel',
+                'namespace': 'core',
+                'help': 'Metadata about an optical channel used to record from an imaging plane',
+                'source': 'optical channel source'},
+            datasets={
+                'description': DatasetBuilder('description', 'optical channel description'),
+                'emission_lambda': DatasetBuilder('emission_lambda', '3.14')},
+        )
+        self.imgpln_builder = GroupBuilder(
+            'imgpln1',
+            attributes={
+                'neurodata_type': 'ImagingPlane',
+                'namespace': 'core',
+                'source': 'ophys integration tests',
+                'help': 'Metadata about an imaging plane'},
+            datasets={
+                'description': DatasetBuilder('description', 'imaging plane description'),
+                'device': DatasetBuilder('device', 'imaging_device_1'),
+                'excitation_lambda': DatasetBuilder('excitation_lambda', '6.28'),
+                'imaging_rate': DatasetBuilder('imaging_rate', '2.718'),
+                'indicator': DatasetBuilder('indicator', 'GFP'),
+                'manifold': DatasetBuilder('manifold', (1, 2, 1, 2, 3),
+                                           attributes={'conversion': 4.0, 'unit': 'manifold unit'}),
+                'reference_frame': DatasetBuilder('reference_frame', 'A frame to refer to'),
+                'location': DatasetBuilder('location', 'somewhere in the brain')},
+            groups={
+                'optchan1': self.optchan_builder
+            }
+        )
+        self.is_builder = GroupBuilder('test_iS',
+                                       attributes={'source': 'a hypothetical source',
+                                                   'namespace': 'core',
+                                                   'neurodata_type': 'ImageSeries',
+                                                   'description': 'no description',
+                                                   'comments': 'no comments',
+                                                   'help': 'Storage object for time-series 2-D image data'},
+                                       datasets={'timestamps': DatasetBuilder('timestamps', [],
+                                                                              attributes={'unit': 'Seconds',
+                                                                                          'interval': 1}),
+                                                 'external_file': DatasetBuilder('external_file', ['images.tiff'],
+                                                                                 attributes={
+                                                                                    'starting_frame': [1, 2, 3]}),
+                                                 'format': DatasetBuilder('format', 'tiff'),
+                                                 'dimension': DatasetBuilder('dimension', [2]),
+                                                 })
+
+        self.pixel_masks_builder = DatasetBuilder('pixel_masks', self.pix_mask,
+                                                  attributes={
+                                                   'namespace': 'core',
+                                                   'neurodata_type': 'PixelMasks',
+                                                   'help': 'a concatenated array of pixel masks'})
+
+        self.image_masks_builder = DatasetBuilder('image_masks', self.img_mask,
+                                                  attributes={
+                                                   'namespace': 'core',
+                                                   'neurodata_type': 'ImageMasks',
+                                                   'help': 'an array of image masks'})
+
+        self.rois_builder = DatasetBuilder('rois', [
+                                            (RegionBuilder(slice(0, 3), self.pixel_masks_builder),
+                                             RegionBuilder([0], self.image_masks_builder)),
+                                            (RegionBuilder(slice(3, 5), self.pixel_masks_builder),
+                                             RegionBuilder([1], self.image_masks_builder))
+                                        ],
+                                        attributes={
+                                         'namespace': 'core',
+                                         'neurodata_type': 'ROITable',
+                                         'help': 'A table for storing ROI data'})
+        ps_builder = GroupBuilder(
+            'test_plane_seg_name',
+            attributes={
+                'neurodata_type': 'PlaneSegmentation',
+                'namespace': 'core',
+                'source': 'integration test PlaneSegmentation',
+                'help': 'Results from segmentation of an imaging plane'},
+            datasets={
+                'description': DatasetBuilder('description', 'plane segmentation description'),
+                'rois': self.rois_builder,
+                'pixel_masks': self.pixel_masks_builder,
+                'image_masks': self.image_masks_builder,
+            },
+            groups={
+                'reference_images': GroupBuilder('reference_images', groups={'test_iS': self.is_builder}),
+            },
+            links={
+                'imaging_plane': LinkBuilder('imaging_plane', self.imgpln_builder)
+            }
+        )
+        return ps_builder
+
+    def setUpContainer(self):
+        return self.buildPlaneSegmentation(self)
+
+    def setUpBuilder(self):
+        return self.get_plane_segmentation_builder(self)
+
+    def addContainer(self, nwbfile):
+        nwbfile.add_imaging_plane(self.imaging_plane)
+        img_seg = ImageSegmentation('plane segmentation round trip')
+        img_seg.add_plane_segmentation(self.container)
+        mod = nwbfile.create_processing_module('plane_seg_test_module',
+                                               'plane segmentation round trip',
+                                               'a plain module for testing')
+        mod.add_data_interface(img_seg)
+
+    def getContainer(self, nwbfile):
+        mod = nwbfile.get_processing_module('plane_seg_test_module')
+        img_seg = mod.get_container('ImageSegmentation')
+        return img_seg.get_plane_segmentation('test_plane_seg_name')

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -81,7 +81,7 @@ class TestTwoPhotonSeries(base.TestDataInterfaceIO):
         timestamps = list(map(lambda x: x/10, range(10)))
         fov = [2.0, 2.0, 5.0]
         ret = TwoPhotonSeries('test_2ps', 'unit test TestTwoPhotonSeries',
-                              data, self.imaging_plane, 'image_unit', 'raw', fov, 1.7, 3.4,
+                              self.imaging_plane, data, 'image_unit', 'raw', fov, 1.7, 3.4,
                               timestamps=timestamps, dimension=[2])
         return ret
 

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -66,12 +66,13 @@ class RoiResponseSeriesConstructor(unittest.TestCase):
         ip = CreatePlaneSegmentation()
         iS = ImageSegmentation('test source', ip, name='test_iS')
 
-        ts = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', ['name1'], iS, timestamps=list())
+        rt_region = ip.create_roi_table_region([1], 'the second ROI')
+
+        ts = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', rt_region, timestamps=list())
         self.assertEqual(ts.name, 'test_ts')
         self.assertEqual(ts.source, 'a hypothetical source')
         self.assertEqual(ts.unit, 'unit')
-        self.assertEqual(ts.roi_names, ['name1'])
-        self.assertEqual(ts.segmentation_interface, iS)
+        self.assertEqual(ts.rois, rt_region)
 
 
 class DfOverFConstructor(unittest.TestCase):
@@ -79,7 +80,9 @@ class DfOverFConstructor(unittest.TestCase):
         ip = CreatePlaneSegmentation()
         iS = ImageSegmentation('test source', ip, name='test_iS')
 
-        rrs = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', ['name1'], iS, timestamps=list())
+        rt_region = ip.create_roi_table_region([1], 'the second ROI')
+
+        rrs = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', rt_region, timestamps=list())
 
         dof = DfOverF('test_dof', rrs)
         self.assertEqual(dof.source, 'test_dof')
@@ -91,7 +94,9 @@ class FluorescenceConstructor(unittest.TestCase):
         ip = CreatePlaneSegmentation()
         iS = ImageSegmentation('test source', ip, name='test_iS')
 
-        ts = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', ['name1'], iS, timestamps=list())
+        rt_region = ip.create_roi_table_region([1], 'the second ROI')
+
+        ts = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', rt_region, timestamps=list())
 
         ff = Fluorescence('test_ff', ts)
         self.assertEqual(ff.source, 'test_ff')
@@ -134,8 +139,8 @@ class PlaneSegmentationConstructor(unittest.TestCase):
 
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, iSS)
-        self.assertEqual(pS.pixel_mask, pix_mask)
-        self.assertEqual(pS.image_mask, img_mask)
+        self.assertEqual(pS.pixel_masks, pix_mask)
+        self.assertEqual(pS.image_masks, img_mask)
 
 
 if __name__ == '__main__':

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -1,7 +1,7 @@
 import unittest
 
 from pynwb.ophys import TwoPhotonSeries, RoiResponseSeries, DfOverF, Fluorescence, PlaneSegmentation, \
-    ImageSegmentation, OpticalChannel, ImagingPlane, ROITable
+    ImageSegmentation, OpticalChannel, ImagingPlane
 from pynwb.image import ImageSeries
 
 import numpy as np
@@ -11,7 +11,7 @@ def CreatePlaneSegmentation():
     w, h = 5, 5
     img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
     pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
-                [7, 8, 2.0],[9, 10, 2.0]]
+                [7, 8, 2.0], [9, 10, 2.0]]
 
     iSS = ImageSeries(name='test_iS', source='a hypothetical source', data=list(), unit='unit',
                       external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -9,25 +9,20 @@ import numpy as np
 
 def CreatePlaneSegmentation():
     w, h = 5, 5
-    img_mask = [[0 for x in range(w)] for y in range(h)]
-    w, h = 5, 2
-    pix_mask = [[0 for x in range(w)] for y in range(h)]
-    pix_mask_weight = [0 for x in range(w)]
-    iSS = ImageSeries(
-        name='test_iS', source='a hypothetical source', data=list(), unit='unit', external_file=['external_file'],
-        starting_frame=[1, 2, 3], format='tiff', timestamps=list())
+    img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
+    pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
+                [7, 8, 2.0],[9, 10, 2.0]]
+    pix_mask_index = [slice(0,3), slice(3,5)]
 
-    roi1 = ROI('roi1', 'test source', 'roi description1', pix_mask, pix_mask_weight, img_mask, iSS)
-    roi2 = ROI('roi2', 'test source', 'roi description2', pix_mask, pix_mask_weight, img_mask, iSS)
-    roi_list = (roi1, roi2)
+    iSS = ImageSeries(name='test_iS', source='a hypothetical source', data=list(), unit='unit',
+                      external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())
 
     oc = OpticalChannel('test_optical_channel', 'test_source', 'description', 'emission_lambda')
-    ip = ImagingPlane(
-        'test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
-        'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
+    ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
+                      'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-    ps = PlaneSegmentation('test source', 'description', ip, 'name', roi_list, iSS)
-    return ps
+    pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS, pix_mask, pix_mask_index, img_mask)
+    return pS
 
 
 class TwoPhotonSeriesConstructor(unittest.TestCase):
@@ -106,59 +101,40 @@ class FluorescenceConstructor(unittest.TestCase):
 class ImageSegmentationConstructor(unittest.TestCase):
 
     def test_init(self):
-        w, h = 5, 5
-        img_mask = [[0 for x in range(w)] for y in range(h)]
-        w, h = 5, 2
-        pix_mask = [[0 for x in range(w)] for y in range(h)]
-        pix_mask_weight = [0 for x in range(w)]
-        iSS = ImageSeries(
-            name='test_iS', source='a hypothetical source', data=list(), unit='unit',
-            external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())
-
-        roi1 = ROI('roi1', 'test source', 'roi description1', pix_mask, pix_mask_weight, img_mask, iSS)
-        roi2 = ROI('roi2', 'test source', 'roi description2', pix_mask, pix_mask_weight, img_mask, iSS)
-        rois = (roi1, roi2)
-
-        oc = OpticalChannel('test_optical_channel', 'test source', 'description', 'emission_lambda')
-        ip = ImagingPlane('test_imaging_plane', 'test source', oc, 'description', 'device', 'excitation_lambda',
-                          'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
-
-        ps = PlaneSegmentation('test source', 'description', ip, 'test_pS', rois, iSS)
+        ps = CreatePlaneSegmentation()
 
         iS = ImageSegmentation('test_source', ps, name='test_iS')
         self.assertEqual(iS.name, 'test_iS')
         self.assertEqual(iS.source, 'test_source')
-        self.assertEqual(iS.plane_segmentations['test_pS'], ps)
-        self.assertEqual(iS['test_pS'], iS.plane_segmentations['test_pS'])
+        self.assertEqual(iS.plane_segmentations[ps.name], ps)
+        self.assertEqual(iS[ps.name], iS.plane_segmentations[ps.name])
 
 
 class PlaneSegmentationConstructor(unittest.TestCase):
     def test_init(self):
         w, h = 5, 5
-        img_mask = [[0 for x in range(w)] for y in range(h)]
-        w, h = 5, 2
-        pix_mask = [[0 for x in range(w)] for y in range(h)]
-        pix_mask_weight = [0 for x in range(w)]
+        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
+        pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
+                    [7, 8, 2.0], [9, 10, 2.0]]
+        pix_mask_index = [slice(0,3), slice(3,5)]
+
         iSS = ImageSeries(name='test_iS', source='a hypothetical source', data=list(), unit='unit',
                           external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())
-
-        roi1 = ROI('roi1', 'test source', 'roi description1', pix_mask, pix_mask_weight, img_mask, iSS)
-        roi2 = ROI('roi2', 'test source', 'roi description2', pix_mask, pix_mask_weight, img_mask, iSS)
-        rois = {'roi1': roi1, 'roi2': roi2}
 
         oc = OpticalChannel('test_optical_channel', 'test_source', 'description', 'emission_lambda')
         ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        pS = PlaneSegmentation('test source', 'description', ip, 'test_name', rois.values(), iSS)
+        pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS, pix_mask, pix_mask_index, img_mask)
+
         self.assertEqual(pS.description, 'description')
         self.assertEqual(pS.source, 'test source')
-        self.assertEqual(pS.roi, rois)
+
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, iSS)
-        self.assertEqual(pS.get_roi('roi1'), roi1)
-        self.assertEqual(pS.get_roi('roi1'), pS.roi['roi1'])
-        self.assertEqual(pS.get_roi('roi1'), pS['roi1'])
+        self.assertEqual(pS.pixel_mask.data, pix_mask)
+        self.assertEqual(pS.pixel_mask_index.data, pix_mask_index)
+        self.assertEqual(pS.image_mask, img_mask)
 
 
 if __name__ == '__main__':

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -1,7 +1,7 @@
 import unittest
 
 from pynwb.ophys import TwoPhotonSeries, RoiResponseSeries, DfOverF, Fluorescence, PlaneSegmentation, \
-    ImageSegmentation, OpticalChannel, ImagingPlane, ROI
+    ImageSegmentation, OpticalChannel, ImagingPlane, ROITable
 from pynwb.image import ImageSeries
 
 import numpy as np
@@ -12,7 +12,6 @@ def CreatePlaneSegmentation():
     img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
     pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
                 [7, 8, 2.0],[9, 10, 2.0]]
-    pix_mask_index = [slice(0,3), slice(3,5)]
 
     iSS = ImageSeries(name='test_iS', source='a hypothetical source', data=list(), unit='unit',
                       external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())
@@ -21,7 +20,9 @@ def CreatePlaneSegmentation():
     ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
                       'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-    pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS, pix_mask, pix_mask_index, img_mask)
+    pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
+    pS.add_roi(pix_mask[0:3], img_mask[0])
+    pS.add_roi(pix_mask[3:5], img_mask[1])
     return pS
 
 
@@ -116,7 +117,6 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
         pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
                     [7, 8, 2.0], [9, 10, 2.0]]
-        pix_mask_index = [slice(0,3), slice(3,5)]
 
         iSS = ImageSeries(name='test_iS', source='a hypothetical source', data=list(), unit='unit',
                           external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())
@@ -125,15 +125,16 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', 'device', 'excitation_lambda',
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
-        pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS, pix_mask, pix_mask_index, img_mask)
+        pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
+        pS.add_roi(pix_mask[0:3], img_mask[0])
+        pS.add_roi(pix_mask[3:5], img_mask[1])
 
         self.assertEqual(pS.description, 'description')
         self.assertEqual(pS.source, 'test source')
 
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, iSS)
-        self.assertEqual(pS.pixel_mask.data, pix_mask)
-        self.assertEqual(pS.pixel_mask_index.data, pix_mask_index)
+        self.assertEqual(pS.pixel_mask, pix_mask)
         self.assertEqual(pS.image_mask, img_mask)
 
 

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -64,7 +64,6 @@ class TwoPhotonSeriesConstructor(unittest.TestCase):
 class RoiResponseSeriesConstructor(unittest.TestCase):
     def test_init(self):
         ip = CreatePlaneSegmentation()
-        iS = ImageSegmentation('test source', ip, name='test_iS')
 
         rt_region = ip.create_roi_table_region([1], 'the second ROI')
 
@@ -78,7 +77,6 @@ class RoiResponseSeriesConstructor(unittest.TestCase):
 class DfOverFConstructor(unittest.TestCase):
     def test_init(self):
         ip = CreatePlaneSegmentation()
-        iS = ImageSegmentation('test source', ip, name='test_iS')
 
         rt_region = ip.create_roi_table_region([1], 'the second ROI')
 
@@ -92,7 +90,6 @@ class DfOverFConstructor(unittest.TestCase):
 class FluorescenceConstructor(unittest.TestCase):
     def test_init(self):
         ip = CreatePlaneSegmentation()
-        iS = ImageSegmentation('test source', ip, name='test_iS')
 
         rt_region = ip.create_roi_table_region([1], 'the second ROI')
 
@@ -139,8 +136,8 @@ class PlaneSegmentationConstructor(unittest.TestCase):
 
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, iSS)
-        self.assertEqual(pS.pixel_masks, pix_mask)
-        self.assertEqual(pS.image_masks, img_mask)
+        self.assertEqual(pS.pixel_masks.data, pix_mask)
+        self.assertEqual(pS.image_masks.data, img_mask)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

ROIs were structured inefficiently and difficult to use.

## How to test the behavior?
See docs/code/write-read-ophys.py
(This also demonstrates some read functionality)
```python
# create your NWBFile object
nwbfile = NWBFile(...)

# create acquisition metadata
optical_channel = OpticalChannel('test_optical_channel', 'optical channel source',
                                 'optical channel description', '3.14')
imaging_plane = nwbfile.create_imaging_plane('test_imaging_plane',
                                             'ophys integration tests',
                                             optical_channel,
                                             'imaging plane description',
                                             'imaging_device_1',
                                             '6.28', '2.718', 'GFP', 'somewhere in the brain',
                                             (1, 2, 1, 2, 3), 4.0, 'manifold unit', 'A frame to refer to')

# create acquisition data
image_series = TwoPhotonSeries(name='test_iS', source='a hypothetical source', dimension=[2],
                               external_file=['images.tiff'], imaging_plane=imaging_plane,
                               starting_frame=[1, 2, 3], format='tiff', timestamps=list())
nwbfile.add_acquisition(image_series)


mod = nwbfile.create_processing_module('img_seg_example', 'ophys demo', 'an example of writing Ca2+ imaging data')
img_seg = ImageSegmentation('a toy image segmentation container')
mod.add_data_interface(img_seg)
ps = img_seg.create_plane_segmentation('integration test PlaneSegmentation', 'plane segmentation description',
                                       imaging_plane, 'test_plane_seg_name', image_series)
# add two ROIs
# - first argument is the pixel mask i.e. a list of pixels and their weights
# - second argument is the image mask
w, h = 3, 3
pix_mask1 = [(0, 0, 1.1), (1, 1, 1.2), (2, 2, 1.3)]
img_mask1 = [[0.0 for x in range(w)] for y in range(h)]
img_mask1[0][0] = 1.1
img_mask1[1][1] = 1.2
img_mask1[2][2] = 1.3
ps.add_roi(pix_mask1, img_mask1)

pix_mask2 = [(0, 0, 2.1), (1, 1, 2.2)]
img_mask2 = [[0.0 for x in range(w)] for y in range(h)]
img_mask2[0][0] = 2.1
img_mask2[1][1] = 2.2
ps.add_roi(pix_mask2, img_mask2)

# add a Fluorescence container
fl = Fluorescence('a toy fluorescence container')
mod.add_data_interface(fl)
# get an ROI table region i.e. a subset of ROIs to create a RoiResponseSeries from
rt_region = ps.create_roi_table_region([0], 'the first of two ROIs')
# make some fake timeseries data
data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
timestamps = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
rrs = fl.create_roi_response_series('test_roi_response_series', 'RoiResponseSeries integration test',
                                    data, 'lumens', rt_region, timestamps=timestamps)
# write data
with NWBHDF5IO(nwb_path, 'w') as io:
    io.write(nwbfile)

# read data back in
io = NWBHDF5IO(nwb_path, 'r')
nwbfile = io.read()

# get the processing module
mod = nwbfile.get_processing_module('img_seg_example')

# get the PlaneSegmentation from the ImageSegmentation data interface
ps = mod['ImageSegmentation'].get_plane_segmentation()
img_mask1 = ps.get_image_mask(0)
pix_mask1 = ps.get_pixel_mask(0)
img_mask2 = ps.get_image_mask(1)
pix_mask2 = ps.get_pixel_mask(1)

# get the RoiResponseSeries from the Fluorescence data interface
rrs = mod['Fluorescence'].get_roi_response_series()
# get the data...
rrs_data = rrs.data
rrs_timestamps = rrs.timestamps
# and now do something cool!
```


## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
