### PR TITLE
Add new tox environments for testing wheel installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ ci-steps: &ci-steps
         name: Test installation from a wheel
         command: |
           . ../venv/bin/activate
-          tox -e $TEST_TOX_ENV recreate --installpkg dist/*-none-any.whl
+          tox -e $TEST_WHEELINSTALL_ENV --recreate --installpkg dist/*-none-any.whl
     - run:
         <<: *publish-prerelease-on-github
 
@@ -77,7 +77,7 @@ conda-steps: &conda-steps
     - run:
         name: Test installation from a wheel
         command: |
-          tox -e $TEST_TOX_ENV recreate --installpkg dist/*-none-any.whl
+          tox -e $TEST_WHEELINSTALL_ENV --recreate --installpkg dist/*-none-any.whl
 
 version: 2
 jobs:
@@ -97,6 +97,7 @@ jobs:
      - TEST_TOX_ENV: "py27"
      - COVERAGE_TOX_ENV: "coverage-py27"
      - BUILD_TOX_ENV: "build-py27"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py27"
     <<: *ci-steps
 
   python35:
@@ -106,6 +107,7 @@ jobs:
      - TEST_TOX_ENV: "py35"
      - COVERAGE_TOX_ENV: "coverage-py35"
      - BUILD_TOX_ENV: "build-py35"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py35"
     <<: *ci-steps
 
   python36:
@@ -115,6 +117,7 @@ jobs:
      - TEST_TOX_ENV: "py36"
      - COVERAGE_TOX_ENV: "coverage-py36"
      - BUILD_TOX_ENV: "build-py36"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py36"
      - UPLOAD_WHEELS: "true"
     <<: *ci-steps
 
@@ -124,6 +127,7 @@ jobs:
     environment:
       - TEST_TOX_ENV: "py27"
       - BUILD_TOX_ENV: "build-py27"
+      - TEST_WHEELINSTALL_ENV: "wheelinstall-py27"
     <<: *conda-steps
 
   miniconda35:
@@ -132,6 +136,7 @@ jobs:
     environment:
       - TEST_TOX_ENV: "py35"
       - BUILD_TOX_ENV: "build-py35"
+      - TEST_WHEELINSTALL_ENV: "wheelinstall-py35"
     <<: *conda-steps
 
   miniconda36:
@@ -140,6 +145,7 @@ jobs:
     environment:
       - TEST_TOX_ENV: "py36"
       - BUILD_TOX_ENV: "build-py36"
+      - TEST_WHEELINSTALL_ENV: "wheelinstall-py36"
     <<: *conda-steps
 
 workflows:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
         - TEST_TOX_ENV=py36
         - COVERAGE_TOX_ENV=coverage-py36
         - BUILD_TOX_ENV=build-py36
+        - BUILD_WHEELINSTALL_ENV=wheelinstall-py36
 
     - os: osx
       language: generic
@@ -23,6 +24,7 @@ matrix:
         - TEST_TOX_ENV=py35
         - COVERAGE_TOX_ENV=coverage-py35
         - BUILD_TOX_ENV=build-py35
+        - BUILD_WHEELINSTALL_ENV=wheelinstall-py35
 
     - os: osx
       language: generic
@@ -31,6 +33,7 @@ matrix:
         - TEST_TOX_ENV=py27
         - COVERAGE_TOX_ENV=coverage-py27
         - BUILD_TOX_ENV=build-py27
+        - BUILD_WHEELINSTALL_ENV=wheelinstall-py27
 
 cache:
   directories:
@@ -47,4 +50,4 @@ script:
   - tox -e $TEST_TOX_ENV
   - tox -e $COVERAGE_TOX_ENV
   - tox -e $BUILD_TOX_ENV
-  - tox -e $TEST_TOX_ENV recreate --installpkg dist/*-none-any.whl
+  - tox -e $TEST_WHEELINSTALL_ENV --recreate --installpkg dist/*-none-any.whl

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,18 +12,21 @@ environment:
       TEST_TOX_ENV: py27
       COVERAGE_TOX_ENV: coverage-py27
       BUILD_TOX_ENV: build-py27
+      TEST_WHEELINSTALL_ENV: wheelinstall-py27
 
     - PYTHON_VERSION: 3.5
       PYTHON: C:\\Python35-x64
       TEST_TOX_ENV: py35
       COVERAGE_TOX_ENV: coverage-py35
       BUILD_TOX_ENV: build-py35
+      TEST_WHEELINSTALL_ENV: wheelinstall-py35
 
     - PYTHON_VERSION: 3.6
       PYTHON: C:\\Python36-x64
       TEST_TOX_ENV: py36
       COVERAGE_TOX_ENV: coverage-py36
       BUILD_TOX_ENV: build-py36
+      TEST_WHEELINSTALL_ENV: wheelinstall-py36
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION%"
@@ -35,7 +38,7 @@ test_script:
   - cd %APPVEYOR_BUILD_FOLDER%
   - tox -e %TEST_TOX_ENV%
   - tox -e %BUILD_TOX_ENV%
-  - ps: (Get-Item $env:APPVEYOR_BUILD_FOLDER\dist\*none-any.whl).Name | ForEach-Object {tox -e $env:TEST_TOX_ENV recreate --installpkg $env:APPVEYOR_BUILD_FOLDER\dist\$_}
+  - ps: (Get-Item $env:APPVEYOR_BUILD_FOLDER\dist\*none-any.whl).Name | ForEach-Object {tox -e $env:TEST_WHEELINSTALL_ENV --recreate --installpkg $env:APPVEYOR_BUILD_FOLDER\dist\$_}
 
 after_test:
   - tox -e %COVERAGE_TOX_ENV%

--- a/tox.ini
+++ b/tox.ini
@@ -65,3 +65,16 @@ commands = {[testenv:coverage]commands}
 passenv = CODECOV_TOKEN
 basepython = python3.6
 commands = {[testenv:coverage]commands}
+
+# Envs that will test installation from a wheel
+[testenv:wheelinstall-py27]
+deps = null
+commands = python -c "import pynwb"
+
+[testenv:wheelinstall-py35]
+deps = null
+commands = python -c "import pynwb"
+
+[testenv:wheelinstall-py36]
+deps = null
+commands = python -c "import pynwb"


### PR DESCRIPTION
## Motivation

Fixes #436 

We were installing dependencies from requirements and
requirements-dev. Now we use dependencies in the setup.py
so that we directly test installing the package without
relying on requirements files. Also added test command so
that each environment tries to import pynwb.

## How to test the behavior?
```
tox -e wheelinstall-py27
tox -e wheelinstall-py35
tox -e wheelinstall-py36
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
