### PR TITLE
Fix links in CONTRIBUTING.RST

### DIFF
--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -146,7 +146,7 @@ Python Code Styleguide
 Licence and Copyright
 =======================
 
-See the `Readme <../Readme.rst>`_ and correspoding `licence <../licence.txt>`_ files for details about the copyright and licence.
+See the `Readme <https://github.com/NeurodataWithoutBorders/pynwb#contributing>`_ and correspoding `licence <https://raw.githubusercontent.com/NeurodataWithoutBorders/pynwb/dev/license.txt>`_ files for details about the copyright and licence.
 
 
 


### PR DESCRIPTION
Changed relative links to PYNWB's Readme.rst and licence.txt with absolute URLs to make sure the links are working in the PyNWB docs on ReadTheDocs

## Motivation

Links were broken on ReadTheDocs

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
