### PR TITLE
Add advanced I/O tutorial

### DIFF
--- a/docs/gallery/general/advanced_hdf5_io.py
+++ b/docs/gallery/general/advanced_hdf5_io.py
@@ -1,0 +1,232 @@
+'''
+Advanced HDF5 I/O
+=====================
+
+The HDF5 storage backend supports a broad range of advanced dataset I/O options, such as,
+chunking and compression. Here we demonstrate how to use these features
+from PyNWB.
+'''
+
+####################
+# Wrapping data arrays with :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`
+# ---------------------------------------------------------------------------------
+#
+# In order to customize the I/O of datasets using the HDF I/O backend we simply need to wrap our datasets
+# using :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`. Using H5DataIO allows us to keep the Container
+# classes independent of the I/O backend while still allowing us to customize HDF5-specific I/O features.
+#
+# Before we get started, lets create an NWBFile for testing so that we can add our data to it.
+#
+
+from datetime import datetime
+from pynwb import NWBFile
+
+start_time = datetime(2017, 4, 3, 11, 0, 0)
+create_date = datetime(2017, 4, 15, 12, 0, 0)
+
+nwbfile = NWBFile(source='PyNWB tutorial',
+                  session_description='demonstrate advanced HDF5 I/O features',
+                  identifier='NWB123',
+                  session_start_time=start_time,
+                  file_create_date=create_date)
+
+
+####################
+# Normally if we create a timeseries we would do
+
+from pynwb import TimeSeries
+import numpy as np
+
+data = np.arange(100, 200, 10)
+timestamps = np.arange(10)
+test_ts = TimeSeries(name='test_regular_timeseries',
+                     source='PyNWB tutorial',
+                     data=data,
+                     unit='SIunit',
+                     timestamps=timestamps)
+nwbfile.add_acquisition(test_ts)
+
+####################
+# Now let's say we want to compress the recorded data values. We now simply need to wrap our data with H5DataIO.
+# Everything else remains the same
+
+from pynwb.form.backends.hdf5.h5_utils import H5DataIO
+wrapped_data = H5DataIO(data=data, compression=True)     # <----
+test_ts = TimeSeries(name='test_compressed_timeseries',
+                     source='PyNWB tutorial',
+                     data=wrapped_data,                  # <----
+                     unit='SIunit',
+                     timestamps=timestamps)
+nwbfile.add_acquisition(test_ts)
+
+####################
+# This simple approach gives us access to a broad range of advanced I/O features, such as, chunking and
+# compression. For a complete list of all available settings see :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`
+
+####################
+# Chunking
+# --------
+#
+# By default, data arrays are stored *contiguously*. This means that on disk/in memory the elements of a
+# multi-dimensional, such as, ```[[1 2] [3 4]]``` are actually stored in a one-dimensional buffer
+# ```1 2 3 4```. Using chunking, allows us to break up our array into chunks so that our array will be
+# stored not in one but multiple buffers, e.g., ``[1 2] [3 4]``. Using this approach allows optimization
+# of data locality for I/O operations and enables the application of filters (e.g., compression) on a
+# per-chunk basis.
+
+#####################
+# .. tip::
+#
+#    For an introduction to chunking and compression in HDF5 and h5py in particular see also `https://www.safaribooksonline.com/library/view/python-and-hdf5/9781491944981/ch04.html <https://www.safaribooksonline.com/library/view/python-and-hdf5/9781491944981/ch04.html>`__
+
+
+####################
+# To use chunking we again, simply need to wrap our dataset using :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`.
+# Using chunking then also allows to also create resizable arrays simply by defining the ``maxshape`` of the array.
+
+data = np.arange(10000).reshape((1000,10))
+wrapped_data = H5DataIO(data=data,
+                        chunks=True,         # <---- Enable chunking
+                        maxshape=(None,10)   # <---- Make the time dimension unlimited and hence resizeable
+                        )
+test_ts = TimeSeries(name='test_chunked_timeseries',
+                     source='PyNWB tutorial',
+                     data=wrapped_data,                  # <----
+                     unit='SIunit',
+                     starting_time=0.0,
+                     rate=10.0)
+nwbfile.add_acquisition(test_ts)
+
+
+####################
+# .. hint::
+#
+#   By also specifying ``fillvalue`` we can define the value that should be used when reading uninitialized
+#   portions of the dataset. If no fill value has been defined, then HDF5 will use a type-appropriate default value.
+#
+
+####################
+# .. note::
+#
+#    Chunking can help improve data read/write performance by allowing us to align chunks with common
+#    read/write operations. The following blog post provides an example
+#    `http://geology.beer/2015/02/10/hdf-for-large-arrays/ <http://geology.beer/2015/02/10/hdf-for-large-arrays/>`__.
+#    for this. But you should also know that, with great power comes great responsibility! I.e., if you choose a
+#    bad chunk size e.g., too small chunks that don't align with our read/write operations, then chunking can
+#    also harm I/O performance.
+
+####################
+# Compression and Other I/O Filters
+# -----------------------------------
+#
+# HDF5 supports I/O filters, i.e, data transformation (e.g, compression) that are applied transparently on
+# read/write operations.  I/O filters operate on a per-chunk basis in HDF5 and as such require the use of chunking.
+# Chunking will be automatically enabled by h5py when compression and other I/O filters are enabled.
+#
+# To use compression, we can wrap our dataset using :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO` and
+# define the approbriate opions:
+
+wrapped_data = H5DataIO(data=data,
+                        compression='gzip',              # <---- Use GZip
+                        compression_opts=4,              # <---- Optional GZip aggression option
+                        )
+test_ts = TimeSeries(name='test_gzipped_timeseries',
+                     source='PyNWB tutorial',
+                     data=wrapped_data,                  # <----
+                     unit='SIunit',
+                     starting_time=0.0,
+                     rate=10.0)
+nwbfile.add_acquisition(test_ts)
+
+####################
+# .. hint::
+#
+#   In addition to ``compression``, :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO` also allows us to
+#   enable the ``shuffle`` and ``fletcher32`` HDF5 I/O filters.
+
+####################
+# .. note::
+#
+#    *h5py* (and *HDF5* more broadly) support a number of different compression
+#    algorithms, e.g., *GZIP*, *SZIP*, or *LZF* (or even custom compression filters).
+#    However, only *GZIP* is built by default with HDF5, i.e., while data compressed
+#    with *GZIP* can be read on all platforms and installation of HDF5, other
+#    compressors may not be installed everywhere so that not all users may
+#    be able to access those files.
+#
+
+
+####################
+# Writing the data
+# -----------------------
+#
+#
+# Writing the data now works as usual.
+
+from pynwb import NWBHDF5IO
+
+io = NWBHDF5IO('advanced_io_example.nwb', 'w')
+io.write(nwbfile)
+io.close()
+
+####################
+# Reading the data
+# ---------------------
+#
+#
+# Again, nothing has changed for read. All of the above advanced I/O features are handled transparently.
+
+io = NWBHDF5IO('advanced_io_example.nwb')
+nwbfile = io.read()
+
+####################
+# Now lets have a look to confirm that all our I/O settings where indeed used.
+
+for k, v in nwbfile.acquisition.items():
+    print( "name=%s, chunks=%s, compression=%s, maxshape=%s" % (k,
+                                                                v.data.chunks,
+                                                                v.data.compression,
+                                                                v.data.maxshape))
+
+####################
+#
+# .. code-block:: python
+#
+#   name=test_regular_timeseries, chunks=None, compression=None, maxshape=(10,)
+#   name=test_compressed_timeseries, chunks=(10,), compression=gzip, maxshape=(10,)
+#   name=test_chunked_timeseries, chunks=(250, 5), compression=None, maxshape=(None, 10)
+#   name=test_gzipped_timeseries, chunks=(250, 5), compression=gzip, maxshape=(1000, 10)
+#
+# As we can see, the datasets have been chunked and compressed correctly. Alos, as expected, chunking
+# was automatically enabled for the compressed datasets.
+
+
+####################
+# Wrapping ``h5py.Datasets`` with :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`
+# ------------------------------------------------------------------------------------------------
+#
+# Just for completeness, :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO` also allows us to customize
+# how ``h5py.Dataset`` objects should be handled on write by the PyNWBs HDF5 backend via the ``link_data``
+# parameter. If ``link_data`` is set to ``True`` then a ``SoftLink`` or ``ExternalLink`` will be created to
+# point to the HDF5 dataset On the other hand, if ``link_data`` is set to ``False`` then the dataset
+# be copied using `h5py.Group.copy <http://docs.h5py.org/en/latest/high/group.html#Group.copy>`__
+# **without copying attributes** and **without expanding soft links, external links, or references**.
+#
+# .. note::
+#
+#   When wrapping an ``h5py.Dataset`` object using H5DataIO, then  all settings except ``link_data``
+#   will be ignored as the h5py.Dataset will either be linked to or copied as on write.
+#
+
+####################
+# Disclaimer
+# ----------------
+#
+# External links included in the tutorial are being provided as a convenience and for informational purposes only;
+# they do not constitute an endorsement or an approval by the authors of any of the products, services or opinions of
+# the corporation or organization or individual. The authors bear no responsibility for the accuracy, legality or
+# content of the external site or for that of subsequent links. Contact the external site for answers to questions
+# regarding its content.
+
+
+

--- a/docs/gallery/general/advanced_hdf5_io.py
+++ b/docs/gallery/general/advanced_hdf5_io.py
@@ -77,17 +77,19 @@ nwbfile.add_acquisition(test_ts)
 #####################
 # .. tip::
 #
-#    For an introduction to chunking and compression in HDF5 and h5py in particular see also `https://www.safaribooksonline.com/library/view/python-and-hdf5/9781491944981/ch04.html <https://www.safaribooksonline.com/library/view/python-and-hdf5/9781491944981/ch04.html>`__
+#    For an introduction to chunking and compression in HDF5 and h5py in particular see also the online book
+#    `Python and HDF5 <https://www.safaribooksonline.com/library/view/python-and-hdf5/9781491944981/ch04.html>`__
+#    by Andrew Collette.
 
 
 ####################
-# To use chunking we again, simply need to wrap our dataset using :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`.
+# To use chunking we again, simply need to wrap our dataset via :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`.
 # Using chunking then also allows to also create resizable arrays simply by defining the ``maxshape`` of the array.
 
-data = np.arange(10000).reshape((1000,10))
+data = np.arange(10000).reshape((1000, 10))
 wrapped_data = H5DataIO(data=data,
-                        chunks=True,         # <---- Enable chunking
-                        maxshape=(None,10)   # <---- Make the time dimension unlimited and hence resizeable
+                        chunks=True,          # <---- Enable chunking
+                        maxshape=(None, 10)   # <---- Make the time dimension unlimited and hence resizeable
                         )
 test_ts = TimeSeries(name='test_chunked_timeseries',
                      source='PyNWB tutorial',
@@ -183,10 +185,10 @@ nwbfile = io.read()
 # Now lets have a look to confirm that all our I/O settings where indeed used.
 
 for k, v in nwbfile.acquisition.items():
-    print( "name=%s, chunks=%s, compression=%s, maxshape=%s" % (k,
-                                                                v.data.chunks,
-                                                                v.data.compression,
-                                                                v.data.maxshape))
+    print("name=%s, chunks=%s, compression=%s, maxshape=%s" % (k,
+                                                               v.data.chunks,
+                                                               v.data.compression,
+                                                               v.data.maxshape))
 
 ####################
 #
@@ -227,6 +229,3 @@ for k, v in nwbfile.acquisition.items():
 # the corporation or organization or individual. The authors bear no responsibility for the accuracy, legality or
 # content of the external site or for that of subsequent links. Contact the external site for answers to questions
 # regarding its content.
-
-
-

--- a/docs/gallery/general/extensions.py
+++ b/docs/gallery/general/extensions.py
@@ -18,7 +18,7 @@ PyNWB API.
 #
 # The following block of code demonstrates how to create a new namespace, and then add a new `neurodata_type`
 # to this namespace. Finally,
-# it calls :py:meth:`~form.spec.write.NamespaceBuilder.export` to save the extensions to disk for downstream use.
+# it calls :py:meth:`~pynwb.form.spec.write.NamespaceBuilder.export` to save the extensions to disk for downstream use.
 
 from pynwb.spec import NWBNamespaceBuilder, NWBGroupSpec, NWBAttributeSpec
 

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -210,8 +210,9 @@ class H5DataIO(DataIO):
              'doc': 'Chunk shape or True ti enable auto-chunking',
              'default': None},
             {'name': 'compression',
-             'type': str,
-             'doc': 'Compression strategy. http://docs.h5py.org/en/latest/high/dataset.html#dataset-compression',
+             'type': (str, bool),
+             'doc': 'Compression strategy. If a bool is given, then gzip compression will be used by default.' +
+                    'http://docs.h5py.org/en/latest/high/dataset.html#dataset-compression',
              'default': None},
             {'name': 'compression_opts',
              'type': int,
@@ -258,6 +259,16 @@ class H5DataIO(DataIO):
             # Define the maxshape of the data if not provided by the user
             if 'maxshape' not in self.__iosettings:
                 self.__iosettings['maxshape'] = self.data.get_maxshape()
+        if 'compression' in self.__iosettings:
+            if isinstance(self.__iosettings['compression'], bool):
+                if self.__iosettings['compression']:
+                    self.__iosettings['compression'] = 'gzip'
+                else:
+                    self.__iosettings.pop('compression', None)
+                    if 'compression_opts' in  self.__iosettings:
+                        warnings.warn('Compression disabled by compression=False setting. ' +
+                                      'compression_opts parameter will, therefore, be ignored.')
+                        self.__iosettings.pop('compression_opts', None)
         if 'compression' in self.__iosettings:
             if self.__iosettings['compression'] != 'gzip':
                 warnings.warn(str(self.__iosettings['compression']) + " compression may not be available" +

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -265,7 +265,7 @@ class H5DataIO(DataIO):
                     self.__iosettings['compression'] = 'gzip'
                 else:
                     self.__iosettings.pop('compression', None)
-                    if 'compression_opts' in  self.__iosettings:
+                    if 'compression_opts' in self.__iosettings:
                         warnings.warn('Compression disabled by compression=False setting. ' +
                                       'compression_opts parameter will, therefore, be ignored.')
                         self.__iosettings.pop('compression_opts', None)

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -116,6 +116,29 @@ class H5IOTest(unittest.TestCase):
         self.assertEqual(dset.shuffle, True)
         self.assertEqual(dset.fletcher32, True)
 
+    def test_write_dataset_list_enable_default_compress(self):
+        a = H5DataIO(np.arange(30).reshape(5, 2, 3),
+                     compression=True)
+        self.assertEqual(a.io_settings['compression'], 'gzip')
+        self.io.write_dataset(self.f, DatasetBuilder('test_dataset', a, attributes={}))
+        dset = self.f['test_dataset']
+        self.assertTrue(np.all(dset[:] == a.data))
+        self.assertEqual(dset.compression, 'gzip')
+
+    def test_write_dataset_list_disable_default_compress(self):
+        with warnings.catch_warnings(record=True) as w:
+            a = H5DataIO(np.arange(30).reshape(5, 2, 3),
+                         compression=False,
+                         compression_opts=5)
+            self.assertEqual(len(w), 1) # We expect a warning that compression options are being ignored
+            self.assertFalse('compression_ops' in a.io_settings)
+            self.assertFalse('compression' in a.io_settings)
+
+        self.io.write_dataset(self.f, DatasetBuilder('test_dataset', a, attributes={}))
+        dset = self.f['test_dataset']
+        self.assertTrue(np.all(dset[:] == a.data))
+        self.assertEqual(dset.compression, None)
+
     def test_write_dataset_list_chunked(self):
         a = H5DataIO(np.arange(30).reshape(5, 2, 3),
                      chunks=(1, 1, 3))

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -130,7 +130,7 @@ class H5IOTest(unittest.TestCase):
             a = H5DataIO(np.arange(30).reshape(5, 2, 3),
                          compression=False,
                          compression_opts=5)
-            self.assertEqual(len(w), 1) # We expect a warning that compression options are being ignored
+            self.assertEqual(len(w), 1)  # We expect a warning that compression options are being ignored
             self.assertFalse('compression_ops' in a.io_settings)
             self.assertFalse('compression' in a.io_settings)
 


### PR DESCRIPTION
## Motivation

Add missing tutorial for showing the use of advnaced I/O options, e.g., chunking and compression. In addition this pull request:

* Adds a default compression setting for H5DataIO
* Adds tests for the new behavior of H5DataIO
* Fixes a link in the extensions tutorial

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
