### PR TITLE
PEP8Speaks: Only scan the diff of the changed files for violations

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -2,3 +2,5 @@ pycodestyle:
     max-line-length: 120
     ignore:
         - E402
+scanner:
+    diff_only: True


### PR DESCRIPTION
Currently PEP8Speaks checks all changed files. This results in warning
messages for lines which were not touched in a given PR.

This is, at least for casual contributors, quite annoying as it basically
forces them to cleanup after other people's contributions.

Let's scan only the changed lines to make it less annoying.