### PR TITLE
Enh/extfilecopy

### DIFF
--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -139,6 +139,11 @@ class HDF5IO(FORMIO):
     def copy_file(self, **kwargs):
         """
         Convenience function to copy an HDF5 file while allowing external links to be resolved.
+
+        NOTE: The source file will be opened in 'r' mode and the destination file will be opened in 'w' mode
+              using h5py. To avoid possible collisions, care should be taken that, e.g., the source file is
+              not opened already when calling this function.
+
         """
         source_filename, dest_filename, expand_external, expand_refs, expand_soft = getargs('source_filename',
                                                                                             'dest_filename',

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -128,6 +128,41 @@ class HDF5IO(FORMIO):
                 ret.append(subspec)
         return ret
 
+    @classmethod
+    @docval({'name': 'source_filename', 'type': str, 'doc': 'the path to the HDF5 file to copy'},
+            {'name': 'dest_filename', 'type': str, 'doc': 'the name of the desitnation file'},
+            {'name': 'expand_external', 'type': bool, 'doc': 'expand external links into new objects', 'default': True},
+            {'name': 'expand_refs', 'type': bool, 'doc': 'copy objects which are pointed to by reference',
+             'default': False},
+            {'name': 'expand_soft', 'type': bool, 'doc': 'expand soft links into new objects', 'default': False}
+            )
+    def copy_file(self, **kwargs):
+        """
+        Convenience function to copy an HDF5 file while allowing external links to be resolved.
+        """
+        source_filename, dest_filename, expand_external, expand_refs, expand_soft = getargs('source_filename',
+                                                                                            'dest_filename',
+                                                                                            'expand_external',
+                                                                                            'expand_refs',
+                                                                                            'expand_soft',
+                                                                                            kwargs)
+        source_file = File(source_filename, 'r')
+        dest_file = File(dest_filename, 'w')
+        for objname in source_file["/"].keys():
+            source_file.copy(source=objname,
+                             dest=dest_file,
+                             name=objname,
+                             expand_external=expand_external,
+                             expand_refs=expand_refs,
+                             expand_soft=expand_soft,
+                             shallow=False,
+                             without_attrs=False,
+                             )
+        for objname in source_file['/'].attrs:
+            dest_file['/'].attrs[objname] = source_file['/'].attrs[objname]
+        source_file.close()
+        dest_file.close()
+
     @docval({'name': 'container', 'type': Container, 'doc': 'the Container object to write'},
             {'name': 'cache_spec', 'type': bool, 'doc': 'cache specification to file', 'default': False},
             {'name': 'link_data', 'type': bool,

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -325,7 +325,6 @@ class H5IOTest(unittest.TestCase):
         self.assertListEqual(self.f['test_dataset'][:].tolist(),
                              self.f['test_copy'][:].tolist())
 
-
 class NWBHDF5IOMultiFileTest(unittest.TestCase):
     """Tests for h5tools IO tools"""
 
@@ -343,14 +342,18 @@ class NWBHDF5IOMultiFileTest(unittest.TestCase):
         self.f = [i._file for i in self.io]
 
     def tearDown(self):
-        for fileobj in self.f:
-            fileobj.close()
-            del fileobj
+        # Close all the files
+        for i in self.io:
+            i.close()
+            del(i)
+        self.io = None
         self.f = None
+        # Make sure the files have been deleted
         for tf in self.test_temp_files:
-            os.remove(tf.name)
-        for i in self.test_temp_files:
-            del i
+            try:
+                os.remove(tf.name)
+            except:
+                pass
         self.test_temp_files = None
 
     def test_copy_file_with_external_links(self):
@@ -389,9 +392,11 @@ class NWBHDF5IOMultiFileTest(unittest.TestCase):
                               unit='SIunit',
                               timestamps=timestamps)
         nwbfile2.add_acquisition(test_ts2)
-        # Write the first file
+        # Write the second file
         self.io[1].write(nwbfile2)
         self.io[1].close()
+        self.io[0].close() # Don't forget to close the first file too
+
 
         # Copy the file
         self.io[2].close()

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -322,5 +322,37 @@ class H5IOTest(unittest.TestCase):
                              self.f['test_copy'][:].tolist())
 
 
+class H5IOMultiFileTest(unittest.TestCase):
+    """Tests for h5tools IO tools"""
+
+    def setUp(self):
+        numfiles = 3
+        self.test_temp_files = [tempfile.NamedTemporaryFile() for i in range(numfiles)]
+
+        # On Windows h5py cannot truncate an open file in write mode.
+        # The temp file will be closed before h5py truncates it
+        # and will be removed during the tearDown step.
+        for i in self.test_temp_files:
+            i.close()
+        self.io = [HDF5IO(i.name) for i in self.test_temp_files]
+        self.f  = [i._file for i in self.io]
+
+
+    def tearDown(self):
+        for fileobj in self.f:
+            path = fileobj.filename
+            fileobj .close()
+            os.remove(path)
+            del fileobj
+        self.f = None
+        for i in self.test_temp_files:
+            del i
+        self.test_temp_files = None
+
+    def test_copy_file_with_external_links(self):
+        self.assertTrue(True)
+
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -5,11 +5,15 @@ from pynwb.form.data_utils import DataChunkIterator
 from pynwb.form.backends.hdf5.h5tools import HDF5IO
 from pynwb.form.backends.hdf5 import H5DataIO
 from pynwb.form.build import DatasetBuilder
-from h5py import SoftLink, HardLink
+from h5py import SoftLink, HardLink, ExternalLink, File
+from pynwb.file import NWBFile
+from pynwb.base import TimeSeries
+
 
 import tempfile
 import warnings
 import numpy as np
+from datetime import datetime
 
 
 class H5IOTest(unittest.TestCase):
@@ -322,10 +326,11 @@ class H5IOTest(unittest.TestCase):
                              self.f['test_copy'][:].tolist())
 
 
-class H5IOMultiFileTest(unittest.TestCase):
+class NWBHDF5IOMultiFileTest(unittest.TestCase):
     """Tests for h5tools IO tools"""
 
     def setUp(self):
+        from pynwb import NWBHDF5IO
         numfiles = 3
         self.test_temp_files = [tempfile.NamedTemporaryFile() for i in range(numfiles)]
 
@@ -334,24 +339,78 @@ class H5IOMultiFileTest(unittest.TestCase):
         # and will be removed during the tearDown step.
         for i in self.test_temp_files:
             i.close()
-        self.io = [HDF5IO(i.name) for i in self.test_temp_files]
-        self.f  = [i._file for i in self.io]
-
+        self.io = [NWBHDF5IO(i.name) for i in self.test_temp_files]
+        self.f = [i._file for i in self.io]
 
     def tearDown(self):
         for fileobj in self.f:
-            path = fileobj.filename
-            fileobj .close()
-            os.remove(path)
+            fileobj.close()
             del fileobj
         self.f = None
+        for tf in self.test_temp_files:
+            os.remove(tf.name)
         for i in self.test_temp_files:
             del i
         self.test_temp_files = None
 
     def test_copy_file_with_external_links(self):
-        self.assertTrue(True)
+        # Setup all the data we need
+        start_time = datetime(2017, 4, 3, 11, 0, 0)
+        create_date = datetime(2017, 4, 15, 12, 0, 0)
+        data = np.arange(1000).reshape((100, 10))
+        timestamps = np.arange(100)
+        # Create the first file
+        nwbfile1 = NWBFile(source='PyNWB tutorial',
+                           session_description='demonstrate external files',
+                           identifier='NWBE1',
+                           session_start_time=start_time,
+                           file_create_date=create_date)
 
+        test_ts1 = TimeSeries(name='test_timeseries',
+                              source='PyNWB tutorial',
+                              data=data,
+                              unit='SIunit',
+                              timestamps=timestamps)
+        nwbfile1.add_acquisition(test_ts1)
+        # Write the first file
+        self.io[0].write(nwbfile1)
+        nwbfile1_read = self.io[0].read()
+
+        # Create the second file
+        nwbfile2 = NWBFile(source='PyNWB tutorial',
+                           session_description='demonstrate external files',
+                           identifier='NWBE1',
+                           session_start_time=start_time,
+                           file_create_date=create_date)
+
+        test_ts2 = TimeSeries(name='test_timeseries',
+                              source='PyNWB tutorial',
+                              data=nwbfile1_read.get_acquisition('test_timeseries').data,
+                              unit='SIunit',
+                              timestamps=timestamps)
+        nwbfile2.add_acquisition(test_ts2)
+        # Write the first file
+        self.io[1].write(nwbfile2)
+        self.io[1].close()
+
+        # Copy the file
+        self.io[2].close()
+        HDF5IO.copy_file(source_filename=self.test_temp_files[1].name,
+                         dest_filename=self.test_temp_files[2].name,
+                         expand_external=True,
+                         expand_soft=False,
+                         expand_refs=False)
+
+        # Test that everything is working as expected
+        # Confirm that our orginal data file is correct
+        f1 = File(self.test_temp_files[0].name)
+        self.assertTrue(isinstance(f1.get('/acquisition/test_timeseries/data', getlink=True), HardLink))
+        # Confirm that we succesfully created and External Link in our second file
+        f2 = File(self.test_temp_files[1].name)
+        self.assertTrue(isinstance(f2.get('/acquisition/test_timeseries/data', getlink=True), ExternalLink))
+        # Confirm that we succesfully resolved the External Link when we copied our second file
+        f3 = File(self.test_temp_files[2].name)
+        self.assertTrue(isinstance(f3.get('/acquisition/test_timeseries/data', getlink=True), HardLink))
 
 
 if __name__ == '__main__':

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -325,6 +325,7 @@ class H5IOTest(unittest.TestCase):
         self.assertListEqual(self.f['test_dataset'][:].tolist(),
                              self.f['test_copy'][:].tolist())
 
+
 class NWBHDF5IOMultiFileTest(unittest.TestCase):
     """Tests for h5tools IO tools"""
 
@@ -352,7 +353,7 @@ class NWBHDF5IOMultiFileTest(unittest.TestCase):
         for tf in self.test_temp_files:
             try:
                 os.remove(tf.name)
-            except:
+            except OSError:
                 pass
         self.test_temp_files = None
 
@@ -395,8 +396,7 @@ class NWBHDF5IOMultiFileTest(unittest.TestCase):
         # Write the second file
         self.io[1].write(nwbfile2)
         self.io[1].close()
-        self.io[0].close() # Don't forget to close the first file too
-
+        self.io[0].close()  # Don't forget to close the first file too
 
         # Copy the file
         self.io[2].close()


### PR DESCRIPTION
## Motivation

This pull request adds a convenience function to HDF5IO to allow us to copy a file while resolving external links. The goal is to allow users that have created files that contain external links to create a new file that includes all the data in a single file that they can then share more easily with others (without having to collect and share a multiple files that are connected via links).

## How to test the behavior?

See the test included with this pull request

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
