### PR TITLE
Exclude example and integration tests from coverage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ commands =
 basepython = python3.6
 
 commands =
-    coverage run test.py
+    coverage run test.py --form --pynwb
     coverage html -d tests/coverage/htmlcov
 
 # Envs that builds wheels and source distribution
@@ -47,7 +47,7 @@ commands = {[testenv:build]commands}
 # Envs that will only be executed on CI that does coverage reporting
 [testenv:coverage]
 commands =
-    coverage run test.py
+    coverage run test.py --form --pynwb
     coverage report -m
     codecov -X fix
 


### PR DESCRIPTION
## Motivation

Fixes #423 
Coverage is only useful in the context of unit testing. Integration tests create the illusion of a higher coverage than what we currently have. Example tests are just executing tutorial code but they are not asserting any conditions explicitly so I excluded also the example tests from coverage. 

## How to test the behavior?
```
make coverage
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
