### PR TITLE
names cannot include '/'

### DIFF
--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -101,7 +101,10 @@ class NWBBaseType(with_metaclass(ExtenderMeta)):
         super(NWBBaseType, self).__init__()
         self.__fields = dict()
         self.__parent = None
-        self.__name = getargs('name', kwargs)
+        name = getargs('name', kwargs)
+        if '/' in name:
+            raise ValueError("name '" + name + "' cannot contain '/'")
+        self.__name = name
         if parent:
             self.parent = parent
         self.__container_source = container_source

--- a/tests/unit/pynwb_tests/test_core_NWBContainer.py
+++ b/tests/unit/pynwb_tests/test_core_NWBContainer.py
@@ -44,6 +44,13 @@ class TestNWBContainer(unittest.TestCase):
         child_obj.parent = parent_obj
         self.assertIs(child_obj.parent, parent_obj)
 
+    def test_slash_restriction(self):
+        """
+        Make sure that a slash is not allowed in the name of an object.
+        This is necessary because h5py interprets '/' as a new group
+        """
+        self.assertRaises(ValueError, MyTestClass, 'test source', 'bad/name')
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The '/' character causes a problem for names of datasets because h5py interprets and creates subgroups, which is not the desired behavior.

Add ValueError in constructor for all data objects if '/' is present
Add test that '/' raises error

## Motivation

fix #129 

## How to test the behavior?
```python
from pynwb import NWBContainer
NWBContainer('a', 'b/c')
```
should raise: `ValueError: name 'b/c' cannot contain '/'`

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
