### PR TITLE
Add codecov parameter file and set coverage alert threshold to 1%

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
Setting documentation can be found at
https://docs.codecov.io/docs/commit-status
    
It was checked using the provided validator.
See https://codecov.io/gh/NeurodataWithoutBorders/pynwb/settings/yaml
