### PR TITLE
Added NWBRefSpec class and tests. Fix #332

### DIFF
--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -1,6 +1,7 @@
 from copy import copy, deepcopy
 
-from .form.spec import LinkSpec, GroupSpec, DatasetSpec, SpecNamespace, NamespaceBuilder, AttributeSpec, DtypeSpec
+from .form.spec import LinkSpec, GroupSpec, DatasetSpec, SpecNamespace,\
+                       NamespaceBuilder, AttributeSpec, DtypeSpec, RefSpec
 from .form.utils import docval, get_docval, fmt_docval_args
 
 from . import CORE_NAMESPACE
@@ -20,6 +21,17 @@ def __swap_inc_def(cls):
         else:
             ret.append(copy(arg))
     return ret
+
+
+_ref_docval = __swap_inc_def(RefSpec)
+
+
+class NWBRefSpec(RefSpec):
+
+    @docval(*_ref_docval)
+    def __init__(self, **kwargs):
+        args, kwargs = fmt_docval_args(RefSpec.__init__, kwargs)
+        super(NWBRefSpec, self).__init__(*args, **kwargs)
 
 
 _attr_docval = __swap_inc_def(AttributeSpec)

--- a/tests/unit/form_tests/spec_tests/test_ref_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_ref_spec.py
@@ -1,0 +1,17 @@
+import unittest2 as unittest
+import json
+
+from pynwb.form.spec import RefSpec
+
+
+class RefSpecTests(unittest.TestCase):
+
+    def test_constructor(self):
+        spec = RefSpec('TimeSeries', 'object')
+        self.assertEqual(spec.target_type, 'TimeSeries')
+        self.assertEqual(spec.reftype, 'object')
+        json.dumps(spec)  # to ensure there are no circular links
+
+    def test_wrong_reference_type(self):
+        with self.assertRaises(ValueError):
+            RefSpec('TimeSeries', 'unknownreftype')

--- a/tests/unit/pynwb_tests/test_spec.py
+++ b/tests/unit/pynwb_tests/test_spec.py
@@ -7,11 +7,25 @@ gets mapped appropriately when constructors and methods are invoked
 import unittest
 
 from pynwb.spec import NWBNamespaceBuilder
+from pynwb.spec import NWBRefSpec
+import json
+
 
 # create a builder for the namespace
-
-
 class NWBNamespaceTest(unittest.TestCase):
 
     def test_constructor(self):
         self.ns_builder = NWBNamespaceBuilder("Frank Laboratory NWB Extensions", "franklab", version='0.1')
+
+
+class NWBRefSpecTests(unittest.TestCase):
+
+    def test_constructor(self):
+        spec = NWBRefSpec('TimeSeries', 'object')
+        self.assertEqual(spec.target_type, 'TimeSeries')
+        self.assertEqual(spec.reftype, 'object')
+        json.dumps(spec)  # to ensure there are no circular links
+
+    def test_wrong_reference_type(self):
+        with self.assertRaises(ValueError):
+            NWBRefSpec('TimeSeries', 'unknownreftype')


### PR DESCRIPTION
## Motivation

Fix #332 . Adds NWBRefSpec class for consistency to ensure that all spec classes in FORM have an equivalent NWB class. This is mainly to make usage more consistent to ensure that all classes can be imported (with the NBW prefix) directly from ``pynwb.spec``

## How to test the behavior?

``from pynwb.spec import NWBRefSpec``

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
