### PR TITLE
Add codecov config file for better defaults

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,9 +2,11 @@ coverage:
   status:
     project:
       default:
-        target: auto
-        threshold: 1%
+        # Don't allow overall project coverage to be dropped more than
+        # 2%
+        threshold: 2
     patch:
       default:
-        target: auto
-        threshold: 1%
+        # 75% of the changed code must be covered by tests
+        threshold: 25
+        only_pulls: true


### PR DESCRIPTION
## Motivation

This PR adds to conditions. 

1) We make the coverage checks fail if a PR adds a lot of code without tests so that it drops overall coverage by 2%. 

2) We make the coverage checks fail if a PR adds code but covers less than 75% of the changed lines.

We can always adjust these numbers if they become annoying. We use these numbers in some of our projects and they have been serving well so far. 
