### PR TITLE
Bug fix for attributes with RefSpec dtypes

### DIFF
--- a/docs/gallery/domain/brain_observatory.py
+++ b/docs/gallery/domain/brain_observatory.py
@@ -6,7 +6,9 @@ Create an nwb file from Allen Brain Observatory data.
 """
 
 ########################################
-# This example demostrates the basic functionality of several parts of the pynwb write API, centered around the optical physiology submodule (pynwb.ophys). We will use the allensdk as a read API, while leveraging the pynwb data model and write api to transform and write the data back to disk.
+# This example demostrates the basic functionality of several parts of the pynwb write API, centered around the optical
+# physiology submodule (pynwb.ophys). We will use the allensdk as a read API, while leveraging the pynwb data model and
+# write api to transform and write the data back to disk.
 
 ########################################
 # .. raw:: html
@@ -27,7 +29,9 @@ ophys_experiment_id = 562095852
 save_file_name = 'brain_observatory.nwb'
 
 ########################################
-# Let's begin by downloading an Allen Institute Brain Observatory file.  After we cache this file locally (approx. 450 MB), we can open data assets we wish to write into our NWB:N file.  These include stimulus, acquisition, and processing data, as well as time "epochs" (intervals of interest)".
+# Let's begin by downloading an Allen Institute Brain Observatory file.  After we cache this file locally (approx. 450
+# MB), we can open data assets we wish to write into our NWB:N file.  These include stimulus, acquisition, and
+# processing data, as well as time "epochs" (intervals of interest)".
 boc = BrainObservatoryCache(manifest_file='manifest.json')
 dataset = boc.get_ophys_experiment_data(ophys_experiment_id)
 metadata = dataset.get_metadata()
@@ -44,7 +48,9 @@ epoch_table['start'] = timestamps[epoch_table['start'].values]
 epoch_table['end'] = timestamps[epoch_table['end'].values]
 
 ########################################
-# 1) First, lets create a top-level "file" container object.  All the other NWB:N data components will be stored hierarchically, relative to this container.  The data won't actually be written to the file system until the end of the script.
+# 1) First, lets create a top-level "file" container object.  All the other NWB:N data components will be stored
+# hierarchically, relative to this container.  The data won't actually be written to the file system until the end of
+# the script.
 
 nwbfile = NWBFile(
     source='Allen Brain Observatory: Visual Coding',
@@ -56,7 +62,8 @@ nwbfile = NWBFile(
 
 
 ########################################
-# 2) Next, we add stimuli templates (one for each type of stimulus), and a data series that indexes these templates to describe what stimulus was being shown during the experiment.
+# 2) Next, we add stimuli templates (one for each type of stimulus), and a data series that indexes these templates to
+# describe what stimulus was being shown during the experiment.
 for stimulus in stimulus_list:
     visual_stimulus_images = ImageSeries(
         name=stimulus,
@@ -76,7 +83,8 @@ for stimulus in stimulus_list:
     nwbfile.add_stimulus(image_index)
 
 ########################################
-# 3) Besides the two-photon calcium image stack, the running speed of the animal was also recordered in this experiment.  We can store this data as a TimeSeries, in the acquisition portion of the file.
+# 3) Besides the two-photon calcium image stack, the running speed of the animal was also recordered in this experiment.
+# We can store this data as a TimeSeries, in the acquisition portion of the file.
 
 running_speed = TimeSeries(
     name='running_speed',
@@ -88,7 +96,10 @@ running_speed = TimeSeries(
 nwbfile.add_acquisition(running_speed)
 
 ########################################
-# 4) In NWB:N, an "epoch" is an interval of experiment time that can slice into a timeseries (for example running_speed, the one we just added).  PyNWB uses an object-oriented approach to create links into these timeseries, so that data is not copied multiple times.  Here, we extract the stimulus epochs (both fine and coarse-grained) from the Brain Observatory experiment using the allensdk.
+# 4) In NWB:N, an "epoch" is an interval of experiment time that can slice into a timeseries (for example running_speed,
+# the one we just added).  PyNWB uses an object-oriented approach to create links into these timeseries, so that data is
+# not copied multiple times.  Here, we extract the stimulus epochs (both fine and coarse-grained) from the Brain
+# Observatory experiment using the allensdk.
 
 for ri, row in trial_table.iterrows():
     nwbfile.create_epoch(start_time=row.start,
@@ -105,7 +116,10 @@ for ri, row in epoch_table.iterrows():
                          description=row.stimulus)
 
 ########################################
-# 5) In the brain observatory, a two-photon microscope is used to acquire images of the calcium activity of neurons expressing a flourescent protien indicator.  Essentially the microscope captures picture (30 times a second) at a single depth in the visual cortex (the imaging plane).  Let's use pynwb to store the metadata associated with this hardware and experimental setup:
+# 5) In the brain observatory, a two-photon microscope is used to acquire images of the calcium activity of neurons
+# expressing a flourescent protien indicator.  Essentially the microscope captures picture (30 times a second) at a
+# single depth in the visual cortex (the imaging plane).  Let's use pynwb to store the metadata associated with this
+# hardware and experimental setup:
 optical_channel = OpticalChannel(
     name='optical_channel',
     source='Allen Brain Observatory: Visual Coding',
@@ -130,7 +144,10 @@ imaging_plane = nwbfile.create_imaging_plane(
 )
 
 ########################################
-# The Allen Insitute does not include the raw imaging signal, as this data would make the file too large. Instead, these data are  preprocessed, and a dF/F flourescence signal extracted for each region-of-interest (ROI). To store the chain of computations necessary to describe this data processing pipeline, pynwb provides a "processing module" with interfaces that simplify and standarize the process of adding the steps in this provenance chain to the file:
+# The Allen Insitute does not include the raw imaging signal, as this data would make the file too large. Instead, these
+# data are  preprocessed, and a dF/F flourescence signal extracted for each region-of-interest (ROI). To store the chain
+# of computations necessary to describe this data processing pipeline, pynwb provides a "processing module" with
+# interfaces that simplify and standarize the process of adding the steps in this provenance chain to the file:
 ophys_module = nwbfile.create_processing_module(
     name='ophys_module',
     source='Allen Brain Observatory: Visual Coding',
@@ -138,7 +155,8 @@ ophys_module = nwbfile.create_processing_module(
 )
 
 ########################################
-# 6) First, we add an image segmentation interface to the module.  This interface implements a pre-defined schema and API that facilitates writing segmentation masks for ROI's:
+# 6) First, we add an image segmentation interface to the module.  This interface implements a pre-defined schema and
+# API that facilitates writing segmentation masks for ROI's:
 
 image_segmentation_interface = ImageSegmentation(
     name='image_segmentation',
@@ -158,7 +176,8 @@ for cell_specimen_id in cell_specimen_ids:
     plane_segmentation.add_roi(curr_name, [], curr_image_mask)
 
 ########################################
-# 7) Next, we add a dF/F  interface to the module.  This allows us to write the dF/F timeseries data associated with each ROI.
+# 7) Next, we add a dF/F  interface to the module.  This allows us to write the dF/F timeseries data associated with
+# each ROI.
 
 dff_interface = DfOverF(name='dff_interface', source='Flourescence data container')
 ophys_module.add_data_interface(dff_interface)

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -931,10 +931,17 @@ class TypeMap(object):
         'int32': int
     }
 
-    @classmethod
     def __get_type(self, spec):
         if isinstance(spec, AttributeSpec):
-            return self._type_map.get(spec.dtype)
+            if isinstance(spec.dtype, RefSpec):
+                tgttype = spec.dtype.target_type
+                for val in self.__container_types.values():
+                    container_type = val.get(tgttype)
+                    if container_type is not None:
+                        return container_type
+                return (Data, Container)
+            else:
+                return self._type_map.get(spec.dtype)
         elif isinstance(spec, LinkSpec):
             return Container
         else:
@@ -946,7 +953,6 @@ class TypeMap(object):
             else:
                 return ('array_data', 'data',)
 
-    @classmethod
     def __get_constructor(self, base, addl_fields):
         # TODO: fix this to be more maintainable and smarter
         existing_args = set()

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -221,6 +221,16 @@ class AttributeSpec(Spec):
         ''' The shape of this attribute's value '''
         return self.get('shape', None)
 
+    @classmethod
+    def build_const_args(cls, spec_dict):
+        ''' Build constructor arguments for this Spec class from a dictionary '''
+        ret = super(AttributeSpec, cls).build_const_args(spec_dict)
+        if 'dtype' in ret:
+            if isinstance(ret['dtype'], dict):
+                ret['dtype'] = RefSpec.build_spec(ret['dtype'])
+        return ret
+
+
 
 _attrbl_args = [
         {'name': 'doc', 'type': str, 'doc': 'a description about what this specification represents'},

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -231,7 +231,6 @@ class AttributeSpec(Spec):
         return ret
 
 
-
 _attrbl_args = [
         {'name': 'doc', 'type': str, 'doc': 'a description about what this specification represents'},
         {'name': 'name', 'type': str, 'doc': 'the name of this base storage container', 'default': None},

--- a/tests/unit/pynwb_tests/test_extension.py
+++ b/tests/unit/pynwb_tests/test_extension.py
@@ -1,18 +1,29 @@
 import unittest
 import os
 from tempfile import gettempdir
+import random
+import string
 
 from pynwb.spec import NWBNamespaceBuilder, NWBGroupSpec, NWBAttributeSpec, NWBDatasetSpec
 from pynwb.form.spec.spec import RefSpec
-from pynwb import load_namespaces, get_class
+from pynwb import load_namespaces, get_class, TimeSeries
+from pynwb.form.utils import get_docval
+
+
+def id_generator(N=10):
+    """
+    Generator a random string of characters.
+    """
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=N))
 
 
 class TestExtension(unittest.TestCase):
 
     def setUp(self):
         self.tempdir = gettempdir()
-        self.ext_source = 'fake_extension.yaml'
-        self.ns_path = 'fake_namespace.yaml'
+        self.prefix = id_generator()
+        self.ext_source = '%s_extension.yaml' % self.prefix
+        self.ns_path = '%s_namespace.yaml' % self.prefix
 
     def tearDown(self):
         for f in (self.ext_source, self.ns_path):
@@ -20,7 +31,7 @@ class TestExtension(unittest.TestCase):
             os.remove(path)
 
     def test_export(self):
-        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', "pynwb_test_extension")
+        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', self.prefix)
         ext1 = NWBGroupSpec('A custom ElectricalSeries for my lab',
                             attributes=[NWBAttributeSpec('trode_id', 'int', 'the tetrode id')],
                             neurodata_type_inc='ElectricalSeries',
@@ -34,10 +45,10 @@ class TestExtension(unittest.TestCase):
 
     def test_get_class(self):
         self.test_load_namespace()
-        TetrodeSeries = get_class('TetrodeSeries', 'pynwb_test_extension')  # noqa: F841
+        TetrodeSeries = get_class('TetrodeSeries', self.prefix)  # noqa: F841
 
     def test_load_namespace_with_reftype_attribute(self):
-        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', "pynwb_test_extension")
+        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', self.prefix)
         test_ds_ext = NWBDatasetSpec(doc='test dataset to add an attr',
                                      name='test_data', shape=(None,),
                                      attributes=[NWBAttributeSpec(name='target_ds',
@@ -48,15 +59,36 @@ class TestExtension(unittest.TestCase):
         ns_builder.export(self.ns_path, outdir=self.tempdir)
         load_namespaces(os.path.join(self.tempdir, self.ns_path))
 
+    def test_load_namespace_with_reftype_attribute_check_autoclass_const(self):
+        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', self.prefix)
+        test_ds_ext = NWBDatasetSpec(doc='test dataset to add an attr',
+                                     name='test_data', shape=(None,),
+                                     attributes=[NWBAttributeSpec(name='target_ds',
+                                                                  doc='the target the dataset applies to',
+                                                                  dtype=RefSpec('TimeSeries', 'object'))],
+                                     neurodata_type_def='my_new_type')
+        ns_builder.add_spec(self.ext_source, test_ds_ext)
+        ns_builder.export(self.ns_path, outdir=self.tempdir)
+        load_namespaces(os.path.join(self.tempdir, self.ns_path))
+        my_new_type = get_class('my_new_type', self.prefix)
+        docval = None
+        for tmp in get_docval(my_new_type.__init__):
+            if tmp['name'] == 'target_ds':
+                docval = tmp
+                break
+        self.assertIsNotNone(docval)
+        self.assertEqual(docval['type'], TimeSeries)
+
 
 class TestCatchDupNS(unittest.TestCase):
 
     def setUp(self):
         self.tempdir = gettempdir()
-        self.ext_source1 = 'fake_extension1.yaml'
-        self.ns_path1 = 'fake_namespace1.yaml'
-        self.ext_source2 = 'fake_extension2.yaml'
-        self.ns_path2 = 'fake_namespace2.yaml'
+        self.prefix = id_generator()
+        self.ext_source1 = '%s_extension1.yaml' % self.prefix
+        self.ns_path1 = '%s_namespace1.yaml' % self.prefix
+        self.ext_source2 = '%s_extension2.yaml' % self.prefix
+        self.ns_path2 = '%s_namespace2.yaml' % self.prefix
 
     def tearDown(self):
         files = (self.ext_source1,
@@ -90,7 +122,8 @@ class TestCatchDupNS(unittest.TestCase):
 class TestCatchDuplicateSpec(unittest.TestCase):
 
     def setUp(self):
-        self.ext_source = 'fake_extension3.yaml'
+        self.prefix = id_generator()
+        self.ext_source = '%s_extension3.yaml' % self.prefix
 
     def tearDown(self):
         pass

--- a/tests/unit/pynwb_tests/test_extension.py
+++ b/tests/unit/pynwb_tests/test_extension.py
@@ -2,7 +2,8 @@ import unittest
 import os
 from tempfile import gettempdir
 
-from pynwb.spec import NWBNamespaceBuilder, NWBGroupSpec, NWBAttributeSpec
+from pynwb.spec import NWBNamespaceBuilder, NWBGroupSpec, NWBAttributeSpec, NWBDatasetSpec
+from pynwb.form.spec.spec import RefSpec
 from pynwb import load_namespaces, get_class
 
 
@@ -19,7 +20,7 @@ class TestExtension(unittest.TestCase):
             os.remove(path)
 
     def test_export(self):
-        ns_builder = NWBNamespaceBuilder('Extension for us in my Lab', "pynwb_test_extension")
+        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', "pynwb_test_extension")
         ext1 = NWBGroupSpec('A custom ElectricalSeries for my lab',
                             attributes=[NWBAttributeSpec('trode_id', 'int', 'the tetrode id')],
                             neurodata_type_inc='ElectricalSeries',
@@ -34,6 +35,18 @@ class TestExtension(unittest.TestCase):
     def test_get_class(self):
         self.test_load_namespace()
         TetrodeSeries = get_class('TetrodeSeries', 'pynwb_test_extension')  # noqa: F841
+
+    def test_load_namespace_with_reftype_attribute(self):
+        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', "pynwb_test_extension")
+        test_ds_ext = NWBDatasetSpec(doc='test dataset to add an attr',
+                                     name='test_data', shape=(None,),
+                                     attributes=[NWBAttributeSpec(name='target_ds',
+                                                                  doc='the target the dataset applies to',
+                                                                  dtype=RefSpec('TimeSeries', 'object'))],
+                                     neurodata_type_def='my_new_type')
+        ns_builder.add_spec(self.ext_source, test_ds_ext)
+        ns_builder.export(self.ns_path, outdir=self.tempdir)
+        load_namespaces(os.path.join(self.tempdir, self.ns_path))
 
 
 class TestCatchDupNS(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_extension.py
+++ b/tests/unit/pynwb_tests/test_extension.py
@@ -14,7 +14,7 @@ def id_generator(N=10):
     """
     Generator a random string of characters.
     """
-    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=N))
+    return ''.join(random.choice(string.ascii_uppercase + string.digits) for _ in range(N))
 
 
 class TestExtension(unittest.TestCase):


### PR DESCRIPTION
## Motivation

When using a ``RefSpec`` as a ``dtype`` for an ``AttributeSpec`` then the load fails because the dict from the YAML spec is not being translated on load to the RefSpec.  The following example illustrates this problem. @lfrank 

```
from pynwb.spec import NWBGroupSpec, NWBAttributeSpec, NWBLinkSpec, NWBNamespaceBuilder, NWBDatasetSpec, NWBDtypeSpec
from pynwb.form.spec import RefSpec
from pynwb import get_class, load_namespaces
import os

ext_path = '.'
ns_name = 'refattrbug'
ns_path = '%s/%s.namespace.yaml' % (ext_path, ns_name)
ext_source = "%s.extensions.yaml" % ns_name

ns_builder = NWBNamespaceBuilder('Extension to test RefType attribute bug', 'test')
test_ds_ext = NWBDatasetSpec(doc='test dataset to add an attr',
                             name='test_data', shape=(None,),
			     attributes=[ # save a reference to a target type
			                  NWBAttributeSpec(name='target_ds', 
                                                           doc='the target the dataset applies to',
					                   dtype=RefSpec('TimeSeries', 'object'))],
			     neurodata_type_def='my_new_type')

# add the class to the namespace builder
ns_builder.add_spec(ext_source, test_ds_ext)
os.chdir(ext_path)

# create a builder for the namespace
ns_builder.export(ns_path)

# test
load_namespaces(ns_path)

```

This pull requests adds the ``builds_const_args`` function for the AttributeSpec to translate the ``dtype`` dict to a RefSpec. This fixes the following error when executing the above script:

```
from ._conv import register_converters as _register_converters
Traceback (most recent call last):
  File "bug_example.py", line 28, in <module>
    load_namespaces(ns_path)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/utils.py", line 355, in func_call
    return func(**parsed['args'])
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/__init__.py", line 95, in load_namespaces
    return __TYPE_MAP.load_namespaces(namespace_path)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/utils.py", line 347, in func_call
    return func(self, **parsed['args'])
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/build/map.py", line 916, in load_namespaces
    deps = self.__ns_catalog.load_namespaces(namespace_path, resolve)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/utils.py", line 347, in func_call
    return func(self, **parsed['args'])
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/namespace.py", line 403, in load_namespaces
    ret[ns['name']] = self.__load_namespace(ns, reader, types_key, resolve=resolve)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/namespace.py", line 352, in __load_namespace
    self.__load_spec_file(reader, s['source'], catalog, dtypes=dtypes, resolve=resolve)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/namespace.py", line 317, in __load_spec_file
    ret.extend(__reg_spec(self.__dataset_spec_cls, spec_dict))
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/namespace.py", line 309, in __reg_spec
    spec_obj = spec_cls.build_spec(spec_dict)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/spec.py", line 50, in build_spec
    kwargs = cls.build_const_args(spec_dict)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/spec.py", line 657, in build_const_args
    ret = super(DatasetSpec, cls).build_const_args(spec_dict)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/spec.py", line 459, in build_const_args
    ret['attributes'] = [AttributeSpec.build_spec(sub_spec) for sub_spec in ret['attributes']]
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/spec.py", line 459, in <listcomp>
    ret['attributes'] = [AttributeSpec.build_spec(sub_spec) for sub_spec in ret['attributes']]
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/spec/spec.py", line 55, in build_spec
    return cls(*args, **kwargs)
  File "/Users/oruebel/Devel/nwb/pynwb/src/pynwb/form/utils.py", line 346, in func_call
    raise_from(TypeError(msg), None)
  File "<string>", line 3, in raise_from
TypeError: incorrect type for 'dtype' (got 'dict', expected 'str or RefSpec')
(py35) 77:franklab oruebel$ cat bug_example.py 
```


## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
