### PR TITLE
Cache allen sdk files on circle for speeding up tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,6 +83,24 @@ conda-steps: &conda-steps
         command: |
           tox -e $TEST_WHEELINSTALL_ENV --recreate --installpkg dist/*-none-any.whl
 
+gallery-steps: &gallery-steps
+  steps:
+    - checkout
+    - restore_cache:
+        keys:
+          - ophys-data-cache
+    - run:
+        <<: *initialize-venv
+    - run:
+        name: Run the gallery tests
+        command: |
+          . ../venv/bin/activate
+          pip install tox
+          tox -e $TEST_TOX_ENV
+    - save_cache:
+        key: ophys-data-cache
+        paths: ophys_experiment_data
+
 version: 2
 jobs:
   flake8:
@@ -152,28 +170,26 @@ jobs:
       - TEST_WHEELINSTALL_ENV: "wheelinstall-py36"
     <<: *conda-steps
 
-  gallery:
+  gallery27:
+    docker:
+      - image: circleci/python:2.7.14-jessie
+    environment:
+     - TEST_TOX_ENV: "gallery-py27"
+    <<: *gallery-steps
+
+  gallery35:
+    docker:
+      - image: circleci/python:3.5.4-jessie
+    environment:
+     - TEST_TOX_ENV: "gallery-py35"
+    <<: *gallery-steps
+
+  gallery36:
     docker:
       - image: circleci/python:3.6.3-jessie
     environment:
-     - TEST_TOX_ENV: "gallery"
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - ophys-data
-      - run:
-          <<: *initialize-venv
-      - run:
-          name: Run the gallery tests
-          command: |
-            . ../venv/bin/activate
-            pip install tox
-            tox -e $TEST_TOX_ENV
-          no_output_timeout: 20m
-      - save_cache:
-          key: ophys-data
-          paths: ophys_experiment_data/*.nwb
+     - TEST_TOX_ENV: "gallery-py36"
+    <<: *gallery-steps
 
 workflows:
   version: 2
@@ -186,4 +202,6 @@ workflows:
       - miniconda27
       - miniconda35
       - miniconda36
-      - gallery
+      - gallery27
+      - gallery35
+      - gallery36

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,6 +159,9 @@ jobs:
      - TEST_TOX_ENV: "gallery"
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - ophys-data
       - run:
           <<: *initialize-venv
       - run:
@@ -168,6 +171,9 @@ jobs:
             pip install tox
             tox -e $TEST_TOX_ENV
           no_output_timeout: 20m
+      - save_cache:
+          key: ophys-data
+          paths: ophys_experiment_data/*.nwb
 
 workflows:
   version: 2

--- a/tox.ini
+++ b/tox.ini
@@ -18,19 +18,6 @@ deps =
 commands =
     python test.py
 
-[testenv:gallery]
-usedevelop = True
-install_command =
-    pip install -U {opts} {packages}
-
-deps =
-    -rrequirements-dev.txt
-    -rrequirements.txt
-    -rrequirements-doc.txt
-
-commands =
-    python test.py --example
-
 # Env to create coverage report locally
 [testenv:localcoverage]
 basepython = python3.6
@@ -90,3 +77,33 @@ commands = python -c "import pynwb"
 [testenv:wheelinstall-py36]
 deps = null
 commands = python -c "import pynwb"
+
+# Envs that will execute gallery tests
+[testenv:gallery]
+install_command =
+    pip install -U {opts} {packages}
+
+deps =
+    -rrequirements-dev.txt
+    -rrequirements.txt
+    -rrequirements-doc.txt
+
+commands =
+    python test.py --example
+
+[testenv:gallery-py27]
+basepython = python2.7
+deps = {[testenv:gallery]deps}
+commands = {[testenv:gallery]commands}
+
+
+[testenv:gallery-py35]
+basepython = python3.5
+deps = {[testenv:gallery]deps}
+commands = {[testenv:gallery]commands}
+
+
+[testenv:gallery-py36]
+basepython = python3.6
+deps = {[testenv:gallery]deps}
+commands = {[testenv:gallery]commands}


### PR DESCRIPTION
## Motivation

Caches big data file so that circle does not have to download it every time. This will speed up gallery tests significantly. Also we run the gallery tests for all 3 python versions now. @nicain that would be great if you can review it. 
