### PR TITLE
Enh/roundtrip tests

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,7 @@ breaking down the barriers to data sharing in neuroscience.
    validation
    api_docs
    software_process
+   make_roundtrip_test
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/make_roundtrip_test.rst
+++ b/docs/source/make_roundtrip_test.rst
@@ -66,7 +66,7 @@ also where you can add additonial containers that your container of interest dep
 :py:class:`~pynwb.ecephys.Device` dependencies.
 
 
-Continuing from our example above, we will add the method for adding a generic :py:class:`~pynwb.base.TimeSeries`: instance:
+Continuing from our example above, we will add the method for adding a generic :py:class:`~pynwb.base.TimeSeries` instance:
 
 
 .. code-block:: python
@@ -88,7 +88,7 @@ method takes an :py:class:`~pynwb.file.NWBFile` as its single argument. The only
 Again, since not all containers go in the same place, we need to tell the test harness how to get back our container
 of interest.
 
-To finish off example from above, we will add the method for getting back our generic :py:class:`~pynwb.base.TimeSeries`: instance:
+To finish off example from above, we will add the method for getting back our generic :py:class:`~pynwb.base.TimeSeries` instance:
 
 .. code-block:: python
 
@@ -97,6 +97,43 @@ To finish off example from above, we will add the method for getting back our ge
         def getContainer(self, nwbfile):
             return nwbfile.get_acquisition(self.container.name)
 
+
+################
+``setUpBuilder``
+################
+
+As mentioned above, there is an optional method to override. This method will add two additional tests. First, it will
+add a test for converting your container into a builder to make sure the intermerdiate data structure gets built
+appropriately. Second it will add a test for constructing your container from the builder returned by your overriden
+``setUpBuilder`` method.  This method takes no arguments, and should return the builder representation of your
+container class instance.
+
+
+This method is not required, but can serve as an additional check to make sure your containers are getting converted
+to the expected structure as described in your specification.
+
+Continuing from the :py:class:`~pynwb.base.TimeSeries` example, lets add ``setUpBuilder``:
+
+.. code-block:: python
+
+    from pynwb.form.build import GroupBuilder
+
+    class TimeSeriesRoundTrip(TestMapRoundTrip):
+
+        def setUpBuilder(self):
+            return GroupBuilder('test_timeseries',
+                                attributes={'source': 'example_source',
+                                            'namespace': base.CORE_NAMESPACE,
+                                            'neurodata_type': 'TimeSeries',
+                                            'description': 'no description',
+                                            'comments': 'no comments',
+                                            'help': 'General time series object'},
+                                datasets={'data': DatasetBuilder('data', list(range(100, 200, 10)),
+                                                                 attributes={'unit': 'SIunit',
+                                                                             'conversion': 1.0,
+                                                                             'resolution': 0.1}),
+                                          'timestamps': DatasetBuilder('timestamps', list(range(10)),
+                                                                       attributes={'unit': 'Seconds', 'interval': 1})})
 
 .. _rt_below:
 

--- a/docs/source/make_roundtrip_test.rst
+++ b/docs/source/make_roundtrip_test.rst
@@ -1,0 +1,112 @@
+=============================
+How to Make a Roundtrip  Test
+=============================
+
+The PyNWB test suite has tools for easily doing round-trip tests of container classes. These
+tools exist in the integration test suite in ``tests/integration/ui_write/base.py`` for this reason
+and for the sake of keeping the repository organized, we recommend you write your tests in
+the ``tests/integration/ui_write`` subdirectory of the Git repository.
+
+For executing your new tests, we recommend using the `test.py` script in the top of the Git
+repository. Roundtrip tests will get executed as part of the integration test suite, which can be executed
+with the following command::
+
+    $ python test.py -i
+
+Before writing tests, we also suggest you familiarize yourself with the
+:ref:`software architecture <software-architecture>` of PyNWB.
+
+--------------------
+``TestMapRoundTrip``
+--------------------
+
+To write a roundtrip test, you will need to subclass the ``TestMapRoundTrip`` class and override some of
+its instance methods.
+
+``TestMapRoundTrip`` provides four methods for testing the process of going from in-memory Python object to data
+stored on disk and back. Three of these methods--``setUpContainer``, ``addContainer``, and ``getContainer``--are
+required for carrying out the roundtrip test. The fourth method is required for testing the conversion
+from the container to the :py:mod:`builder <pynwb.form.build.builders>`--the intermediate data structure
+that gets used by :py:class:`~pynwb.form.backends.io.FORMIO` implementations for writing to disk.
+
+If you do not want to test step of the process, you can just implement ``setUpContainer``, ``addContainer``, and
+``getContainer``.
+
+##################
+``setUpContainer``
+##################
+
+The first thing (and possibly the *only* thing -- see :ref:`rt_below`) you need to do is override is the ``setUpContainer``
+method. This method should take no arguments, and return an instance of the container class you are testing.
+
+Here is an example using a generic :py:class:`~pynwb.base.TimeSeries`:
+
+.. code-block:: python
+
+    from . base import TestMapRoundTrip
+
+    class TimeSeriesRoundTrip(TestMapRoundTrip):
+
+        def setUpContainer(self):
+            return TimeSeries('test_timeseries', 'example_source', list(range(100, 200, 10)),
+                              'SIunit', timestamps=list(range(10)), resolution=0.1)
+
+
+################
+``addContainer``
+################
+
+The next thing is to tell the ``TestMapRoundTrip`` how to add the container to an NWBFile. This method takes a single
+argument--the :py:class:`~pynwb.file.NWBFile` instance that will be used to write your container.
+
+This method is required because different container types are allowed in different parts of an NWBFile. This method is
+also where you can add additonial containers that your container of interest depends on. For example, for the
+:py:class:`~pynwb.ecephys.ElectricalSeries` roundtrip test, ``addContainer`` handles adding the
+:py:class:`~pynwb.ecephys.ElectrodeGroup`, :py:class:`~pynwb.ecephys.ElectrodeTable`, and
+:py:class:`~pynwb.ecephys.Device` dependencies.
+
+
+Continuing from our example above, we will add the method for adding a generic :py:class:`~pynwb.base.TimeSeries`: instance:
+
+
+.. code-block:: python
+
+    class TimeSeriesRoundTrip(TestMapRoundTrip):
+
+        def addContainer(self, nwbfile):
+            nwbfile.add_acquisition(self.container)
+
+
+################
+``getContainer``
+################
+
+Finally, you need to tell ``TestMapRoundTrip`` how to get back the container we added. As with ``addContainer``, this
+method takes an :py:class:`~pynwb.file.NWBFile` as its single argument. The only difference is that this
+:py:class:`~pynwb.file.NWBFile` instance is what was read back in.
+
+Again, since not all containers go in the same place, we need to tell the test harness how to get back our container
+of interest.
+
+To finish off example from above, we will add the method for getting back our generic :py:class:`~pynwb.base.TimeSeries`: instance:
+
+.. code-block:: python
+
+    class TimeSeriesRoundTrip(TestMapRoundTrip):
+
+        def getContainer(self, nwbfile):
+            return nwbfile.get_acquisition(self.container.name)
+
+
+.. _rt_below:
+
+-----------------------
+``TestDataInterfaceIO``
+-----------------------
+
+If you are testing something that can go in *acquisition*, you can avoid writing ``addContainer`` and ``getContainer``
+by extending ``TestDataInterfaceIO``.  This class has already overriden these methods to add your container object to
+acquisition.
+
+Even if your container can go in acquisition, you may still need to override ``addContainer`` if your container depends
+other containers that you need to add to the :py:class:`~pynwb.file.NWBFile` that will be written.

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -33,7 +33,7 @@ class HDF5IO(FORMIO):
     def __init__(self, **kwargs):
         '''Open an HDF5 file for IO
 
-        For `mode`, see :ref:`write_nwbfile`
+        For `mode`, see `h5py.File <http://docs.h5py.org/en/latest/high/file.html#opening-creating-files>_`.
         '''
         path, manager, mode, comm = popargs('path', 'manager', 'mode', 'comm', kwargs)
         if manager is None:

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -26,8 +26,7 @@ class TestMapNWBContainer(unittest.TestCase):
 
     def setUp(self):
         self.__manager = get_manager()
-        self.__container = self.setUpContainer()
-        self.__builder = self.setUpBuilder()
+        self.container = self.setUpContainer()
 
     @property
     def required_tests(self):
@@ -37,22 +36,15 @@ class TestMapNWBContainer(unittest.TestCase):
     def manager(self):
         return self.__manager
 
-    @property
-    def container(self):
-        return self.__container
-
-    @property
-    def builder(self):
-        return self.__builder
-
     def test_build(self):
-        # raise Exception
+        self.builder = self.setUpBuilder()
         self.maxDiff = None
         result = self.manager.build(self.container)
         # do something here to validate the result Builder against the spec
         self.assertDictEqual(result, self.builder)
 
     def test_construct(self):
+        self.builder = self.setUpBuilder()
         result = self.manager.construct(self.builder)
         self.assertContainerEqual(result, self.container)
 
@@ -109,6 +101,7 @@ class TestMapRoundTrip(TestMapNWBContainer):
 
     def setUp(self):
         super(TestMapRoundTrip, self).setUp()
+        self.container = self.setUpContainer()
         self.start_time = datetime(1971, 1, 1, 12, 0, 0)
         self.create_date = datetime(2018, 4, 15, 12, 0, 0)
         self.container_type = self.container.__class__.__name__

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -88,7 +88,10 @@ class TestMapNWBContainer(unittest.TestCase):
                     elif isinstance(f2, NWBData):
                         self.assertTrue(np.array_equal(f1.data, f2))
                 else:
-                    self.assertEqual(f1, f2)
+                    if isinstance(f1, float):
+                        self.assertAlmostEqual(f1, f2)
+                    else:
+                        self.assertEqual(f1, f2)
 
     def assertDataEqual(self, data1, data2):
         self.assertEqual(type(data1), type(data2))

--- a/tests/integration/ui_write/test_icephys.py
+++ b/tests/integration/ui_write/test_icephys.py
@@ -1,0 +1,47 @@
+import unittest2 as unittest
+
+import numpy as np
+
+from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder, ReferenceBuilder
+
+from pynwb.icephys import *  # noqa: F403
+from pynwb.misc import UnitTimes
+
+from . import base
+
+
+class TestIntracellularElectrode(base.TestMapRoundTrip):
+
+    def setUpContainer(self):
+        elec = IntracellularElectrode(name="elec0", source='', slice='', resistance='', seal='', description='',
+                                      location='', filtering='', initial_access_resistance='', device='')
+        return elec
+
+    def addContainer(self, nwbfile):
+        ''' Should take an NWBFile object and add the container to it '''
+        nwbfile.add_ic_electrode(self.container)
+
+    def getContainer(self, nwbfile):
+        ''' Should take an NWBFile object and return the Container'''
+        return nwbfile.get_ic_electrode(self.container.name)
+
+
+class TestPCS(base.TestDataInterfaceIO):
+
+    def setUpElectrode(self):
+        self.elec = IntracellularElectrode(name="elec0", source='', slice='', resistance='', seal='', description='',
+                                      location='', filtering='', initial_access_resistance='', device='')
+
+    def addContainer(self, nwbfile):
+        ''' Should take an NWBFile object and add the container to it '''
+        nwbfile.add_ic_electrode(self.elec)
+        super(TestPCS, self).addContainer(nwbfile)
+
+
+class TestCCSS(TestPCS):
+
+    def setUpContainer(self):
+        self.setUpElectrode()
+        ccss = CurrentClampStimulusSeries(name="ccss", source="command", data=[1, 2, 3, 4, 5], unit='A',
+                                          starting_time=123.6, rate=10e3, electrode=self.elec, gain=0.126)
+        return ccss

--- a/tests/integration/ui_write/test_icephys.py
+++ b/tests/integration/ui_write/test_icephys.py
@@ -1,11 +1,4 @@
-import unittest2 as unittest
-
-import numpy as np
-
-from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder, ReferenceBuilder
-
-from pynwb.icephys import *  # noqa: F403
-from pynwb.misc import UnitTimes
+from pynwb.icephys import IntracellularElectrode, CurrentClampStimulusSeries
 
 from . import base
 
@@ -30,7 +23,7 @@ class TestPCS(base.TestDataInterfaceIO):
 
     def setUpElectrode(self):
         self.elec = IntracellularElectrode(name="elec0", source='', slice='', resistance='', seal='', description='',
-                                      location='', filtering='', initial_access_resistance='', device='')
+                                           location='', filtering='', initial_access_resistance='', device='')
 
     def addContainer(self, nwbfile):
         ''' Should take an NWBFile object and add the container to it '''


### PR DESCRIPTION
## Motivation

Make writing roundtrip tests easier.   Fix #440, #441 

## How to test the behavior?
```python
from . import base

# Roundtrip an NWBContainer i.e. something that isn't allowed in 'acquisition`
class TestElectrodeGroupIO(base.TestMapRoundTrip):

    def setUpContainer(self):
        self.dev1 = Device('dev1', 'a test source')  # noqa: F405
        return ElectrodeGroup('elec1', 'a test source',  # noqa: F405
                                        'a test ElectrodeGroup',
                                        'a nonexistent place',
                                        self.dev1)

    def addContainer(self, nwbfile):
        ''' Should take an NWBFile object and add the container to it '''
        nwbfile.add_device(self.dev1)
        nwbfile.add_electrode_group(self.container)

    def getContainer(self, nwbfile):
        ''' Should take an NWBFile object and return the Container'''
        return nwbfile.get_electrode_group(self.container.name)

# Roundtrip an NWBDataInterface i.e. something that can go in 'acquisition`
class TestUnitTimes(base.TestDataInterfaceIO):

    def setUpContainer(self):
        ut = UnitTimes('UnitTimes add_spike_times unit test')
        ut.add_spike_times(0, [0, 1, 2])
        ut.add_spike_times(1, [3, 4, 5])

    # roundtrip the container, and get it back for some additional tests
    def test_my_special_test(self)
        roundtripped = self.roundtripContainer()
        # now do something in addition to testing attribute equality

```

relates to #450 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
