### PR TITLE
Fix NWB Extensions tutorial order of arguments in call to NWBAttributeSpec

### DIFF
--- a/docs/gallery/general/extensions.py
+++ b/docs/gallery/general/extensions.py
@@ -27,7 +27,7 @@ ext_source = "mylab.extensions.yaml"
 
 ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', "mylab")
 ext = NWBGroupSpec('A custom ElectricalSeries for my lab',
-                   attributes=[NWBAttributeSpec('trode_id', 'int', 'the tetrode id')],
+                   attributes=[NWBAttributeSpec('trode_id', 'the tetrode id', 'int')],
                    neurodata_type_inc='ElectricalSeries',
                    neurodata_type_def='TetrodeSeries')
 


### PR DESCRIPTION
This fixes issue issue #502 

(Corrects the order of the arguments in the call to NWBAttributeSpec in the tutorial at:
https://pynwb.readthedocs.io/en/latest/tutorials/general/extensions.html#sphx-glr-tutorials-general-extensions-py ).