### PR TITLE
gitignore: Exclude docs/source/tutorials/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ docs/notebooks/boc/
 docs/source/pynwb*.rst
 docs/source/modules.rst
 
+# Auto-generated tutorials
+docs/source/tutorials/
+
 ### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
This commit excludes files generated by building the documentation
following the integration of sphinx gallery feature in eb8bf1d