### PR TITLE
Doc/iter write tutorial

### DIFF
--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -153,15 +153,17 @@ from random import random
 import numpy as np
 
 
-def iter_sin(chunk_length=10):
+def iter_sin(chunk_length=10, max_chunks=100):
     """
-    Generator creating a random number of chunks of length chunk_lenght containing
+    Generator creating a random number of chunks (but at most max_chunks) of length chunk_length containing
     random samples of sin([0, 2pi]).
     """
     x = 0
-    while(x < 0.5):
+    num_chunks=0
+    while(x < 0.5 and num_chunks<max_chunks):
         val = np.asarray([sin(random() * 2 * pi) for i in range(chunk_length)])
         x = random()
+        num_chunks += 1
         yield val
     return
 

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -475,7 +475,7 @@ print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks_comp
 
 import numpy as np
 # Create the test data
-datashape = (10000, 10)   # OK, this not really large, but we just want to show how it works
+datashape = (100, 10)   # OK, this not really large, but we just want to show how it works
 num_values = np.prod(datashape)
 arrdata = np.arange(num_values).reshape(datashape)
 # Write the test data to disk
@@ -514,7 +514,7 @@ from pynwb.form.data_utils import DataChunkIterator
 data = DataChunkIterator(data=iter_largearray(filename='basic_sparse_iterwrite_testdata.npy',
                                               shape=datashape),
                          maxshape=datashape,
-                         buffersize=100)   # Buffer 100 elements into a chunk, i.e., create chunks of shape (100,10)
+                         buffersize=10)   # Buffer 10 elements into a chunk, i.e., create chunks of shape (10,10)
 
 
 ####################
@@ -577,7 +577,7 @@ else:
 import numpy as np
 # Create the test data
 num_channels = 10
-num_steps = 10000
+num_steps = 100
 channel_files = ['basic_sparse_iterwrite_testdata_channel_%i.npy' % i for i in range(num_channels)]
 for f in channel_files:
     temp = np.memmap(f, dtype='float64', mode='w+', shape=(num_steps,))

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -160,7 +160,7 @@ def iter_sin(chunk_length=10):
     """
     x = 0
     while(x < 0.5):
-        val = np.asarray([sin(random()*2*pi) for i in range(chunk_length)])
+        val = np.asarray([sin(random() * 2 * pi) for i in range(chunk_length)])
         x = random()
         yield val
     return
@@ -501,7 +501,7 @@ def iter_largearray(filename, shape, dtype='float64'):
     for i in range(shape[0]):
         # Open the file and read the next chunk
         newfp = np.memmap(filename, dtype=dtype, mode='r', shape=shape)
-        curr_data = newfp[i:(i+1), ...]
+        curr_data = newfp[i:(i + 1), ...]
         del newfp  # Reopen the file in each iterator to prevent accumulation of data in memory
         yield curr_data
     return

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -159,8 +159,8 @@ def iter_sin(chunk_length=10, max_chunks=100):
     random samples of sin([0, 2pi]).
     """
     x = 0
-    num_chunks=0
-    while(x < 0.5 and num_chunks<max_chunks):
+    num_chunks = 0
+    while(x < 0.5 and num_chunks < max_chunks):
         val = np.asarray([sin(random() * 2 * pi) for i in range(chunk_length)])
         x = random()
         num_chunks += 1

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -8,10 +8,678 @@ writing large arrays without loading all data into memory and streaming data wri
 """
 
 ####################
+# Introduction
+# --------------------------------------------
+
+
+####################
+# What is Iterative Data Write?
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# ------------
+# In the typical write process, datasets are created and written as a whole. In contrast,
+# iterative data write refers to the writing of the content of a dataset in an incremental,
+# iterative fashion.
+
+####################
+# Why Iterative Data Write?
+# ^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# The possible applications for iterative data write are broad. Here we list a few typcial applications
+# for iterative data write in practice.
+#
+# * **Large data arrays** A central challenge when dealing with large data arrays is that it is often
+#   not feasible to load all of the data into memory. Using an iterative data write process allows us
+#   to avoid this problem by writing the data one-subblock-at-a-time, so that we only need to hold
+#   a small subset of the array in memory at any given time.
+# * **Data streaming** In the context of streaming data we are faced with several issues:
+#   **1)** data is not available in memory but arrives in subblocks as the stream progresses
+#   **2)** caching the data of a stream in-memory is often prohibitively expensive and volatile
+#   **3)** the total size of the data is often unknown ahead of time.
+#   Iterative data write allows us to address issues 1) and 2) by enabling us to save data to
+#   file incrementally as it arrives from the data stream. Issue 3) is addressed in the HDF5
+#   storage backend via support for chunking, enabling the creation of resizable arrays.
+#
+#   * **Data generators** Data generators are in many ways similar to data streams only that the
+#     data is typically being generated locally and programmatically rather than from an external
+#     data source.
+# * **Sparse data arrays** In order to reduce storage size of sparse arrays a challenge is that while
+#   the data array (e.g., a matrix) may be large, only few values are set. To avoid storage overhead
+#   for storing the full array we can employ (in HDF5) a combination of chunking, compression, and
+#   and iterative data write to significantly reduce storage cost for sparse data.
+#
+
+####################
+# Iterating Over Data Arrays
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# In PyNWB the process of iterating over large data arrays is implemented via the concept of
+# :py:class:`~pynwb.form.data_utils.DataChunk` and :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator`.
+#
+# * :py:class:`~pynwb.form.data_utils.DataChunk` is a simple data structure used to describe
+#   a subset of a larger data array (i.e., a data chunk), consisting of:
+#
+#   * ``DataChunk.data`` : the array with the data value(s) of the chunk and
+#   * ``DataChunk.selection`` : the NumPy index tuple describing the location of the chunk in the whole array.
+#
+# * :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator` then defines a class for iterating over large
+#   data arrays one-:py:class:`~pynwb.form.data_utils.DataChunk`-at-a-time.
+#
+# * :py:class:`~pynwb.form.data_utils.DataChunkIterator` is a specific implementation of an
+#   :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator` that accepts any iterable and assumes
+#   that we iterate over the first dimension of the data array. :py:class:`~pynwb.form.data_utils.DataChunkIterator`
+#   also supports buffered read, i.e., multiple values from the input iterator can be combined to a single chunk.
+#   This is useful for buffered I/O operations, e.g., to improve performance by accumulating data in memory and
+#   writing larger blocks at once.
+#
+
+####################
+# Iterative Data Write: API
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# On the front end, all a user needs to do is to create or wrap their data in a
+# :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator`. The I/O backend (e.g.,
+# :py:class:`~pynwb.form.backends.hdf5.h5tools.HDF5IO` or :py:class:`~pynwb.NWBHDF5IO`) then
+# implements the iterative processing of the data chunk iterators. PyNWB also provides with
+# :py:class:`~pynwb.form.data_utils.DataChunkIterator` a specific implementation of a data chunk iterator
+# which we can use to wrap common iterable types (e.g., generators, lists, or numpy arrays).
+# For more advanced use cases we then need to implement our own derived class of
+# :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator`.
+#
+# .. tip::
+#
+#    Currrently the the HDF5 I/O backend of PyNWB (:py:class:`~pynwb.form.backends.hdf5.h5tools.HDF5IO`,
+#    :py:class:`~pynwb.NWBHDF5IO`) processes itertive data writes one-dataset-at-a-time. This means, that
+#    while you may have an arbitrary number of iterative data writes, the write is performed in order.
+#    In the future we may use a queing process to enable the simultaneous processing of multiple iterative writes at
+#    the same time.
+#
+# Preparations:
+# ^^^^^^^^^^^^^^^^^^^^
+#
+# The data write in our examples really does not change. We, therefore, here create a
+# simple helper function first to write a simple NWBFile containing a single timeseries to
+# avoid repition of the same code and to allow us to focus on the important parts of this tutorial.
+
+from datetime import datetime
+from pynwb import NWBFile, TimeSeries
+from pynwb import NWBHDF5IO
+
+
+def write_test_file(filename, data):
+    """
+    Simple helper function to write an NWBFile with a single timeseries containing data
+    :param filename: String with the name of the output file
+    :param data: The data of the timeseries
+    """
+
+    # Create a test NWBfile
+    start_time = datetime(2017, 4, 3, 11, 0, 0)
+    create_date = datetime(2017, 4, 15, 12, 0, 0)
+    nwbfile = NWBFile('PyNWB tutorial',
+                      'demonstrate NWBFile basics',
+                      'NWB123',
+                      start_time,
+                      file_create_date=create_date)
+
+    # Create our time series
+    test_ts = TimeSeries(name='synthetic_timeseries',
+                         source='PyNWB tutorial',
+                         data=data,                     # <---------
+                         unit='SIunit',
+                         rate=1.0,
+                         starting_time=0.0)
+    nwbfile.add_acquisition(test_ts)
+
+    # Write the data to file
+    io = NWBHDF5IO(filename, 'w')
+    io.write(nwbfile)
+    io.close()
+
+
+####################
+# Example: Write Data from Generators and Streams
+# -----------------------------------------------------
+#
+# Here we use a simple data generator but PyNWB does not make any assumptions about what happens
+# inside the generator. Instead of creating data programmatically, you may hence, e.g., receive
+# data from an acquisition system (or other source). We can, hence, use the same approach to write streaming data.
+
+####################
+# Step 1: Define the data generator
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+from math import sin, pi
+from random import random
+import numpy as np
+
+
+def iter_sin(chunk_length=10):
+    """
+    Generator creating a random number of chunks of length chunk_lenght containing
+    random samples of sin([0, 2pi]).
+    """
+    x = 0
+    while(x < 0.5):
+        val = np.asarray([sin(random()*2*pi) for i in range(chunk_length)])
+        x = random()
+        yield val
+    return
+
+
+####################
+# Step 2: Wrap the generator in a DataChunkIterator
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 
 from pynwb.form.data_utils import DataChunkIterator
-from pynwb.form.data_utils import DataChunk
 
+data = DataChunkIterator(data=iter_sin(10))
+
+####################
+# Step 3: Write the data as usual
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Here we use our wrapped generator to create the data for a synthetic time series.
+
+write_test_file(filename='basic_iterwrite_example.nwb',
+                data=data)
+
+####################
+# Discussion
+# ^^^^^^^^^^
+# Note, we here actually do not know how long our timeseries will be.
+
+print("maxshape=%s, recommended_data_shape=%s, dtype=%s" % (str(data.maxshape),
+                                                            str(data.recommended_data_shape()),
+                                                            str(data.dtype)))
+
+####################
+# ``[Out]:``
+#
+# .. code-block:: python
+#
+#   maxshape=(None, 10), recommended_data_shape=(1, 10), dtype=float64
+#
+# As we can see :py:class:`~pynwb.form.data_utils.DataChunkIterator` automatically recommends
+# in its ``maxshape`` that the first dimensions of our array should be unlimited (``None``) and the second
+# dimension be ``10`` (i.e., the length of our chunk. Since :py:class:`~pynwb.form.data_utils.DataChunkIterator`
+# has no way of knowing the minimum size of the array it automatically recommends the size of the first
+# chunk as the minimum size (i.e, ``(1, 10)`` and also infers the data type automatically from the first chunk.
+# To further customize this behavior we may also define the ``maxshape``, ``dtype``, and ``buffer_size`` when
+# we create the :py:class:`~pynwb.form.data_utils.DataChunkIterator`.
+#
+# We here used :py:class:`~pynwb.form.data_utils.DataChunkIterator` to conveniently wrap our data stream.
+#
+# .. tip::
+#
+#    :py:class:`~pynwb.form.data_utils.DataChunkIterator` assumes that our generators yields
+#
+#    * ``1`` complete element along the **first dimension** of our array and
+#    * that we are yielding all elements along the first dimension in **consecutive order**
+#
+#    This behavior is useful in many practical cased. However, If the this strategy does not match our
+#    needs, then we can alternatively implement our own derived
+#    :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator`.  We show an example of this next.
+#
+
+
+####################
+# Example: Optimizing Sparse Data Array I/O and Storage
+# -------------------------------------------------------
+#
+# Step 1: Create a data chunk iterator for our sparse matrix
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+from pynwb.form.data_utils import AbstractDataChunkIterator, DataChunk
+
+
+class SparseMatrixIterator(AbstractDataChunkIterator):
+
+    def __init__(self, shape, num_chunks, chunk_shape):
+        """
+        :param shape: 2D tuple with the shape of the matrix
+        :param num_chunks: Number of data chunks to be created
+        :param chunk_shape: The shape of each chunk to be created
+        :return:
+        """
+        self.shape, self.num_chunks, self.chunk_shape = shape, num_chunks, chunk_shape
+        self.__chunks_created = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """
+        Return in each iteration a fully occupied data chunk of self.chunk_shape values at a random
+        location within the matrix. Chunks are non-overlapping. REMEMBER: h5py does not support all
+        fancy indexing that numpy does so we need to make sure our selection can be
+        handled by the backend.
+        """
+        if self.__chunks_created < self.num_chunks:
+            data = np.random.rand(np.prod(self.chunk_shape)).reshape(self.chunk_shape)
+            xmin = np.random.randint(0, int(self.shape[0] / self.chunk_shape[0]), 1)[0] * self.chunk_shape[0]
+            xmax = xmin + self.chunk_shape[0]
+            ymin = np.random.randint(0, int(self.shape[1] / self.chunk_shape[1]), 1)[0] * self.chunk_shape[1]
+            ymax = ymin + self.chunk_shape[1]
+            self.__chunks_created += 1
+            return DataChunk(data=data,
+                             selection=np.s_[xmin:xmax, ymin:ymax])
+        else:
+            raise StopIteration
+
+    next = __next__
+
+    def recommended_chunk_shape(self):
+        # Here we can optionally recommend what a good chunking should be.
+        return self.chunk_shape
+
+    def recommended_data_shape(self):
+        # We know the full size of the array. In cases where we don't know the full size
+        # this should be the minimum size.
+        return self.shape
+
+    @property
+    def dtype(self):
+        # The data type of our array
+        return np.dtype(float)
+
+    @property
+    def maxshape(self):
+        # We know the full shape of the array. If we don't know the size of a dimension
+        # beforehand we can set the dimension to None instead
+        return self.shape
+
+
+#####################
+# Step 2: Instantiate our sparse matrix
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+
+# Setting for our random sparse matrix
+xsize = 1000000
+ysize = 1000000
+num_chunks = 1000
+chunk_shape = (10, 10)
+num_values = num_chunks * np.prod(chunk_shape)
+
+# Create our sparse matrix data.
+data = SparseMatrixIterator(shape=(xsize, ysize),
+                            num_chunks=num_chunks,
+                            chunk_shape=chunk_shape)
+
+#####################
+# In order to also enable compression and other advanced HDF5 dataset I/O featurs we can then also
+# wrap our data via :py:class:`pynwb.form.backends.hdf5.h5_utils.H5DataIO`.
+from pynwb.form.backends.hdf5.h5_utils import H5DataIO
+matrix2 = SparseMatrixIterator(shape=(xsize, ysize),
+                               num_chunks=num_chunks,
+                               chunk_shape=chunk_shape)
+data2 = H5DataIO(data=matrix2,
+                 compression='gzip',
+                 compression_opts=4)
+
+######################
+# We can now alos customize the chunking , fillvalue and other settings
+#
+from pynwb.form.backends.hdf5.h5_utils import H5DataIO
+
+# Increase the chunk size and add compression
+matrix3 = SparseMatrixIterator(shape=(xsize, ysize),
+                               num_chunks=num_chunks,
+                               chunk_shape=chunk_shape)
+data3 = H5DataIO(data=matrix3,
+                 chunks=(100, 100),
+                 fillvalue=np.nan)
+
+# Increase the chunk size and add compression
+matrix4 = SparseMatrixIterator(shape=(xsize, ysize),
+                               num_chunks=num_chunks,
+                               chunk_shape=chunk_shape)
+data4 = H5DataIO(data=matrix4,
+                 compression='gzip',
+                 compression_opts=4,
+                 chunks=(100, 100),
+                 fillvalue=np.nan
+                 )
+
+####################
+# Step 3: Write the data as usual
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Here we use our SparseMatrixIterator as input for our TimeSeries
+
+write_test_file(filename='basic_sparse_iterwrite_example.nwb',
+                data=data)
+write_test_file(filename='basic_sparse_iterwrite_compressed_example.nwb',
+                data=data2)
+write_test_file(filename='basic_sparse_iterwrite_largechunks_example.nwb',
+                data=data3)
+write_test_file(filename='basic_sparse_iterwrite_largechunks_compressed_example.nwb',
+                data=data4)
+
+####################
+# Check the results
+# ^^^^^^^^^^^^^^^^^
+#
+# Now lets check out the size of our data file and compare it agains the expected full size of our matrix
+import os
+
+expected_size = xsize * ysize * 8              # This is the full size of our matrix in byte
+occupied_size = num_values * 8    # Number of non-zero values in out matrix
+file_size = os.stat('basic_sparse_iterwrite_example.nwb').st_size  # Real size of the file
+file_size_compressed = os.stat('basic_sparse_iterwrite_compressed_example.nwb').st_size
+file_size_largechunks = os.stat('basic_sparse_iterwrite_largechunks_example.nwb').st_size
+file_size_largechunks_compressed = os.stat('basic_sparse_iterwrite_largechunks_compressed_example.nwb').st_size
+mbfactor = 1000. * 1000  # Factor used to convert to MegaBytes
+
+print("1) Sparse Matrix Size:")
+print("   Expected Size :  %.2f MB" % (expected_size / mbfactor))
+print("   Occupied Size :  %.5f MB" % (occupied_size / mbfactor))
+print("2) NWB:N HDF5 file (no compression):")
+print("   File Size     :  %.2f MB" % (file_size / mbfactor))
+print("   Reduction     :  %.2f x" % (expected_size / file_size))
+print("3) NWB:N HDF5 file (with GZIP compression):")
+print("   File Size     :  %.5f MB" % (file_size_compressed / mbfactor))
+print("   Reduction     :  %.2f x" % (expected_size / file_size_compressed))
+print("4) NWB:N HDF5 file (large chunks):")
+print("   File Size     :  %.5f MB" % (file_size_largechunks / mbfactor))
+print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks))
+print("5) NWB:N HDF5 file (large chunks with compression):")
+print("   File Size     :  %.5f MB" % (file_size_largechunks_compressed / mbfactor))
+print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks_compressed))
+
+####################
+# ``[Out]:``
+#
+#  .. code-block:: python
+#
+#        1) Sparse Matrix Size:
+#           Expected Size :  8000000.00 MB
+#           Occupied Size :  0.80000 MB
+#        2) NWB:N HDF5 file (no compression):
+#           File Size     :  0.89 MB
+#           Reduction     :  9035219.28 x
+#        3) NWB:N HDF5 file (with GZIP compression):
+#           File Size     :  0.88847 MB
+#           Reduction     :  9004283.79 x
+#        4) NWB:N HDF5 file (large chunks):
+#           File Size     :  80.08531 MB
+#           Reduction     :  99893.47 x
+#        5) NWB:N HDF5 file (large chunks with compression):
+#           File Size     :  1.14671 MB
+#           Reduction     :  6976450.12 x
+#
+# Discussion
+# ^^^^^^^^^^
+#
+# * **1) vs 2)** While the full matrix would have a size of ``8TB`` the HDF5 file is only ``0.88MB``. This is roughly
+#   the same as the real occupied size of ``0.8MB``. When using chunking, HDF5 does not allocate the full dataset but
+#   only allocates chunks that actually contain data. In (2) the size of our chunks align perfectly with the
+#   occupied chunks of our sparse matrix, hence, only the minimal amount of storage needs to be allocated.
+#   A slight overhead (here 0.08MB) is expected because our file contains also the additional objects from
+#   the NWBFile, plus some overhead for managing all the HDF5 metadata for all objects.
+# * **3) vs 2)**  Adding compression does not yield any improvement here. This is expected, because, again we
+#   selected the chunking here in a way that we already allocated the minimum  amount of storage to represent our data.
+# * **4) vs 2)** When we increase our chunk size to ``(100,100)`` (i.e., ``100x`` larger than the chunks produced by
+#   our matrix generator) we observe an according roughly ``100x`` increase in file size. This is expected
+#   since our chunks now do not align perfectly with the occupied data and each occupied chunk is allocated fully.
+# * **5) vs 4)** When using compression for the larger chunks we see a significant reduction
+#   in file size (``1.14MB`` vs. ``80MB``). This is because the allocated chunks now contain in addition to the random
+#   values large areas of constant fillvalues, which compress easily.
+#
+# **Advantages:**
+#
+# * We only need to hold one :py:class:`~pynwb.form.data_utils.DataChunk` in memory at any given time
+# * Only the data chunks in the HDF5 file that contain non-default values are ever being allocated
+# * The overall size of our file is reduced significantly
+# * Reduced I/O load
+# * On read users can use the array as usual
+#
+# .. tip::
+#
+#    With great power comes great responsibility**!** I/O and storage cost will depend among others on the chunk size,
+#    compression options, and the the write pattern, i.e., the number and structure of the
+#    :py:class:`~pynwb.form.data_utils.DataChunk` objects written. For example, using ``(1,1)`` chunks and writing them
+#    one value at a time would result in poor I/O performance in most practical cases, because of the large number of
+#    chunks and large number of small I/O operations required.
+#
+# .. tip::
+#
+#    A word of caution, while this approach helps optimize storage, the in-memory representation on read is
+#    still a dense numpy array. This behavior is convenient for many user interactions with the data but
+#    can be problematic with regard to performance/memory when accessing large data subsets.
+#
+#   .. code-block:: python
+#
+#       io = NWBHDF5IO('basic_sparse_iterwrite_example.nwb')
+#       nwbfile = io.read()
+#       data = nwbfile.get_acquisition('synthetic_timeseries').data  # <-- PyNWB does lazy load; no problem
+#       subset = data[10:100, 10:100]                                # <-- Loading a subset is fine too
+#       alldata = data[:]            # <-- !!!! This would load the complete (1000000 x 1000000) array !!!!
+#
+# .. tip::
+#
+#    As we have seen here, our data chunk iterator may produce chunks in arbitrary order and locations with the
+#    array. In the case of the HDF5 I/O backend we need to take care that the selection we yield can be understood
+#    by h5py.
+
+####################
+# Example: Convert large binary data arrays
+# -----------------------------------------------------
+#
+# When converting large data files a typical problem is that it is often too expensive to load all the data
+# into memory. This example is very similar to the data generator example only that instead of generating
+# data on-the-fly in memory we are loading data from a file one-chunk-at-a-time in our generator.
+#
+
+####################
+# Create example data
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+import numpy as np
+# Create the test data
+datashape = (10000, 10)   # OK, this not really large, but we just want to show how it works
+num_values = np.prod(datashape)
+arrdata = np.arange(num_values).reshape(datashape)
+# Write the test data to disk
+temp = np.memmap('basic_sparse_iterwrite_testdata.npy', dtype='float64', mode='w+', shape=datashape)
+temp[:] = arrdata
+del temp  # Flush to disk
+
+####################
+# Step 1: Create a generator for our array
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# Note, we here use a generator for simplicity but we could equally well also implement our own
+# :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator`.
+
+
+def iter_largearray(filename, shape, dtype='float64'):
+    """
+    Generator reading [chunk_size, :] elements from our array in each iteration.
+    """
+    for i in range(shape[0]):
+        # Open the file and read the next chunk
+        newfp = np.memmap(filename, dtype=dtype, mode='r', shape=shape)
+        curr_data = newfp[i:(i+1), ...]
+        del newfp  # Reopen the file in each iterator to prevent accumulation of data in memory
+        yield curr_data
+    return
+
+
+####################
+# Step 2: Wrap the generator in a DataChunkIterator
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+
+from pynwb.form.data_utils import DataChunkIterator
+
+data = DataChunkIterator(data=iter_largearray(filename='basic_sparse_iterwrite_testdata.npy',
+                                              shape=datashape),
+                         maxshape=datashape,
+                         buffersize=100)   # Buffer 100 elements into a chunk, i.e., create chunks of shape (100,10)
+
+
+####################
+# Step 3: Write the data as usual
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+
+write_test_file(filename='basic_sparse_iterwrite_largearray.nwb',
+                data=data)
+
+####################
+# .. tip::
+#
+#       Again, if we want to explicitly control how our data will be chunked (compressed etc.)
+#       in the HDF5 file then we need to wrap our :py:class:`~pynwb.form.data_utils.DataChunkIterator`
+#       using :py:class:`pynwb.form.backends.hdf5.h5_utils.H5DataIO`
+
+####################
+# Discussion
+# ^^^^^^^^^^
+# Let's verify that our data was written correctly
+
+# Read the NWB file
+from pynwb import NWBHDF5IO    # noqa
+
+io = NWBHDF5IO('basic_sparse_iterwrite_largearray.nwb')
+nwbfile = io.read()
+data = nwbfile.get_acquisition('synthetic_timeseries').data
+# Compare all the data values of our two arrays
+data_match = np.all(arrdata == data[:])   # Don't do this for very large arrays!
+# Print result message
+if data_match:
+    print("Success: All data values match")
+else:
+    print("ERROR: Mismathch between data")
+
+
+####################
+# ``[Out]:``
+#
+#  .. code-block:: python
+#
+#       Success: All data values match
+
+
+####################
+# Example: Convert arrays stored in multiple files
+# -----------------------------------------------------
+#
+# In practice, data from recording devices may distributed across many files, e.g., one file per time range
+# or one file per recording channel. Using iterative data write provides an elegant solution to this problem
+# as it allows us to process large arrays one-subarray-at-a-time. To make things more interesting we'll show
+# this for the case where each recording channel (i.e, the second dimension of our TimeSeries) is broken up
+# across files.
+
+####################
+# Create example data
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+import numpy as np
+# Create the test data
+num_channels = 10
+num_steps = 10000
+channel_files = ['basic_sparse_iterwrite_testdata_channel_%i.npy' for i in range(num_channels)]
+for f in channel_files:
+    temp = np.memmap(f, dtype='float64', mode='w+', shape=(num_steps,))
+    temp[:] = np.arange(num_steps, dtype='float64')
+    del temp  # Flush to disk
+
+#####################
+# Step 1: Create a data chunk iterator for our multifile array
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+from pynwb.form.data_utils import AbstractDataChunkIterator, DataChunk   # noqa
+
+
+class MultiFileArrayIterator(AbstractDataChunkIterator):
+
+    def __init__(self, channel_files, num_steps):
+        """
+        :param channel_files: List of files with the channels
+        :param num_steps: Number of timesteps per channel
+        :return:
+        """
+        self.shape = (num_steps, len(channel_files))
+        self.channel_files = channel_files
+        self.num_steps = num_steps
+        self.__curr_index = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        """
+        Return in each iteration the data from a single file
+        """
+        if self.__curr_index < len(channel_files):
+            newfp = np.memmap(channel_files[self.__curr_index],
+                              dtype='float64', mode='r', shape=(self.num_steps,))
+            curr_data = newfp[:]
+            i = self.__curr_index
+            self.__curr_index += 1
+            del newfp
+            return DataChunk(data=curr_data,
+                             selection=np.s_[:, i])
+        else:
+            raise StopIteration
+
+    next = __next__
+
+    def recommended_chunk_shape(self):
+        return None   # Use autochunking
+
+    def recommended_data_shape(self):
+        return self.shape
+
+    @property
+    def dtype(self):
+        return np.dtype('float64')
+
+    @property
+    def maxshape(self):
+        return self.shape
+
+
+#####################
+# Step 2: Instantiate our multi file iterator
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+
+data = MultiFileArrayIterator(channel_files, num_steps)
+
+####################
+# Step 3: Write the data as usual
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+
+write_test_file(filename='basic_sparse_iterwrite_multifile.nwb',
+                data=data)
+
+####################
+# Discussion
+# ^^^^^^^^^^
+#
+# That's it ;-)
+#
+# .. tip::
+#
+#    Common mistakes that will result in errors on write:
+#
+#    * The size of a :py:class:`~pynwb.form.data_utils.DataChunk does not match the selection.
+#    * The selection for the :py:class:`~pynwb.form.data_utils.DataChunk` is not supported by h5py
+#      (e.g., unordered lists etc.)
+#
+#    Other common mistakes:
+#
+#    * Choosing inappropriate chunk sizes. This typically means bad performance with regard to I/O and/or storage cost.
+#    * Using auto chunking without supplying a good recommended_data_shape. h5py auto chunking can only make a good
+#      guess of what the chunking should be if it (at least roughly) knows what the shape of the array will be.
+#    * Trying to wrap a data generator using the default :py:class:`~pynwb.form.data_utils.DataChunkIterator`
+#      when the generator that does not comply with the assumptions of the default implementation (i.e., yield
+#      individual, complete elements along the first dimension of the array one-at-a-time). Depending on the generator,
+#      this may or may not result in an error on write, but the the array you are generating will probably end up
+#      at least not having the intended shape.
+#

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -578,7 +578,7 @@ import numpy as np
 # Create the test data
 num_channels = 10
 num_steps = 10000
-channel_files = ['basic_sparse_iterwrite_testdata_channel_%i.npy' for i in range(num_channels)]
+channel_files = ['basic_sparse_iterwrite_testdata_channel_%i.npy' % i for i in range(num_channels)]
 for f in channel_files:
     temp = np.memmap(f, dtype='float64', mode='w+', shape=(num_steps,))
     temp[:] = np.arange(num_steps, dtype='float64')

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -87,7 +87,7 @@ writing large arrays without loading all data into memory and streaming data wri
 #
 # .. tip::
 #
-#    Currrently the the HDF5 I/O backend of PyNWB (:py:class:`~pynwb.form.backends.hdf5.h5tools.HDF5IO`,
+#    Currently the HDF5 I/O backend of PyNWB (:py:class:`~pynwb.form.backends.hdf5.h5tools.HDF5IO`,
 #    :py:class:`~pynwb.NWBHDF5IO`) processes itertive data writes one-dataset-at-a-time. This means, that
 #    while you may have an arbitrary number of iterative data writes, the write is performed in order.
 #    In the future we may use a queing process to enable the simultaneous processing of multiple iterative writes at
@@ -208,17 +208,13 @@ print("maxshape=%s, recommended_data_shape=%s, dtype=%s" % (str(data.maxshape),
 # To further customize this behavior we may also define the ``maxshape``, ``dtype``, and ``buffer_size`` when
 # we create the :py:class:`~pynwb.form.data_utils.DataChunkIterator`.
 #
-# We here used :py:class:`~pynwb.form.data_utils.DataChunkIterator` to conveniently wrap our data stream.
-#
 # .. tip::
 #
-#    :py:class:`~pynwb.form.data_utils.DataChunkIterator` assumes that our generators yields
-#
-#    * ``1`` complete element along the **first dimension** of our array and
-#    * that we are yielding all elements along the first dimension in **consecutive order**
-#
-#    This behavior is useful in many practical cased. However, If the this strategy does not match our
-#    needs, then we can alternatively implement our own derived
+#    We here used :py:class:`~pynwb.form.data_utils.DataChunkIterator` to conveniently wrap our data stream.
+#    :py:class:`~pynwb.form.data_utils.DataChunkIterator` assumes that our generators yields in **consecutive order**
+#    **single** complete element along the **first dimension** of our a array (i.e., iterate over the first
+#    axis and yield one-element-at-a-time). This behavior is useful in many practical cases. However, if
+#    this strategy does not match our needs, then you can alternatively implement our own derived
 #    :py:class:`~pynwb.form.data_utils.AbstractDataChunkIterator`.  We show an example of this next.
 #
 
@@ -309,7 +305,7 @@ data = SparseMatrixIterator(shape=(xsize, ysize),
 
 #####################
 # In order to also enable compression and other advanced HDF5 dataset I/O featurs we can then also
-# wrap our data via :py:class:`pynwb.form.backends.hdf5.h5_utils.H5DataIO`.
+# wrap our data via :py:class:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`.
 from pynwb.form.backends.hdf5.h5_utils import H5DataIO
 matrix2 = SparseMatrixIterator(shape=(xsize, ysize),
                                num_chunks=num_chunks,
@@ -319,7 +315,7 @@ data2 = H5DataIO(data=matrix2,
                  compression_opts=4)
 
 ######################
-# We can now alos customize the chunking , fillvalue and other settings
+# We can now also customize the chunking , fillvalue and other settings
 #
 from pynwb.form.backends.hdf5.h5_utils import H5DataIO
 
@@ -346,7 +342,7 @@ data4 = H5DataIO(data=matrix4,
 # Step 3: Write the data as usual
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# Here we use our SparseMatrixIterator as input for our TimeSeries
+# Here we simply use our ``SparseMatrixIterator`` as input for our ``TimeSeries``
 
 write_test_file(filename='basic_sparse_iterwrite_example.nwb',
                 data=data)
@@ -412,18 +408,19 @@ print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks_comp
 # Discussion
 # ^^^^^^^^^^
 #
-# * **1) vs 2)** While the full matrix would have a size of ``8TB`` the HDF5 file is only ``0.88MB``. This is roughly
+# * **1) vs 2):** While the full matrix would have a size of ``8TB`` the HDF5 file is only ``0.88MB``. This is roughly
 #   the same as the real occupied size of ``0.8MB``. When using chunking, HDF5 does not allocate the full dataset but
 #   only allocates chunks that actually contain data. In (2) the size of our chunks align perfectly with the
 #   occupied chunks of our sparse matrix, hence, only the minimal amount of storage needs to be allocated.
 #   A slight overhead (here 0.08MB) is expected because our file contains also the additional objects from
 #   the NWBFile, plus some overhead for managing all the HDF5 metadata for all objects.
-# * **3) vs 2)**  Adding compression does not yield any improvement here. This is expected, because, again we
-#   selected the chunking here in a way that we already allocated the minimum  amount of storage to represent our data.
-# * **4) vs 2)** When we increase our chunk size to ``(100,100)`` (i.e., ``100x`` larger than the chunks produced by
+# * **3) vs 2):**  Adding compression does not yield any improvement here. This is expected, because, again we
+#   selected the chunking here in a way that we already allocated the minimum  amount of storage to represent our data
+#   and lossless compression of random data is not efficient.
+# * **4) vs 2):** When we increase our chunk size to ``(100,100)`` (i.e., ``100x`` larger than the chunks produced by
 #   our matrix generator) we observe an according roughly ``100x`` increase in file size. This is expected
 #   since our chunks now do not align perfectly with the occupied data and each occupied chunk is allocated fully.
-# * **5) vs 4)** When using compression for the larger chunks we see a significant reduction
+# * **5) vs 4):** When using compression for the larger chunks we see a significant reduction
 #   in file size (``1.14MB`` vs. ``80MB``). This is because the allocated chunks now contain in addition to the random
 #   values large areas of constant fillvalues, which compress easily.
 #
@@ -437,8 +434,8 @@ print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks_comp
 #
 # .. tip::
 #
-#    With great power comes great responsibility**!** I/O and storage cost will depend among others on the chunk size,
-#    compression options, and the the write pattern, i.e., the number and structure of the
+#    With great power comes great responsibility **!** I/O and storage cost will depend among others on the chunk size,
+#    compression options, and the write pattern, i.e., the number and structure of the
 #    :py:class:`~pynwb.form.data_utils.DataChunk` objects written. For example, using ``(1,1)`` chunks and writing them
 #    one value at a time would result in poor I/O performance in most practical cases, because of the large number of
 #    chunks and large number of small I/O operations required.
@@ -459,7 +456,7 @@ print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks_comp
 #
 # .. tip::
 #
-#    As we have seen here, our data chunk iterator may produce chunks in arbitrary order and locations with the
+#    As we have seen here, our data chunk iterator may produce chunks in arbitrary order and locations within the
 #    array. In the case of the HDF5 I/O backend we need to take care that the selection we yield can be understood
 #    by h5py.
 
@@ -467,7 +464,7 @@ print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks_comp
 # Example: Convert large binary data arrays
 # -----------------------------------------------------
 #
-# When converting large data files a typical problem is that it is often too expensive to load all the data
+# When converting large data files, a typical problem is that it is often too expensive to load all the data
 # into memory. This example is very similar to the data generator example only that instead of generating
 # data on-the-fly in memory we are loading data from a file one-chunk-at-a-time in our generator.
 #
@@ -533,7 +530,7 @@ write_test_file(filename='basic_sparse_iterwrite_largearray.nwb',
 #
 #       Again, if we want to explicitly control how our data will be chunked (compressed etc.)
 #       in the HDF5 file then we need to wrap our :py:class:`~pynwb.form.data_utils.DataChunkIterator`
-#       using :py:class:`pynwb.form.backends.hdf5.h5_utils.H5DataIO`
+#       using :py:class:`~pynwb.form.backends.hdf5.h5_utils.H5DataIO`
 
 ####################
 # Discussion
@@ -567,10 +564,10 @@ else:
 # Example: Convert arrays stored in multiple files
 # -----------------------------------------------------
 #
-# In practice, data from recording devices may distributed across many files, e.g., one file per time range
+# In practice, data from recording devices may be distributed across many files, e.g., one file per time range
 # or one file per recording channel. Using iterative data write provides an elegant solution to this problem
 # as it allows us to process large arrays one-subarray-at-a-time. To make things more interesting we'll show
-# this for the case where each recording channel (i.e, the second dimension of our TimeSeries) is broken up
+# this for the case where each recording channel (i.e, the second dimension of our ``TimeSeries``) is broken up
 # across files.
 
 ####################
@@ -668,7 +665,7 @@ write_test_file(filename='basic_sparse_iterwrite_multifile.nwb',
 #
 #    Common mistakes that will result in errors on write:
 #
-#    * The size of a :py:class:`~pynwb.form.data_utils.DataChunk does not match the selection.
+#    * The size of a :py:class:`~pynwb.form.data_utils.DataChunk` does not match the selection.
 #    * The selection for the :py:class:`~pynwb.form.data_utils.DataChunk` is not supported by h5py
 #      (e.g., unordered lists etc.)
 #
@@ -678,8 +675,8 @@ write_test_file(filename='basic_sparse_iterwrite_multifile.nwb',
 #    * Using auto chunking without supplying a good recommended_data_shape. h5py auto chunking can only make a good
 #      guess of what the chunking should be if it (at least roughly) knows what the shape of the array will be.
 #    * Trying to wrap a data generator using the default :py:class:`~pynwb.form.data_utils.DataChunkIterator`
-#      when the generator that does not comply with the assumptions of the default implementation (i.e., yield
+#      when the generator does not comply with the assumptions of the default implementation (i.e., yield
 #      individual, complete elements along the first dimension of the array one-at-a-time). Depending on the generator,
-#      this may or may not result in an error on write, but the the array you are generating will probably end up
+#      this may or may not result in an error on write, but the array you are generating will probably end up
 #      at least not having the intended shape.
 #

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -1,0 +1,17 @@
+"""
+Iterative Data Write
+====================
+
+This example demonstrate how to iteratively write data arrays with applications to
+writing large arrays without loading all data into memory and streaming data write.
+
+"""
+
+####################
+#
+# ------------
+#
+
+from pynwb.form.data_utils import DataChunkIterator
+from pynwb.form.data_utils import DataChunk
+

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -3,7 +3,7 @@ from warnings import warn
 from collections import Iterable
 
 from .form.utils import docval, getargs, popargs, fmt_docval_args
-from .form.data_utils import DataChunkIterator, DataIO
+from .form.data_utils import AbstractDataChunkIterator, DataIO
 
 from . import register_class, CORE_NAMESPACE
 from .core import NWBDataInterface, MultiContainerInterface
@@ -147,11 +147,14 @@ class TimeSeries(NWBDataInterface):
         if isinstance(data, TimeSeries):
             data.fields['data_link'].append(self)
             self.fields['num_samples'] = data.num_samples
-        elif isinstance(data, DataChunkIterator):
+        elif isinstance(data, AbstractDataChunkIterator):
             self.fields['num_samples'] = -1
         elif isinstance(data, DataIO):
             this_data = data.data
-            self.fields['num_samples'] = len(this_data)
+            if isinstance(this_data, AbstractDataChunkIterator):
+                self.fields['num_samples'] = -1
+            else:
+                self.fields['num_samples'] = len(this_data)
         elif data is None:
             self.fields['num_samples'] = 0
         else:

--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -257,7 +257,7 @@ class H5DataIO(DataIO):
                 self.__iosettings['chunks'] = self.data.recommended_chunk_shape()
             # Define the maxshape of the data if not provided by the user
             if 'maxshape' not in self.__iosettings:
-                self.__iosettings['maxshape'] = self.data.get_maxshape()
+                self.__iosettings['maxshape'] = self.data.maxshape
         if 'compression' in self.__iosettings:
             if self.__iosettings['compression'] != 'gzip':
                 warnings.warn(str(self.__iosettings['compression']) + " compression may not be available" +

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -691,9 +691,9 @@ class HDF5IO(FORMIO):
             io_settings['shape'] = data.recommended_data_shape()
         # Define the maxshape of the data if not provided by the user
         if 'maxshape' not in io_settings:
-            io_settings['maxshape'] = data.get_maxshape()
+            io_settings['maxshape'] = data.maxshape
         if 'dtype' not in io_settings:
-            io_settings['dtype'] = data.get_dtype()
+            io_settings['dtype'] = data.dtype
         try:
             dset = parent.create_dataset(name, **io_settings)
         except Exception as exc:

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -118,10 +118,10 @@ class DataChunkIterator(AbstractDataChunkIterator):
         """Initialize the DataChunkIterator"""
         # Get the user parameters
         self.data, self.__maxshape, self.__dtype, self.buffer_size = getargs('data',
-                                                                              'maxshape',
-                                                                              'dtype',
-                                                                              'buffer_size',
-                                                                               kwargs)
+                                                                             'maxshape',
+                                                                             'dtype',
+                                                                             'buffer_size',
+                                                                             kwargs)
         # Create an iterator for the data if possible
         self.__data_iter = iter(self.data) if isinstance(self.data, Iterable) else None
         self.__next_chunk = DataChunk(None, None)

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -25,51 +25,84 @@ def get_shape(data):
         return None
 
 
+@docval_macro('array_data')
 class AbstractDataChunkIterator(with_metaclass(ABCMeta, object)):
+    """
+    Abstract iterator class used to iterate over DataChunks.
+
+    Derived classes must ensure that all abstract methods and abstract properties are implemented, in
+    particular, dtype, maxshape, __iter__, ___next__, recommended_chunk_shape, and recommended_data_shape.
+    """
 
     @abstractmethod
     def __iter__(self):
-        pass
+        """Return the iterator object"""
+        raise NotImplementedError("__iter__ not implemented for derived class")
 
     @abstractmethod
     def __next__(self):
-        pass
+        """
+        Return the next data chunk or raise a StopIteration exception if all chunks have been retrieved.
+
+        HINT: numpy.s_ provides a convenient way to generate index tuples using standard array slicing. This
+        is often useful to define the DataChunk.selection of the current chunk
+
+        :returns: DataChunk object with the data and selection of the current chunk
+        :rtype: DataChunk
+        """
+        raise NotImplementedError("__next__ not implemented for derived class")
 
     @abstractmethod
     def recommended_chunk_shape(self):
-        pass
+        """
+
+        :return: NumPy-style shape tuple describing the recommended shape for the chunks of the target
+                 array or None. This may or may not be the same as the shape of the chunks returned in the
+                 iteration process.
+        """
+        raise NotImplementedError("recommended_chunk_shape not implemented for derived class")
 
     @abstractmethod
     def recommended_data_shape(self):
-        pass
+        """
+        Recommend the initial shape for the data array.
+
+        This is useful in particular to avoid repeated resized of the target array when reading from
+        this data iterator. This should typically be either the final size of the array or the known
+        minimal shape of the array.
+
+        :return: NumPy-style shape tuple indicating the recommended initial shape for the target array.
+                 This may or may not be the final full shape of the array, i.e., the array is allowed
+                 to grow. This should not be None.
+        """
+        raise NotImplementedError("recommended_data_shape not implemented for derived class")
 
     @abstractproperty
     def dtype(self):
-        pass
+        """
+        Define the data type of the array
+
+        :return: NumPy style dtype or otherwise compliant dtype string
+        """
+        raise NotImplementedError("dtype not implemented for derived class")
 
     @abstractproperty
     def maxshape(self):
-        pass
+        """
+        Property describing the maximum shape of the data array that is being iterated over
+
+        :return: NumPy-style shape tuple indicating the maxiumum dimensions up to which the dataset may be
+                 resized. Axes with None are unlimited.
+        """
+        raise NotImplementedError("maxshape not implemented for derived class")
 
 
-@docval_macro('array_data')
 class DataChunkIterator(AbstractDataChunkIterator):
-    """Custom iterator class used to iterate over chunks of data.
+    """
+    Custom iterator class used to iterate over chunks of data.
 
-    Derived classes must ensure that self.shape and self.dtype are set properly.
-    define the self.maxshape property describing the maximum shape of the array.
-    In addition, derived classes must implement the __next__ method (or overwrite _read_next_chunk
-    if the default behavior of __next__ should be reused). The __next__ method must return
-    in each iteration 1) a numpy array with the data values for the chunk and 2) a numpy-compliant index tuple
-    describing where the chunk is located within the complete data.
-    HINT: `numpy.s <https://docs.scipy.org/doc/numpy-1.13.0/reference/generated/numpy.s_.html>`_ provides a
-    convenient way to generate index tuples using standard array slicing. There are
-    a number of additional functions that one can overwrite to customize behavior, e.g,
-    the :py:func:`~form.utils.DataChunkIterator.recommended_chunk_shape` or
-    :py:func:`~form.utils.DataChunkIterator.recommended_data_shape`
-
-    The default implementation accepts any iterable and assumes that we iterate over
-    the first dimension of the data array. The default implemention supports buffered read,
+    This default implementation of AbstractDataChunkIterator accepts any iterable and assumes that we iterate over
+    the first dimension of the data array. DataChunkIterator supports buffered read,
     i.e., multiple values from the input iterator can be combined to a single chunk. This is
     useful for buffered I/O operations, e.g., to improve performance by accumulating data
     in memory and writing larger blocks at once.
@@ -82,7 +115,7 @@ class DataChunkIterator(AbstractDataChunkIterator):
             {'name': 'buffer_size', 'type': int, 'doc': 'Number of values to be buffered in a chunk', 'default': 1},
             )
     def __init__(self, **kwargs):
-        """Initalize the DataChunkIterator"""
+        """Initialize the DataChunkIterator"""
         # Get the user parameters
         self.data, self.__maxshape, self.__dtype, self.buffer_size = getargs('data',
                                                                               'maxshape',

--- a/src/pynwb/form/data_utils.py
+++ b/src/pynwb/form/data_utils.py
@@ -43,12 +43,12 @@ class AbstractDataChunkIterator(with_metaclass(ABCMeta, object)):
     def recommended_data_shape(self):
         pass
 
-    @abstractmethod
-    def get_dtype(self):
+    @abstractproperty
+    def dtype(self):
         pass
 
-    @abstractmethod
-    def get_maxshape(self):
+    @abstractproperty
+    def maxshape(self):
         pass
 
 
@@ -57,7 +57,7 @@ class DataChunkIterator(AbstractDataChunkIterator):
     """Custom iterator class used to iterate over chunks of data.
 
     Derived classes must ensure that self.shape and self.dtype are set properly.
-    define the self.max_shape property describing the maximum shape of the array.
+    define the self.maxshape property describing the maximum shape of the array.
     In addition, derived classes must implement the __next__ method (or overwrite _read_next_chunk
     if the default behavior of __next__ should be reused). The __next__ method must return
     in each iteration 1) a numpy array with the data values for the chunk and 2) a numpy-compliant index tuple
@@ -75,7 +75,7 @@ class DataChunkIterator(AbstractDataChunkIterator):
     in memory and writing larger blocks at once.
     """
     @docval({'name': 'data', 'type': None, 'doc': 'The data object used for iteration', 'default': None},
-            {'name': 'max_shape', 'type': tuple,
+            {'name': 'maxshape', 'type': tuple,
              'doc': 'The maximum shape of the full data array. Use None to indicate unlimited dimensions',
              'default': None},
             {'name': 'dtype', 'type': np.dtype, 'doc': 'The Numpy data type for the array', 'default': None},
@@ -84,52 +84,52 @@ class DataChunkIterator(AbstractDataChunkIterator):
     def __init__(self, **kwargs):
         """Initalize the DataChunkIterator"""
         # Get the user parameters
-        self.data, self.max_shape, self.dtype, self.buffer_size = getargs('data',
-                                                                          'max_shape',
-                                                                          'dtype',
-                                                                          'buffer_size',
-                                                                          kwargs)
+        self.data, self.__maxshape, self.__dtype, self.buffer_size = getargs('data',
+                                                                              'maxshape',
+                                                                              'dtype',
+                                                                              'buffer_size',
+                                                                               kwargs)
         # Create an iterator for the data if possible
         self.__data_iter = iter(self.data) if isinstance(self.data, Iterable) else None
         self.__next_chunk = DataChunk(None, None)
         self.__first_chunk_shape = None
         # Determine the shape of the data if possible
-        if self.max_shape is None:
+        if self.__maxshape is None:
             # If the self.data object identifies it shape then use it
             if hasattr(self.data,  "shape"):
-                self.max_shape = self.data.shape
+                self.__maxshape = self.data.shape
                 # Avoid the special case of scalar values by making them into a 1D numpy array
-                if len(self.max_shape) == 0:
+                if len(self.__maxshape) == 0:
                     self.data = np.asarray([self.data, ])
-                    self.max_shape = self.data.shape
+                    self.__maxshape = self.data.shape
                     self.__data_iter = iter(self.data)
-            # Try to get an accurate idea of max_shape for other Python datastructures if possible.
+            # Try to get an accurate idea of __maxshape for other Python datastructures if possible.
             # Don't just callget_shape for a generator as that would potentially trigger loading of all the data
             elif isinstance(self.data, list) or isinstance(self.data, tuple):
-                self.max_shape = ShapeValidator.get_data_shape(self.data, strict_no_data_load=True)
+                self.__maxshape = ShapeValidator.get_data_shape(self.data, strict_no_data_load=True)
 
         # If we have a data iterator, then read the first chunk
-        if self.__data_iter is not None:  # and(self.max_shape is None or self.dtype is None):
+        if self.__data_iter is not None:  # and(self.__maxshape is None or self.__dtype is None):
             self._read_next_chunk()
 
         # If we still don't know the shape then try to determine the shape from the first chunk
-        if self.max_shape is None and self.__next_chunk.data is not None:
+        if self.__maxshape is None and self.__next_chunk.data is not None:
             data_shape = ShapeValidator.get_data_shape(self.__next_chunk.data)
-            self.max_shape = list(data_shape)
+            self.__maxshape = list(data_shape)
             try:
-                self.max_shape[0] = len(self.data)  # We use self.data here because self.__data_iter does not allow len
+                self.__maxshape[0] = len(self.data)  # We use self.data here because self.__data_iter does not allow len
             except TypeError:
-                self.max_shape[0] = None
-            self.max_shape = tuple(self.max_shape)
+                self.__maxshape[0] = None
+            self.__maxshape = tuple(self.__maxshape)
 
         # Determine the type of the data if possible
         if self.__next_chunk.data is not None:
-            self.dtype = self.__next_chunk.data.dtype
+            self.__dtype = self.__next_chunk.data.dtype
             self.__first_chunk_shape = ShapeValidator.get_data_shape(self.__next_chunk.data)
 
     @classmethod
     @docval({'name': 'data', 'type': None, 'doc': 'The data object used for iteration', 'default': None},
-            {'name': 'max_shape', 'type': tuple,
+            {'name': 'maxshape', 'type': tuple,
              'doc': 'The maximum shape of the full data array. Use None to indicate unlimited dimensions',
              'default': None},
             {'name': 'dtype', 'type': np.dtype, 'doc': 'The Numpy data type for the array', 'default': None},
@@ -217,16 +217,18 @@ class DataChunkIterator(AbstractDataChunkIterator):
     def recommended_data_shape(self):
         """Recommend an initial shape of the data. This is useful when progressively writing data and
         we want to recommend and initial size for the dataset"""
-        if self.max_shape is not None:
-            if np.all([i is not None for i in self.max_shape]):
-                return self.max_shape
+        if self.__maxshape is not None:
+            if np.all([i is not None for i in self.__maxshape]):
+                return self.__maxshape
         return self.__first_chunk_shape
 
-    def get_maxshape(self):
-        return self.max_shape
+    @property
+    def maxshape(self):
+        return self.__maxshape
 
-    def get_dtype(self):
-        return self.dtype
+    @property
+    def dtype(self):
+        return self.__dtype
 
 
 class DataChunk(object):
@@ -286,7 +288,7 @@ class ShapeValidator(object):
                     shape.extend(__get_shape_helper(local_data[0]))
             return tuple(shape)
         if isinstance(data, DataChunkIterator):
-            return data.max_shape
+            return data.maxshape
         if hasattr(data, 'shape'):
             return data.shape
         if hasattr(data, '__len__') and not isinstance(data, (text_type, binary_type)):

--- a/tests/unit/form_tests/utils_test/test_core_DataChunkIterator.py
+++ b/tests/unit/form_tests/utils_test/test_core_DataChunkIterator.py
@@ -14,7 +14,7 @@ class DataChunkIteratorTests(unittest.TestCase):
 
     def test_none_iter(self):
         dci = DataChunkIterator(None)
-        self.assertIsNone(dci.max_shape)
+        self.assertIsNone(dci.maxshape)
         self.assertIsNone(dci.dtype)
         count = 0
         for chunk in dci:
@@ -40,7 +40,7 @@ class DataChunkIteratorTests(unittest.TestCase):
     def test_numpy_iter_unmatched_buffer_size(self):
         a = np.arange(10)
         dci = DataChunkIterator(data=a, buffer_size=3)
-        self.assertTupleEqual(dci.max_shape, a.shape)
+        self.assertTupleEqual(dci.maxshape, a.shape)
         self.assertEquals(dci.dtype, a.dtype)
         count = 0
         for chunk in dci:
@@ -56,7 +56,7 @@ class DataChunkIteratorTests(unittest.TestCase):
     def test_standard_iterator_unbuffered(self):
         dci = DataChunkIterator(data=range(10), buffer_size=1)
         self.assertEqual(dci.dtype, np.dtype(int))
-        self.assertTupleEqual(dci.max_shape, (10,))
+        self.assertTupleEqual(dci.maxshape, (10,))
         self.assertTupleEqual(dci.recommended_data_shape(), (10,))  # Test before and after iteration
         count = 0
         for chunk in dci:
@@ -69,7 +69,7 @@ class DataChunkIteratorTests(unittest.TestCase):
     def test_standard_iterator_unmatched_buffersized(self):
         dci = DataChunkIterator(data=range(10), buffer_size=3)
         self.assertEquals(dci.dtype, np.dtype(int))
-        self.assertTupleEqual(dci.max_shape, (10,))
+        self.assertTupleEqual(dci.maxshape, (10,))
         self.assertIsNone(dci.recommended_chunk_shape())
         self.assertTupleEqual(dci.recommended_data_shape(), (10,))  # Test before and after iteration
         count = 0
@@ -85,7 +85,7 @@ class DataChunkIteratorTests(unittest.TestCase):
     def test_multidimensional_list(self):
         a = np.arange(30).reshape(5, 2, 3).tolist()
         dci = DataChunkIterator(a)
-        self.assertTupleEqual(dci.max_shape, (5, 2, 3))
+        self.assertTupleEqual(dci.maxshape, (5, 2, 3))
         self.assertEqual(dci.dtype, np.dtype(int))
         count = 0
         for chunk in dci:
@@ -95,17 +95,17 @@ class DataChunkIteratorTests(unittest.TestCase):
         self.assertTupleEqual(dci.recommended_data_shape(), (5, 2, 3))
         self.assertIsNone(dci.recommended_chunk_shape())
 
-    def test_max_shape(self):
+    def test_maxshape(self):
         a = np.arange(30).reshape(5, 2, 3)
         aiter = iter(a)
         daiter = DataChunkIterator.from_iterable(aiter, buffer_size=2)
-        self.assertEqual(daiter.get_maxshape(), (None, 2, 3))
+        self.assertEqual(daiter.maxshape, (None, 2, 3))
 
     def test_dtype(self):
         a = np.arange(30, dtype='int32').reshape(5, 2, 3)
         aiter = iter(a)
         daiter = DataChunkIterator.from_iterable(aiter, buffer_size=2)
-        self.assertEqual(daiter.get_dtype(), a.dtype)
+        self.assertEqual(daiter.dtype, a.dtype)
 
 
 class DataChunkTests(unittest.TestCase):

--- a/tests/unit/form_tests/utils_test/test_core_ShapeValidator.py
+++ b/tests/unit/form_tests/utils_test/test_core_ShapeValidator.py
@@ -140,8 +140,7 @@ class ShapeValidatorTests(unittest.TestCase):
 
     def test_DataChunkIterator_ignore_undetermined_axis(self):
         # Compare data chunk iterators with undetermined axis (ignore axis)
-        d1 = DataChunkIterator(data=np.arange(10).reshape(2, 5))
-        d1.max_shape = (None, 5)
+        d1 = DataChunkIterator(data=np.arange(10).reshape(2, 5), maxshape=(None, 5))
         d2 = DataChunkIterator(data=np.arange(10).reshape(2, 5))
         res = ShapeValidator.assertEqualShape(d1, d2, ignore_undetermined=True)
         self.assertTrue(res.result)
@@ -155,8 +154,7 @@ class ShapeValidatorTests(unittest.TestCase):
 
     def test_DataChunkIterator_error_on_undetermined_axis(self):
         # Compare data chunk iterators with undetermined axis (error on undetermined axis)
-        d1 = DataChunkIterator(data=np.arange(10).reshape(2, 5))
-        d1.max_shape = (None, 5)
+        d1 = DataChunkIterator(data=np.arange(10).reshape(2, 5), maxshape=(None, 5))
         d2 = DataChunkIterator(data=np.arange(10).reshape(2, 5))
         res = ShapeValidator.assertEqualShape(d1, d2, ignore_undetermined=False)
         self.assertFalse(res.result)


### PR DESCRIPTION
## Motivation

Add tutorial on iterative data write using ``AbstractDataChunkIterator``

This also adds a few changes for the iterative data write itself. In particular:

* ``get_dtype`` and ``get_maxshape`` are now abstract properties``type`` and ``maxshape``  of `` AbstractDataChunkIterator`` and its subclasses
* Bug fixes to allow ``TimeSeries``to use ``AbstractDataChunkIterator`` implementations in general not just our own ``DataChunkIterator``
* Added/updated the docs for ``AbstractDataChunkIterator`` and ``DataChunkIterator``

## How to test the behavior?
```
python  python docs/gallery/general/iterative_write.py 
```
and

```
cd docs
make html
open _build/html/tutorials/general/iterative_write.html
```


## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
