### PR TITLE
Add name to ROITable

### DIFF
--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -104,13 +104,13 @@ img_mask1 = [[0.0 for x in range(w)] for y in range(h)]
 img_mask1[0][0] = 1.1
 img_mask1[1][1] = 1.2
 img_mask1[2][2] = 1.3
-ps.add_roi(pix_mask1, img_mask1)
+ps.add_roi('1234', pix_mask1, img_mask1)
 
 pix_mask2 = [(0, 0, 2.1), (1, 1, 2.2)]
 img_mask2 = [[0.0 for x in range(w)] for y in range(h)]
 img_mask2[0][0] = 2.1
 img_mask2[1][1] = 2.2
-ps.add_roi(pix_mask2, img_mask2)
+ps.add_roi('5678', pix_mask2, img_mask2)
 
 
 ####################
@@ -136,8 +136,15 @@ mod.add_data_interface(fl)
 # created with :py:func:`~pynwb.ophys.PlaneSegmentation.create_roi_table_region`.
 
 
-rt_region = ps.create_roi_table_region([0], 'the first of two ROIs')
+rt_region = ps.create_roi_table_region('the first of two ROIs', region=[0])
 
+####################
+# Alternatively, you can get create a region using the names of the ROIs you added by passing in
+# the ROI names with the *names* argument. We will create the same region we did above, but
+# by using the name of the ROI.
+
+
+rt_region = ps.create_roi_table_region('the first of two ROIs', names=['1234'])
 
 ####################
 # Now that you have an :py:class:`~pynwb.ophys.ROITableRegion`, you can create your an
@@ -216,6 +223,7 @@ rrs = mod['Fluorescence'].get_roi_response_series()
 # get the data...
 rrs_data = rrs.data
 rrs_timestamps = rrs.timestamps
+rrs_rois = rrs.rois
 # and now do something cool!
 
 ####################

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -425,8 +425,10 @@ class NWBTable(NWBData):
             msg = "no '%s' column in %s" % (colname, self.__class__.__name__)
             raise KeyError(msg)
         ret = list()
-        for i, row in enumerate(self.data):
-            if row[idx] == value:
+        for i in range(len(self.data)):
+            row = self.data[i]
+            row_val = row[idx]
+            if row_val == value:
                 ret.append(i)
         return ret
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -358,6 +358,11 @@ class NWBTable(NWBData):
         if hasattr(cls, '__columns__'):
             columns = getattr(cls, '__columns__')
 
+            idx = dict()
+            for i, col in enumerate(columns):
+                idx[col['name']] = i
+            setattr(cls, '__colidx__', idx)
+
             if cls.__init__ == bases[-1].__init__:     # check if __init__ is overridden
                 name = {'name': 'name', 'type': str, 'doc': 'the name of this table'}
                 defname = getattr(cls, '__defaultname__', None)
@@ -408,12 +413,22 @@ class NWBTable(NWBData):
         self.data.append(tuple(values[col] for col in self.columns))
         return ret
 
-    @docval({'name': 'kwargs', 'type': dict, 'doc': 'the column to query by'})
-    def query(self, **kwargs):
+    def which(self, **kwargs):
         '''
         Query a table
         '''
-        raise NotImplementedError('query')
+        if len(kwargs) != 1:
+            raise ValueError("only one column can be queried")
+        colname, value = kwargs.popitem()
+        idx = self.__colidx__.get(colname)
+        if idx is None:
+            msg = "no '%s' column in %s" % (colname, self.__class__.__name__)
+            raise KeyError(msg)
+        ret = list()
+        for i, row in enumerate(self.data):
+            if row[idx] == value:
+                ret.append(i)
+        return ret
 
     def __len__(self):
         return len(self.data)

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -41,6 +41,9 @@ datasets:
     dtype: text
     value: A table for storing ROI data
   dtype:
+  - name: name
+    dtype: ascii
+    doc: a name for this ROI
   - name: pixel_mask
     dtype:
       reftype: region

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -59,7 +59,8 @@ _et_docval = [
     {'name': 'location', 'type': str, 'doc': 'the location of electrode within the subject e.g. brain region'},
     {'name': 'filtering', 'type': str, 'doc': 'description of hardware filtering'},
     {'name': 'description', 'type': str, 'doc': 'a brief description of what this electrode is'},
-    {'name': 'group', 'type': ElectrodeGroup, 'doc': 'the ElectrodeGroup object to add to this NWBFile'}
+    {'name': 'group', 'type': ElectrodeGroup, 'doc': 'the ElectrodeGroup object to add to this NWBFile'},
+    {'name': 'group_name', 'type': str, 'doc': 'the ElectrodeGroup object to add to this NWBFile', 'default': None}
 ]
 
 
@@ -74,7 +75,6 @@ class ElectrodeTable(NWBTable):
     def __init__(self, **kwargs):
         data, name = getargs('data', 'name', kwargs)
         colnames = [i['name'] for i in _et_docval]
-        colnames.append('group_name')
         super(ElectrodeTable, self).__init__(colnames, name, data)
 
     @docval(*_et_docval)

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -167,6 +167,7 @@ class TwoPhotonSeries(ImageSeries):
 
 
 _roit_docval = [
+    {'name': 'name', 'type': str, 'help': 'a name for this ROI'},
     {'name': 'pixel_mask', 'type': RegionSlicer, 'help': 'a region into a PixelMasks'},
     {'name': 'image_mask', 'type': RegionSlicer, 'help': 'a region into an ImageMasks'},
 ]
@@ -262,19 +263,20 @@ class PlaneSegmentation(NWBContainer):
         self.image_masks = im if isinstance(im, ImageMasks) else ImageMasks(im)
         self.rois = ROITable() if rois is None else rois
 
-    @docval({'name': 'pixel_mask', 'type': 'array_data',
+    @docval({'name': 'name', 'type': str, 'help': 'a name for this ROI'},
+            {'name': 'pixel_mask', 'type': 'array_data',
              'doc': 'the index of the ROI in roi_ids to retrieve the pixel mask for'},
             {'name': 'image_mask', 'type': 'array_data',
              'doc': 'the index of the ROI in roi_ids to retrieve the pixel mask for'})
     def add_roi(self, **kwargs):
-        pixel_mask, image_mask = getargs('pixel_mask', 'image_mask', kwargs)
+        name, pixel_mask, image_mask = getargs('name', 'pixel_mask', 'image_mask', kwargs)
         n_rois = len(self.rois)
         im_region = get_region_slicer(self.image_masks, [n_rois])
         self.image_masks.append(image_mask)
         n_pixels = len(self.pixel_masks)
         self.pixel_masks.extend(pixel_mask)
         pm_region = get_region_slicer(self.pixel_masks, slice(n_pixels, n_pixels + len(pixel_mask)))
-        self.rois.add_row(pm_region, im_region)
+        self.rois.add_row(name, pm_region, im_region)
         return n_rois+1
 
     @docval({'name': 'index', 'type': int,

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -180,8 +180,8 @@ class TestPlaneSegmentation(base.TestMapRoundTrip):
         self.pix_mask = deepcopy(pix_mask)
         pS = PlaneSegmentation('integration test PlaneSegmentation', 'plane segmentation description',
                                self.imaging_plane, 'test_plane_seg_name', self.image_series)
-        pS.add_roi(pix_mask[0:3], img_mask[0])
-        pS.add_roi(pix_mask[3:5], img_mask[1])
+        pS.add_roi('1234', pix_mask[0:3], img_mask[0])
+        pS.add_roi('5678', pix_mask[3:5], img_mask[1])
         return pS
 
     @staticmethod
@@ -248,9 +248,9 @@ class TestPlaneSegmentation(base.TestMapRoundTrip):
                                                    'help': 'an array of image masks'})
 
         self.rois_builder = DatasetBuilder('rois', [
-                                            (RegionBuilder(slice(0, 3), self.pixel_masks_builder),
+                                            ('1234', RegionBuilder(slice(0, 3), self.pixel_masks_builder),
                                              RegionBuilder([0], self.image_masks_builder)),
-                                            (RegionBuilder(slice(3, 5), self.pixel_masks_builder),
+                                            ('5678', RegionBuilder(slice(3, 5), self.pixel_masks_builder),
                                              RegionBuilder([1], self.image_masks_builder))
                                         ],
                                         attributes={
@@ -304,7 +304,7 @@ class TestRoiResponseSeriesIO(base.TestDataInterfaceIO):
 
     def setUpContainer(self):
         self.plane_segmentation = TestPlaneSegmentation.buildPlaneSegmentation(self)
-        self.rt_region = self.plane_segmentation.create_roi_table_region([0], 'the first of two ROIs')
+        self.rt_region = self.plane_segmentation.create_roi_table_region('the first of two ROIs', region=[0])
 
         data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         timestamps = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -21,8 +21,8 @@ def CreatePlaneSegmentation():
                       'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
     pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
-    pS.add_roi(pix_mask[0:3], img_mask[0])
-    pS.add_roi(pix_mask[3:5], img_mask[1])
+    pS.add_roi("1234", pix_mask[0:3], img_mask[0])
+    pS.add_roi("5678", pix_mask[3:5], img_mask[1])
     return pS
 
 
@@ -128,8 +128,8 @@ class PlaneSegmentationConstructor(unittest.TestCase):
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
         pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
-        pS.add_roi(pix_mask[0:3], img_mask[0])
-        pS.add_roi(pix_mask[3:5], img_mask[1])
+        pS.add_roi("1234", pix_mask[0:3], img_mask[0])
+        pS.add_roi("5678", pix_mask[3:5], img_mask[1])
 
         self.assertEqual(pS.description, 'description')
         self.assertEqual(pS.source, 'test source')

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -65,7 +65,7 @@ class RoiResponseSeriesConstructor(unittest.TestCase):
     def test_init(self):
         ip = CreatePlaneSegmentation()
 
-        rt_region = ip.create_roi_table_region([1], 'the second ROI')
+        rt_region = ip.create_roi_table_region('the second ROI', region=[1])
 
         ts = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', rt_region, timestamps=list())
         self.assertEqual(ts.name, 'test_ts')
@@ -78,7 +78,7 @@ class DfOverFConstructor(unittest.TestCase):
     def test_init(self):
         ip = CreatePlaneSegmentation()
 
-        rt_region = ip.create_roi_table_region([1], 'the second ROI')
+        rt_region = ip.create_roi_table_region('the second ROI', region=[1])
 
         rrs = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', rt_region, timestamps=list())
 
@@ -91,7 +91,7 @@ class FluorescenceConstructor(unittest.TestCase):
     def test_init(self):
         ip = CreatePlaneSegmentation()
 
-        rt_region = ip.create_roi_table_region([1], 'the second ROI')
+        rt_region = ip.create_roi_table_region('the second ROI', region=[1])
 
         ts = RoiResponseSeries('test_ts', 'a hypothetical source', list(), 'unit', rt_region, timestamps=list())
 


### PR DESCRIPTION
## Motivation

ROIs lost their names in the recent refactor and regions were based on indices into the ROI table.

## How to test the behavior?
```
plane_segmentation.create_roi_table_region("an example region", names=['1234'])
#or
plane_segmentation.create_roi_table_region("an example region", region=[0])
```

fix #421 

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
