### PR TITLE
Doc/externaldata

### DIFF
--- a/docs/gallery/general/linking_data.py
+++ b/docs/gallery/general/linking_data.py
@@ -1,0 +1,219 @@
+'''
+Modular Data Storage using External Files
+===========================================
+
+PyNWB supports linking between files using external links.
+'''
+
+
+####################
+# Example Use Case: Integrating data from multiple files
+# ---------------------------------------------------------
+#
+# NBWContainer classes (e.g., :py:meth:`~pynwb.base.TimeSeries`) support the integration of data stored in external
+# HDF5 files with NWB data files via external links. To make things more concrete, let's look at the following use
+# case. We want to simultaneously record multiple data steams during data acquisition. Using the concept of external
+# links allows us to save each data stream to an external HDF5 files during data acquisition and to
+# afterwards link the data into a single NWB:N file. In this case, each recording becomes represented by a
+# separate file-system object that can be set as read-only once the experiment is done.  In the following
+# we are using :py:meth:`~pynwb.base.TimeSeries` as an example, but the same approach works for other
+# NWBContainers as well.
+#
+#
+
+####################
+# .. tip::
+#
+#    In the case of :py:meth:`~pynwb.base.TimeSeries`, the uncorrected time  stamps generated  by the acquisition
+#    system can be stored (or linked) in the *sync* group. In the NWB:N format, hardware-recorded time data
+#    must then be corrected to a common time base (e.g., timestamps from all hardware sources aligned) before
+#    it can be included in the *timestamps* of the *TimeSeries* This means, in the case
+#    of :py:meth:`~pynwb.base.TimeSeries` we need to be careful that we are not including data with incompatible
+#    timestamps in the same file when using external links.
+#
+
+
+####################
+# Creating test data
+# ---------------------------
+#
+# In the following we are creating 2 TimeSeries each written to a separate file. In the following we
+# then show how we can integrate these files into a single NWBFile.
+
+
+from datetime import datetime
+from pynwb import NWBFile
+from pynwb import TimeSeries
+from pynwb import NWBHDF5IO
+import numpy as np
+
+# Create the base data
+start_time = datetime(2017, 4, 3, 11, 0, 0)
+create_date = datetime(2017, 4, 15, 12, 0, 0)
+data = np.arange(1000).reshape((100,10))
+timestamps = np.arange(100)
+filename1 = 'external1_example.nwb'
+filename2 = 'external2_example.nwb'
+filename3 = 'external_linkcontainer_example.nwb'
+filename4 = 'external_linkdataset_example.nwb'
+
+# Create the first file
+nwbfile1 = NWBFile(source='PyNWB tutorial',
+                   session_description='demonstrate external files',
+                   identifier='NWBE1',
+                   session_start_time=start_time,
+                   file_create_date=create_date)
+# Create the second file
+test_ts1 = TimeSeries(name='test_timeseries',
+                      source='PyNWB tutorial',
+                      data=data,
+                      unit='SIunit',
+                      timestamps=timestamps)
+nwbfile1.add_acquisition(test_ts1)
+# Write the first file
+io = NWBHDF5IO(filename1, 'w')
+io.write(nwbfile1)
+io.close()
+
+# Create the second file
+nwbfile2 = NWBFile(source='PyNWB tutorial',
+                   session_description='demonstrate external files',
+                   identifier='NWBE2',
+                   session_start_time=start_time,
+                   file_create_date=create_date)
+# Create the second file
+test_ts2 = TimeSeries(name='test_timeseries',
+                      source='PyNWB tutorial',
+                      data=data,
+                      unit='SIunit',
+                      timestamps=timestamps)
+nwbfile2.add_acquisition(test_ts2)
+# Write the second file
+io = NWBHDF5IO(filename2, 'w')
+io.write(nwbfile2)
+io.close()
+
+
+#####################
+# Linking to select datasets
+# --------------------------
+#
+
+####################
+# Step 1: Create the new NWBFile
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+# Create the first file
+nwbfile4 = NWBFile(source='PyNWB tutorial',
+                   session_description='demonstrate external files',
+                   identifier='NWBE4',
+                   session_start_time=start_time,
+                   file_create_date=create_date)
+
+
+####################
+# Step 2: Get the dataset you want to link to
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Now let's open our test files and retrieve our timeseries.
+#
+
+# Get the first timeseries
+io1 = NWBHDF5IO(filename1)
+nwbfile1 = io1.read()
+timeseries_1 = nwbfile1.get_acquisition('test_timeseries')
+timeseries_1_data = timeseries_1.data
+
+####################
+# Step 3: Create the object you want to link to the data
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# To make it explicit that we want to link to the dataset we here link to the
+
+# Create a new timeseries that links to our data
+test_ts4 = TimeSeries(name='test_timeseries1',
+                      source='PyNWB tutorial',
+                      data= timeseries_1_data,   # <-------
+                      unit='SIunit',
+                      timestamps=timestamps)
+nwbfile4.add_acquisition(test_ts4)
+
+####################
+# In the above case we did not make it explicit how we want to handle the data from
+# our timeseries, this means that  :py:class:`~pynwb.NWBHDF5IO` class [#]_ will need to
+# determine on write how to treat the dataset. We can make this explicit and customize this
+# behavior on a per-dataset basis by wrapping our dataset using
+# :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`
+
+from pynwb.form.backends.hdf5.h5_utils import H5DataIO
+
+# Create another timeseries that links to the same data
+test_ts5 = TimeSeries(name='test_timeseries2',
+                      source='PyNWB tutorial',
+                      data= H5DataIO(data=timeseries_1_data, link_data=True),   # <-------
+                      unit='SIunit',
+                      timestamps=timestamps)
+nwbfile4.add_acquisition(test_ts5)
+
+####################
+# Step 4: Write the data
+# ^^^^^^^^^^^^^^^^^^^^^^^
+#
+from pynwb import NWBHDF5IO
+
+io4 = NWBHDF5IO('basic_example.nwb', 'w')
+io4.write(nwbfile4, link_data=True)     # <-------- Specify default behavior to link rather than copy data
+io4.close()
+
+#####################
+# .. note::
+#
+#   In the case of TimeSeries one advantage of linking to just the main dataset is that we can now
+#   use our own timestamps in case the timestamps in the original file are not alligned with the
+#   clock of the NWBFile we are creating. In this way we can use the linking to "re-align" different
+#   TimeSeries without having to copy the main data.
+
+
+####################
+# Linking to whole Containers
+# ---------------------------
+
+####################
+# Step 1: Get the container object you want to link to
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Now let's open our test files and retrieve our timeseries.
+#
+
+# Get the first timeseries
+io1 = NWBHDF5IO(filename1)
+nwbfile1 = io1.read()
+timeseries_1 = nwbfile1.get_acquisition('test_timeseries')
+
+# Get the second timeseries
+io2 = NWBHDF5IO(filename1)
+nwbfile2 = io1.read()
+timeseries_2 = nwbfile1.get_acquisition('test_timeseries')
+
+####################
+# Step 2: Add the container to another NWBFile
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# To intergrate both :py:meth:`~pynwb.base.TimeSeries` into a single file we simply create a new
+# :py:meth:`~pynwb.file.NWBFile` and our existing :py:meth:`~pynwb.base.TimeSeries` to it. PyNWBs
+# :py:meth:`~pynwb.NWBHDF5IO` backend then automatically detects that the TimeSeries have already
+# been written to another file and will create external links for us.
+#
+
+# Create a new NWBFile
+# Create the first file
+nwbfile3 = NWBFile(source='PyNWB tutorial',
+                   session_description='demonstrate external files',
+                   identifier='NWBE3',
+                   session_start_time=start_time,
+                   file_create_date=create_date)
+nwbfile3.add_acquisition(timeseries_1)
+nwbfile3.add_acquisition(timeseries_2)
+
+## Write our third file that includes our two timeseries as external links
+io3 = NWBHDF5IO(filename3, 'w')
+io3.write(nwbfile3)
+io3.close()
+

--- a/docs/gallery/general/linking_data.py
+++ b/docs/gallery/general/linking_data.py
@@ -5,7 +5,6 @@ Modular Data Storage using External Files
 PyNWB supports linking between files using external links.
 '''
 
-
 ####################
 # Example Use Case: Integrating data from multiple files
 # ---------------------------------------------------------
@@ -24,6 +23,14 @@ PyNWB supports linking between files using external links.
 ####################
 # .. tip::
 #
+#    The same strategies we use here for creating External Links also apply to Soft Links.
+#    The main difference between soft and external links is that soft links point to other
+#    objects within the same file while external links point to objects in external files.
+#
+
+####################
+# .. tip::
+#
 #    In the case of :py:meth:`~pynwb.base.TimeSeries`, the uncorrected time  stamps generated  by the acquisition
 #    system can be stored (or linked) in the *sync* group. In the NWB:N format, hardware-recorded time data
 #    must then be corrected to a common time base (e.g., timestamps from all hardware sources aligned) before
@@ -32,6 +39,13 @@ PyNWB supports linking between files using external links.
 #    timestamps in the same file when using external links.
 #
 
+####################
+# .. warning::
+#
+#    External links can become stale/break. Since external links are pointing to data in other files
+#    external links may become invalid any time files are modified on the file system, e.g., renamed,
+#    moved or access permissions are changed.
+#
 
 ####################
 # Creating test data
@@ -56,6 +70,7 @@ filename1 = 'external1_example.nwb'
 filename2 = 'external2_example.nwb'
 filename3 = 'external_linkcontainer_example.nwb'
 filename4 = 'external_linkdataset_example.nwb'
+filename5 = 'external_linkdataset_copy_example.nwb'
 
 # Create the first file
 nwbfile1 = NWBFile(source='PyNWB tutorial',
@@ -139,7 +154,7 @@ nwbfile4.add_acquisition(test_ts4)
 
 ####################
 # In the above case we did not make it explicit how we want to handle the data from
-# our timeseries, this means that  :py:class:`~pynwb.NWBHDF5IO` class [#]_ will need to
+# our timeseries, this means that :py:class:`~pynwb.NWBHDF5IO` will need to
 # determine on write how to treat the dataset. We can make this explicit and customize this
 # behavior on a per-dataset basis by wrapping our dataset using
 # :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`
@@ -160,7 +175,7 @@ nwbfile4.add_acquisition(test_ts5)
 #
 from pynwb import NWBHDF5IO
 
-io4 = NWBHDF5IO('basic_example.nwb', 'w')
+io4 = NWBHDF5IO(filename4, 'w')
 io4.write(nwbfile4, link_data=True)     # <-------- Specify default behavior to link rather than copy data
 io4.close()
 
@@ -177,6 +192,7 @@ io4.close()
 # Linking to whole Containers
 # ---------------------------
 
+"""
 ####################
 # Step 1: Get the container object you want to link to
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -216,4 +232,32 @@ nwbfile3.add_acquisition(timeseries_2)
 io3 = NWBHDF5IO(filename3, 'w')
 io3.write(nwbfile3)
 io3.close()
+"""
+
+####################
+# Creating a single file for sharing
+# -----------------------------------
+#
+# External links are convenient but to share data we may want to hand a single file with all the
+# data to our collaborator rather than having to collect all relevant files. To do this,
+# :py:class:`~pynwb.from.backends.hdf5.h5tools.HDF5IO` (and in turn :py:class:`~pynwb.NWBHDF5IO`)
+# provide the conveniencefunction :py:func:`~pynwb.from.backends.hdf5.h5tools.HDF5IO.copy_file`
+
+NWBHDF5IO.copy_file(source_filename=filename4,
+                    dest_filename=filename5,
+                    expand_external=True)
+
+
+####################
+#
+# Here we copied with the following default settings of :py:func:`~pynwb.from.backends.hdf5.h5tools.HDF5IO.copy_file` :
+#
+#  * ``expand_external=True`` Expand external links into the file, i.e., copy objects refered to by external links
+#  * ``expand_soft=False``    Do not expand soft links
+#  * ``expand_refs=False``    Do not copy objects which are pointed to by reference
+#
+
+
+
+
 

--- a/docs/gallery/general/linking_data.py
+++ b/docs/gallery/general/linking_data.py
@@ -64,7 +64,7 @@ import numpy as np
 # Create the base data
 start_time = datetime(2017, 4, 3, 11, 0, 0)
 create_date = datetime(2017, 4, 15, 12, 0, 0)
-data = np.arange(1000).reshape((100,10))
+data = np.arange(1000).reshape((100, 10))
 timestamps = np.arange(100)
 filename1 = 'external1_example.nwb'
 filename2 = 'external2_example.nwb'
@@ -147,7 +147,7 @@ timeseries_1_data = timeseries_1.data
 # Create a new timeseries that links to our data
 test_ts4 = TimeSeries(name='test_timeseries1',
                       source='PyNWB tutorial',
-                      data= timeseries_1_data,   # <-------
+                      data=timeseries_1_data,   # <-------
                       unit='SIunit',
                       timestamps=timestamps)
 nwbfile4.add_acquisition(test_ts4)
@@ -164,7 +164,8 @@ from pynwb.form.backends.hdf5.h5_utils import H5DataIO
 # Create another timeseries that links to the same data
 test_ts5 = TimeSeries(name='test_timeseries2',
                       source='PyNWB tutorial',
-                      data= H5DataIO(data=timeseries_1_data, link_data=True),   # <-------
+                      data=H5DataIO(data=timeseries_1_data,     # <-------
+                                    link_data=True),            # <-------
                       unit='SIunit',
                       timestamps=timestamps)
 nwbfile4.add_acquisition(test_ts5)
@@ -227,7 +228,7 @@ nwbfile3 = NWBFile(source='PyNWB tutorial',
 nwbfile3.add_acquisition(timeseries_1)             # <--------
 nwbfile3.add_acquisition(timeseries_2)             # <--------
 
-## Write our third file that includes our two timeseries as external links
+# Write our third file that includes our two timeseries as external links
 io3 = NWBHDF5IO(filename3, 'w')
 io3.write(nwbfile3)
 io3.close()
@@ -247,7 +248,6 @@ NWBHDF5IO.copy_file(source_filename=filename4,
                     expand_external=True        # <------ Expand/copy external links
                     )
 
-
 ####################
 #
 # Here we copied with the following default settings of :py:func:`~pynwb.from.backends.hdf5.h5tools.HDF5IO.copy_file` :
@@ -256,8 +256,3 @@ NWBHDF5IO.copy_file(source_filename=filename4,
 #  * ``expand_soft=False``    Do not expand soft links
 #  * ``expand_refs=False``    Do not copy objects which are pointed to by reference
 #
-
-
-
-
-

--- a/docs/gallery/general/linking_data.py
+++ b/docs/gallery/general/linking_data.py
@@ -142,7 +142,7 @@ timeseries_1_data = timeseries_1.data
 # Step 3: Create the object you want to link to the data
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# To make it explicit that we want to link to the dataset we here link to the
+# To link to the dataset we can simply assign the data object (here `` timeseries_1.data``) to a new ``TimeSeries``
 
 # Create a new timeseries that links to our data
 test_ts4 = TimeSeries(name='test_timeseries1',
@@ -154,7 +154,7 @@ nwbfile4.add_acquisition(test_ts4)
 
 ####################
 # In the above case we did not make it explicit how we want to handle the data from
-# our timeseries, this means that :py:class:`~pynwb.NWBHDF5IO` will need to
+# our TimeSeries, this means that :py:class:`~pynwb.NWBHDF5IO` will need to
 # determine on write how to treat the dataset. We can make this explicit and customize this
 # behavior on a per-dataset basis by wrapping our dataset using
 # :py:meth:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`
@@ -176,7 +176,8 @@ nwbfile4.add_acquisition(test_ts5)
 from pynwb import NWBHDF5IO
 
 io4 = NWBHDF5IO(filename4, 'w')
-io4.write(nwbfile4, link_data=True)     # <-------- Specify default behavior to link rather than copy data
+io4.write(nwbfile4,
+          link_data=True)     # <-------- Specify default behavior to link rather than copy data
 io4.close()
 
 #####################
@@ -192,7 +193,6 @@ io4.close()
 # Linking to whole Containers
 # ---------------------------
 
-"""
 ####################
 # Step 1: Get the container object you want to link to
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -218,21 +218,20 @@ timeseries_2 = nwbfile1.get_acquisition('test_timeseries')
 # been written to another file and will create external links for us.
 #
 
-# Create a new NWBFile
-# Create the first file
+# Create a new NWBFile that links to the external timeseries
 nwbfile3 = NWBFile(source='PyNWB tutorial',
                    session_description='demonstrate external files',
                    identifier='NWBE3',
                    session_start_time=start_time,
                    file_create_date=create_date)
-nwbfile3.add_acquisition(timeseries_1)
-nwbfile3.add_acquisition(timeseries_2)
+nwbfile3.add_acquisition(timeseries_1)             # <--------
+nwbfile3.add_acquisition(timeseries_2)             # <--------
 
 ## Write our third file that includes our two timeseries as external links
 io3 = NWBHDF5IO(filename3, 'w')
 io3.write(nwbfile3)
 io3.close()
-"""
+
 
 ####################
 # Creating a single file for sharing
@@ -241,11 +240,12 @@ io3.close()
 # External links are convenient but to share data we may want to hand a single file with all the
 # data to our collaborator rather than having to collect all relevant files. To do this,
 # :py:class:`~pynwb.from.backends.hdf5.h5tools.HDF5IO` (and in turn :py:class:`~pynwb.NWBHDF5IO`)
-# provide the conveniencefunction :py:func:`~pynwb.from.backends.hdf5.h5tools.HDF5IO.copy_file`
+# provide the convenience function :py:func:`~pynwb.from.backends.hdf5.h5tools.HDF5IO.copy_file`
 
 NWBHDF5IO.copy_file(source_filename=filename4,
                     dest_filename=filename5,
-                    expand_external=True)
+                    expand_external=True        # <------ Expand/copy external links
+                    )
 
 
 ####################


### PR DESCRIPTION
## Motivation

Add Sphinx gallery tutorial page for how to create external links.

**Dependencies**
* This example uses the enhancements added in #468 and should hence be merged after #468 
* This example also shows the process for creating external links to whole containers. This is currently not working, because of the tracking of parents raising and error that we can't reassign parents. @ajtritt  is working on this and this pull request should be merged after that problem is fixed. 

The above dependencies occur in the last two sections of the example, i.e., we can also remove those sections for now and add them back later. 

## How to test the behavior?

```
cd docs
make html
open _build/html/tutorials/general/linking_data.html
```
and

```
python docs/gallery/general/linking_data.py
```


## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
