### PR TITLE
Add sphinx_gallery prototyping code resolves #414

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ run-style-check: &run-style-check
 initialize-venv: &initialize-venv
   name: Initialize Virtual Environment
   command: |
+    sudo apt-get install python2.7-dev
     python -m virtualenv ../venv || python -m venv ../venv
     . ../venv/bin/activate
 
@@ -66,6 +67,9 @@ conda-steps: &conda-steps
     - run:
         name: Configure conda
         command: |
+          apt-get update -y
+          apt-get upgrade -y
+          apt-get install -y build-essential
           conda config --set always_yes yes --set changeps1 no
           conda config --add channels conda-forge
           conda install virtualenv
@@ -125,6 +129,12 @@ jobs:
       - TEST_TOX_ENV: "py27"
       - BUILD_TOX_ENV: "build-py27"
     <<: *conda-steps
+    steps:
+      - checkout
+      - run:
+          name: Add subprocess32
+          command: |
+            conda install subprocess32
 
   miniconda35:
     docker:

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,6 +1,4 @@
-sphinx==1.6.5
 matplotlib
 pillow
-sphinx_rtd_theme
-sphinx-gallery
+
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,8 @@ requests==2.18.4
 ruamel.yaml==0.15.35
 six==1.11.0
 urllib3==1.22
+sphinx==1.6.5
+sphinx-gallery==0.1.13
+sphinx_rtd_theme==0.2.4
+matplotlib==2.2.2
+pillow==5.1.0

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,12 @@ setup_args = {
         'ruamel.yaml',
         'python-dateutil',
         'six',
-        'requests'
+        'requests',
+        'sphinx==1.6.5',
+        'sphinx-gallery',
+        'sphinx_rtd_theme',
+        'matplotlib',
+        'pillow'
     ],
     'packages': pkgs,
     'package_dir': {'': 'src'},

--- a/src/pynwb/docutils/sg_prototype.py
+++ b/src/pynwb/docutils/sg_prototype.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+
+"""Top-level package for sg-prototype.
+
+Example usage:
+from pynwb.docutils.sg_prototype import  build
+build('/Users/nicholasc/projects/pynwb/issues/414/helloworld.py', conda_env='pynwb')
+
+"""
+
+import tempfile
+import os
+import subprocess
+import shutil
+from sys import platform as _platform
+
+__author__ = """Nicholas Cain"""
+__email__ = 'nicholasc@alleninstitute.org'
+__version__ = '0.1.0'
+
+OPEN_DEFAULT = False
+TGT_DIR_DEFAULT_SUFFIX = os.path.abspath('_html_sg-prototype')
+TGT_DIR_DEFAULT = os.path.abspath(os.path.join('.', TGT_DIR_DEFAULT_SUFFIX))
+
+
+def assert_firefox():
+
+    try:
+        subprocess.check_output(['firefox', '--version'])
+        return True
+    except Exception as e:
+        return False
+
+
+def check_tgt_dir(tgt_dir):
+    if os.path.exists(tgt_dir):
+        raise RuntimeError('Target directory %s already exists; specify different directory \
+                            (-o or --output) or remove' % tgt_dir)
+
+
+def build(src_file, tgt_dir=TGT_DIR_DEFAULT, open_html=OPEN_DEFAULT, conda_env=None):
+
+    # Get temporary build dir, and make html using template:
+    temp_dir = tempfile.mkdtemp()
+    template_loc = 'https://github.com/nicain/sg-template.git'
+
+    err_code = subprocess.call('git clone %s %s' % (template_loc, temp_dir), shell=True)
+    assert err_code == 0
+
+    # remove the template example, and replace with user-supplied file
+    if src_file is not None:
+        os.remove(os.path.join(temp_dir, 'docs', 'gallery', 'helloworld.py'))
+        shutil.copy(src_file, os.path.join(temp_dir, 'docs', 'gallery', os.path.basename(src_file)))
+
+    print(os.path.join(temp_dir, 'docs'))
+    if conda_env is None:
+        err_code = subprocess.call('cd %s && make html' % os.path.join(temp_dir, 'docs'), shell=True)
+    else:
+        err_code = subprocess.call('source activate %s && \
+                                    cd %s && make html' % (conda_env, os.path.join(temp_dir, 'docs')), shell=True)
+    assert err_code == 0
+
+    # Move built html to tgt_dir:
+    check_tgt_dir(tgt_dir)
+    shutil.move(os.path.join(temp_dir, 'docs', '_build', 'html'), tgt_dir)
+
+    # Grab out generated example file:
+    if src_file is not None:
+        infile_slug = os.path.basename(src_file).split('.')[0]
+    else:
+        infile_slug = 'helloworld'
+    fname_slug = '%s.html' % infile_slug
+    output_file = os.path.join(tgt_dir, 'tutorials', fname_slug)
+    if not os.path.exists(output_file):
+        raise RuntimeError('File generation failed')
+    print('Output file generated: %s' % output_file)
+
+    # Open or print file:
+    if open_html is True:
+        if _platform == "linux" or _platform == "linux2":
+            if assert_firefox():
+                open_command = 'firefox %s' % output_file
+            else:
+                raise NotImplementedError
+        elif _platform == "darwin":
+            open_command = 'open %s' % output_file
+        elif _platform == "win32":
+            raise NotImplementedError
+        elif _platform == "win64":
+            raise NotImplementedError
+        else:
+            raise NotImplementedError
+        subprocess.call(open_command, shell=True)
+
+    else:
+
+        pass
+
+    return 0

--- a/tests/unit/pynwb_tests/test_docutils.py
+++ b/tests/unit/pynwb_tests/test_docutils.py
@@ -1,0 +1,22 @@
+import unittest
+import shutil
+import os
+
+from pynwb.docutils.sg_prototype import build
+
+
+class DocUtils(unittest.TestCase):
+
+    def setUp(self):
+
+        TGT_DIR_SUFFIX = os.path.abspath('_html_sg-prototype_TEST')
+        TGT_DIR = os.path.abspath(os.path.join(__file__, TGT_DIR_SUFFIX))
+
+        self.test_dir = TGT_DIR
+
+    def test_sg_build(self):
+
+        build(None, tgt_dir=self.test_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)


### PR DESCRIPTION
## Motivation

This PR provides a folder "docutils" that can contain utility code useful for generating documentation and examples.  This folder contains a file called sg_prototype, whose build method can be handed a sphinx_gallery example file which can then be build and viewed in a web browser, without building all documentation.

## How to test the behavior?
A test file is included at: pynwb/tests/unit/pynwb_tests/test_docutils.py

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
