### PR TITLE
Remove pep8speaks since we run flake8 as part of circle

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,6 +1,0 @@
-pycodestyle:
-    max-line-length: 120
-    ignore:
-        - E402
-scanner:
-    diff_only: True

--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -139,7 +139,7 @@ Format Specification Styleguide
 Python Code Styleguide
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Python coding style is checked via ``flake8`` and ``pep8speaks`` for automatic checking of PEP8 style during pull requets.
+Python coding style is checked via ``flake8`` for automatic checking of PEP8 style during pull requets.
 
 Endorsement
 -----------
@@ -156,5 +156,3 @@ As indicated in the PyNWB license: *“You are under no obligation whatsoever to
 Contributors to the NWB code base are expected to use a permissive, non-copyleft open source license. Typically 3-clause BSD i used, but any compatible license is allowed, the MIT and Apache 2.0 licenses being good alternative choices. The GPL and other copyleft licenses are not allowed due to the consternation it generates across many organizations.
 
 Also, make sure that you are permitted to contribute code. Some organizations, even academic organizations, have agreements in place that discuss IP ownership in detail (i.e., address IP rights and ownership that you create while under the employ of the organization). These are typically signed documents that you looked at on your first day of work and then promptly forgot. We don’t want contributed code to be yanked later due to IP issues.
-
-


### PR DESCRIPTION
## Motivation

Pep8speaks executes [pep8](http://pep8.readthedocs.io/en/release-1.7.x/intro.html) when a PR is submitted. We also run [flake8](http://flake8.pycqa.org/en/latest/) as part of our testing infrastructure. This was getting confusing so we decided to rely on flake8 tests that are executed by circle [here]
(https://github.com/NeurodataWithoutBorders/pynwb/blob/remove-pep8speaks/.circleci/config.yml#L106-L114). Before this PR gets merged we need to disable pep8speak service from PyNWB repository. It can be found under settings/Integrations & services. 

![settings](https://user-images.githubusercontent.com/11761461/39363051-dd845bc2-49f6-11e8-8d88-cff0e50f395f.png)

![int_services](https://user-images.githubusercontent.com/11761461/39363101-10ce2fda-49f7-11e8-97cf-9b254dde2760.png)

![configure](https://user-images.githubusercontent.com/11761461/39363105-13c6d340-49f7-11e8-948c-7de736118a2e.png)

An admin needs to do this. @oruebel @ajtritt 




