### PR TITLE
Fix readthedocs, document conf.py

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -24,10 +24,11 @@ from pynwb._version import get_versions
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
 
+# -- Autodoc configuration -----------------------------------------------------
+
 autoclass_content = 'both'
 autodoc_docstring_signature = True
 autodoc_member_order = 'bysource'
-add_function_parentheses = False
 
 # -- General configuration -----------------------------------------------------
 
@@ -94,7 +95,7 @@ exclude_patterns = ['_build', 'test.py']
 # default_role = None
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
-# add_function_parentheses = True
+add_function_parentheses = False
 
 # If true, the current module name will be prepended to all description
 # unit titles (such as .. function::).
@@ -269,6 +270,12 @@ latex_elements = {
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 # texinfo_show_urls = 'footnote'
 
+
+# -- PyNWB sphinx extension ----------------------------------------------------
+
+#
+# see http://www.sphinx-doc.org/en/master/extdev/appapi.html
+#
 
 def run_apidoc(_):
     from sphinx.apidoc import main

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,13 +16,26 @@ import sys
 import os
 import sphinx_rtd_theme
 from sphinx.domains.python import PythonDomain
-from pynwb._version import get_versions
 
+
+# -- Support building doc without install --------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 # sys.path.insert(0, os.path.abspath('.'))
+
+# Get the project root dir, which is the parent parent dir of this
+cwd = os.getcwd()
+project_root = os.path.dirname(os.path.dirname(cwd))
+
+# Insert the project root dir as the first element in the PYTHONPATH.
+# This lets us ensure that the source package is imported, and that its
+# version is used.
+sys.path.insert(0, os.path.join(project_root, 'src'))
+
+from pynwb._version import get_versions
+
 
 # -- Autodoc configuration -----------------------------------------------------
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ chardet==3.0.4
 h5py==2.7.1
 idna==2.6
 numpy==1.14.0
-python-dateutil==2.6.1
+python-dateutil==2.7.0
 requests==2.18.4
 ruamel.yaml==0.15.35
 six==1.11.0


### PR DESCRIPTION
Also fix support for building documentation without installing pynwb.
Building the documentation is now possible doing:

```
pip install -r requirements-doc.txt
make htmldoc
```