### PR TITLE
Enh/validatedtype

### DIFF
--- a/src/pynwb/data/nwb.behavior.yaml
+++ b/src/pynwb/data/nwb.behavior.yaml
@@ -20,7 +20,7 @@ groups:
     - num_times
     - num_features
     doc: 2-D array storing position or direction relative to some reference frame.
-    dtype: number
+    dtype: float
     name: data
     shape:
     - null

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -19,7 +19,7 @@ groups:
     - - num_times
       - num_channels
     doc: Recorded voltage data.
-    dtype: number
+    dtype: float
     name: data
     shape:
     - - null

--- a/src/pynwb/data/nwb.icephys.yaml
+++ b/src/pynwb/data/nwb.icephys.yaml
@@ -8,7 +8,7 @@ groups:
   - dims:
     - num_times
     doc: Recorded voltage or current.
-    dtype: number
+    dtype:
     name: data
     shape:
     - null

--- a/src/pynwb/data/nwb.icephys.yaml
+++ b/src/pynwb/data/nwb.icephys.yaml
@@ -8,7 +8,7 @@ groups:
   - dims:
     - num_times
     doc: Recorded voltage or current.
-    dtype:
+    dtype: float
     name: data
     shape:
     - null

--- a/src/pynwb/data/nwb.image.yaml
+++ b/src/pynwb/data/nwb.image.yaml
@@ -20,7 +20,7 @@ groups:
       - y
       - x
     doc: Either binary data containing image or empty.
-    dtype: number
+    dtype: int8
     name: data
     shape:
     - - null

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -60,11 +60,11 @@ groups:
     - doc: Value is 'float('NaN')'
       dtype: float
       name: conversion
-      default_value: NaN
+      value: NaN
     - doc: Value is 'float('NaN')'
       dtype: float
       name: resolution
-      default_value: NaN
+      value: NaN
     - doc: Value is 'n/a'
       dtype: text
       name: unit
@@ -92,11 +92,11 @@ groups:
     - doc: Value is 'float('NaN')'
       dtype: float
       name: conversion
-      default_value: NaN
+      value: NaN
     - doc: Value is 'float('NaN')'
       dtype: float
       name: resolution
-      default_value: NaN
+      value: NaN
     - doc: Value is 'n/a'
       dtype: text
       name: unit

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -13,7 +13,7 @@ groups:
         \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
         \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
         \ below describes how to convert the data to the specified SI unit."
-      dtype: None
+      dtype: text
       name: unit
       required: false
     dims:
@@ -58,15 +58,15 @@ groups:
   datasets:
   - attributes:
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: conversion
-      value: NaN
+      default_value: NaN
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: resolution
-      value: NaN
+      default_value: NaN
     - doc: Value is 'n/a'
-      dtype: None
+      dtype: text
       name: unit
       value: n/a
     dims:
@@ -90,15 +90,15 @@ groups:
   datasets:
   - attributes:
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: conversion
-      value: NaN
+      default_value: NaN
     - doc: Value is 'float('NaN')'
-      dtype: None
+      dtype: float
       name: resolution
-      value: NaN
+      default_value: NaN
     - doc: Value is 'n/a'
-      dtype: None
+      dtype: text
       name: unit
       value: n/a
     dims:

--- a/src/pynwb/form/spec/__init__.py
+++ b/src/pynwb/form/spec/__init__.py
@@ -5,6 +5,7 @@ from .spec import NAME_WILDCARD
 from .spec import Spec
 from .spec import AttributeSpec
 from .spec import DtypeSpec
+from .spec import DtypeHelper
 from .spec import RefSpec
 from .spec import DatasetSpec
 from .spec import LinkSpec

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -44,8 +44,7 @@ class DtypeHelper():
 
     # List of valid primary data type strings
     valid_primary_dtypes = set(list(primary_dtype_synonyms.keys()) +
-                               [vi for v in primary_dtype_synonyms.values() for vi in v] +
-                               ['number',])
+                               [vi for v in primary_dtype_synonyms.values() for vi in v])
 
     @staticmethod
     def simplify_cpd_type(cpd_type):

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -215,13 +215,15 @@ class AttributeSpec(Spec):
                 raise ValueError("cannot specify 'value' and 'default_value'")
             self['default_value'] = default_value
             self['required'] = False
+        if shape is not None:
+            self['shape'] = shape
         if dims is not None:
             self['dims'] = dims
             if 'shape' not in self:
                 self['shape'] = tuple([None] * len(dims))
-            else:
-                if len(self['dims']) != len(self['shape']):
-                    raise ValueError("'dims' and 'shape' must be the same length")
+        if self.shape is not None and self.dims is not None:
+            if len(self['dims']) != len(self['shape']):
+                raise ValueError("'dims' and 'shape' must be the same length")
 
     @property
     def dtype(self):
@@ -602,9 +604,9 @@ class DatasetSpec(BaseStorageSpec):
             self['dims'] = dims
             if 'shape' not in self:
                 self['shape'] = tuple([None] * len(dims))
-            else:
-                if len(self['dims']) != len(self['shape']):
-                    raise ValueError("'dims' and 'shape' must be the same length")
+        if self.shape is not None and self.dims is not None:
+            if len(self['dims']) != len(self['shape']):
+                raise ValueError("'dims' and 'shape' must be the same length")
         if dtype is not None:
             if isinstance(dtype, list):  # Dtype is a compound data type
                 for _i, col in enumerate(dtype):

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -205,8 +205,8 @@ class AttributeSpec(Spec):
             self['dtype'] = dtype
             # Validate the dype string
             if self['dtype'] not in DtypeHelper.valid_primary_dtypes:
-                # print(kwargs)
-                raise ValueError('dtype %s not a valid primary data type' % self['dtype'])
+                raise ValueError('dtype %s not a valid primary data type %s' % (self['dtype'],
+                                                                                str(DtypeHelper.valid_primary_dtypes)))
         if value is not None:
             self.pop('required', None)
             self['value'] = value
@@ -618,7 +618,8 @@ class DatasetSpec(BaseStorageSpec):
             else:   # Dtype is a string
                 self['dtype'] = dtype
                 if self['dtype'] not in DtypeHelper.valid_primary_dtypes:
-                    raise ValueError('dtype %s not a valid primary data type' % self['dtype'])
+                    raise ValueError('dtype %s not a valid primary data type %s' %
+                                     (self['dtype'], str(DtypeHelper.valid_primary_dtypes)))
         super(DatasetSpec, self).__init__(doc, **kwargs)
         if default_value is not None:
             self['default_value'] = default_value

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -13,7 +13,7 @@ ONE_OR_MANY = '+'
 DEF_QUANTITY = 1
 FLAGS = {
     'zero_or_one': ZERO_OR_ONE,
-    'zero_or_more': ZERO_OR_MANY,
+    'zero_or_many': ZERO_OR_MANY,
     'one_or_many': ONE_OR_MANY
 }
 
@@ -555,9 +555,13 @@ class DtypeSpec(ConstructableDict):
     @docval({'name': 'spec', 'type': (str, dict), 'doc': 'the spec object to check'}, is_method=False)
     def is_ref(**kwargs):
         spec = getargs('spec', kwargs)
+        spec_is_ref = False
         if isinstance(spec, dict):
-            return _target_type_key in spec
-        return False
+            if _target_type_key in spec:
+                spec_is_ref = True
+            elif 'dtype' in spec and isinstance(spec['dtype'], dict) and _target_type_key in spec['dtype']:
+                spec_is_ref = True
+        return spec_is_ref
 
     @classmethod
     def build_const_args(cls, spec_dict):
@@ -694,6 +698,11 @@ class DatasetSpec(BaseStorageSpec):
     def shape(self):
         ''' The shape of the dataset '''
         return self.get('shape', None)
+
+    @property
+    def default_value(self):
+        '''The default value of the dataset or None if not specified'''
+        return self.get('default_value', None)
 
     @classmethod
     def __check_dim(cls, dim, data):

--- a/src/pynwb/form/validate/errors.py
+++ b/src/pynwb/form/validate/errors.py
@@ -1,6 +1,6 @@
 
 from ..utils import docval, getargs
-from ..spec.spec import simplify_cpd_type
+from ..spec.spec import DtypeHelper
 from numpy import dtype
 
 
@@ -62,7 +62,7 @@ class DtypeError(Error):
         expected = getargs('expected', kwargs)
         received = getargs('received', kwargs)
         if isinstance(expected, list):
-            expected = simplify_cpd_type(expected)
+            expected = DtypeHelper.simplify_cpd_type(expected)
         reason = "incorrect type - expected '%s', got '%s'" % (expected, received)
         loc = getargs('location', kwargs)
         super(DtypeError, self).__init__(name, reason, location=loc)

--- a/src/pynwb/form/validate/validator.py
+++ b/src/pynwb/form/validate/validator.py
@@ -7,7 +7,7 @@ from ..utils import docval, getargs
 from ..data_utils import get_shape
 
 from ..spec import Spec, AttributeSpec, GroupSpec, DatasetSpec, RefSpec
-from ..spec.spec import BaseStorageSpec, simplify_cpd_type
+from ..spec.spec import BaseStorageSpec, DtypeHelper
 from ..spec import SpecNamespace
 
 from ..build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder, RegionBuilder
@@ -24,26 +24,13 @@ __valid_dtypes = {
     'int': int,
     'int32': np.int32,
     'int16': np.int16,
+    'int8': np.int8,
     'text': text_type,
     'region': 'region',
     'object': 'object',
 }
 
-__synonyms = {
-    'float': ["float", "float32"],
-    'double': ["double", "float64"],
-    'short': ["int16", "short"],
-    'int': ["int32", "int"],
-    'long': ["int64", "long"],
-    'utf': ["text", "utf", "utf8", "utf-8"],
-    'ascii': ["ascii", "bytes"],
-    'uint8': ["uint8"],
-    'uint16': ["uint16"],
-    'uint32': ["uint32", "uint"],
-    'uint64': ["uint64"],
-    'object': ['object'],
-    'region': ['region']
-}
+__synonyms = DtypeHelper.primary_dtype_synonyms
 
 __additional = {
     'float': ['double'],
@@ -72,7 +59,7 @@ def check_type(expected, received):
     if isinstance(expected, list):
         if len(expected) > len(received):
             raise ValueError('compound type shorter than expected')
-        for i, exp in enumerate(simplify_cpd_type(expected)):
+        for i, exp in enumerate(DtypeHelper.simplify_cpd_type(expected)):
             rec = received[i]
             if rec not in __allowable[exp]:
                 return False

--- a/tests/unit/form_tests/build_tests/test_io_manager.py
+++ b/tests/unit/form_tests/build_tests/test_io_manager.py
@@ -93,7 +93,7 @@ class TestBase(unittest.TestCase):
                                           'attr2',
                                           'an example integer attribute',
                                           'int')])],
-                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'str')])
+                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
 
         self.spec_catalog = SpecCatalog()
         self.spec_catalog.register_spec(self.foo_spec, 'test.yaml')

--- a/tests/unit/form_tests/build_tests/test_io_map.py
+++ b/tests/unit/form_tests/build_tests/test_io_map.py
@@ -141,7 +141,7 @@ class TestDynamicContainer(unittest.TestCase):
                                   datasets=[DatasetSpec('an example dataset', 'int', name='data',
                                                         attributes=[AttributeSpec(
                                                             'attr2', 'an example integer attribute', 'int')])],
-                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'str')])
+                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
         self.spec_catalog = SpecCatalog()
         self.spec_catalog.register_spec(self.bar_spec, 'test.yaml')
         self.namespace = SpecNamespace('a test namespace', CORE_NAMESPACE,
@@ -237,7 +237,7 @@ class TestObjectMapperNested(TestObjectMapper):
                                   datasets=[DatasetSpec('an example dataset', 'int', name='data',
                                                         attributes=[AttributeSpec(
                                                             'attr2', 'an example integer attribute', 'int')])],
-                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'str')])
+                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'text')])
 
     def test_build(self):
         ''' Test default mapping functionality when object attributes map to an  attribute deeper
@@ -272,7 +272,7 @@ class TestObjectMapperNoNesting(TestObjectMapper):
         self.bar_spec = GroupSpec('A test group specification with a data type',
                                   data_type_def='Bar',
                                   datasets=[DatasetSpec('an example dataset', 'int', name='data')],
-                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'str'),
+                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'text'),
                                               AttributeSpec('attr2', 'an example integer attribute', 'int')])
 
     def test_build(self):
@@ -304,7 +304,7 @@ class TestObjectMapperContainer(TestObjectMapper):
         self.bar_spec = GroupSpec('A test group specification with a data type',
                                   data_type_def='Bar',
                                   groups=[GroupSpec('an example group', data_type_def='Foo')],
-                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'str'),
+                                  attributes=[AttributeSpec('attr1', 'an example string attribute', 'text'),
                                               AttributeSpec('attr2', 'an example integer attribute', 'int')])
 
     def test_default_mapping_keys(self):

--- a/tests/unit/form_tests/build_tests/test_io_map_data.py
+++ b/tests/unit/form_tests/build_tests/test_io_map_data.py
@@ -46,7 +46,7 @@ class TestDataMap(unittest.TestCase):
 
     def setUpBazSpec(self):
         self.baz_spec = DatasetSpec('an Baz type', 'int', name='MyBaz', data_type_def='Baz',
-                                    attributes=[AttributeSpec('baz_attr', 'an example string attribute', 'str')])
+                                    attributes=[AttributeSpec('baz_attr', 'an example string attribute', 'text')])
 
     def test_build(self):
         ''' Test default mapping functionality when no attributes are nested '''

--- a/tests/unit/form_tests/spec_tests/test_attribute_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_attribute_spec.py
@@ -15,3 +15,52 @@ class AttributeSpecTests(unittest.TestCase):
         self.assertEqual(spec['doc'], 'my first attribute')
         self.assertIsNone(spec.parent)
         json.dumps(spec)  # to ensure there are no circular links
+
+    def test_invalid_dtype(self):
+        with self.assertRaises(ValueError):
+            AttributeSpec(name='attribute1',
+                          doc='my first attribute',
+                          dtype='invalid'              # <-- Invalid dtype must raise a ValueError
+                          )
+
+    def test_both_value_and_default_value_set(self):
+        with self.assertRaises(ValueError):
+            AttributeSpec(name='attribute1',
+                          doc='my first attribute',
+                          dtype='int',
+                          value=5,
+                          default_value=10            # <-- Default_value and value can't be set at the same time
+                          )
+
+    def test_colliding_shape_and_dims(self):
+        with self.assertRaises(ValueError):
+            AttributeSpec(name='attribute1',
+                          doc='my first attribute',
+                          dtype='int',
+                          dims=['test'],
+                          shape=[None, 2]           # <-- Length of shape and dims do not match must raise a ValueError
+                          )
+
+    def test_default_value(self):
+        spec = AttributeSpec('attribute1',
+                             'my first attribute',
+                             'text',
+                             default_value='some text')
+        self.assertEqual(spec['default_value'], 'some text')
+        self.assertEqual(spec.default_value, 'some text')
+
+    def test_shape(self):
+        shape = [None,2]
+        spec = AttributeSpec('attribute1',
+                             'my first attribute',
+                             'text',
+                             shape=shape)
+        self.assertEqual(spec['shape'],shape)
+        self.assertEqual(spec.shape, shape)
+
+    def test_dims_without_shape(self):
+        spec = AttributeSpec('attribute1',
+                             'my first attribute',
+                             'text',
+                             dims=['test'])
+        self.assertEqual(spec.shape, (None,))

--- a/tests/unit/form_tests/spec_tests/test_attribute_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_attribute_spec.py
@@ -9,9 +9,9 @@ class AttributeSpecTests(unittest.TestCase):
     def test_constructor(self):
         spec = AttributeSpec('attribute1',
                              'my first attribute',
-                             'str')
+                             'text')
         self.assertEqual(spec['name'], 'attribute1')
-        self.assertEqual(spec['dtype'], 'str')
+        self.assertEqual(spec['dtype'], 'text')
         self.assertEqual(spec['doc'], 'my first attribute')
         self.assertIsNone(spec.parent)
         json.dumps(spec)  # to ensure there are no circular links

--- a/tests/unit/form_tests/spec_tests/test_attribute_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_attribute_spec.py
@@ -50,12 +50,12 @@ class AttributeSpecTests(unittest.TestCase):
         self.assertEqual(spec.default_value, 'some text')
 
     def test_shape(self):
-        shape = [None,2]
+        shape = [None, 2]
         spec = AttributeSpec('attribute1',
                              'my first attribute',
                              'text',
                              shape=shape)
-        self.assertEqual(spec['shape'],shape)
+        self.assertEqual(spec['shape'], shape)
         self.assertEqual(spec.shape, shape)
 
     def test_dims_without_shape(self):
@@ -63,4 +63,4 @@ class AttributeSpecTests(unittest.TestCase):
                              'my first attribute',
                              'text',
                              dims=['test'])
-        self.assertEqual(spec.shape, (None,))
+        self.assertEqual(spec.shape, (None, ))

--- a/tests/unit/form_tests/spec_tests/test_dataset_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_dataset_spec.py
@@ -1,7 +1,27 @@
 import unittest2 as unittest
 import json
 
-from pynwb.form.spec import GroupSpec, DatasetSpec, AttributeSpec, DtypeSpec
+from pynwb.form.spec import GroupSpec, DatasetSpec, AttributeSpec, DtypeSpec, DtypeHelper, RefSpec
+
+class DtypeSpecHelper(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_recommended_dtypes(self):
+        self.assertListEqual(DtypeHelper.recommended_primary_dtypes,
+                             list(DtypeHelper.primary_dtype_synonyms.keys()))
+
+    def test_valid_primary_dtypes(self):
+        a = set(list(DtypeHelper.primary_dtype_synonyms.keys()) + [vi for v in DtypeHelper.primary_dtype_synonyms.values()
+                                                               for vi in v] + ['number', ])
+        self.assertSetEqual(a, DtypeHelper.valid_primary_dtypes)
+
+    def test_simplify_cpd_type(self):
+        compound_type =  [DtypeSpec('test', 'test field', 'float'),
+                          DtypeSpec('test2', 'test field2', 'int')]
+        expected_result = ['float', 'int']
+        result = DtypeHelper.simplify_cpd_type(compound_type)
+        self.assertListEqual(result, expected_result)
 
 
 class DtypeSpecTests(unittest.TestCase):
@@ -24,8 +44,8 @@ class DtypeSpecTests(unittest.TestCase):
 class DatasetSpecTests(unittest.TestCase):
     def setUp(self):
         self.attributes = [
-            AttributeSpec('attribute1', 'my first attribute', 'str'),
-            AttributeSpec('attribute2', 'my second attribute', 'str')
+            AttributeSpec('attribute1', 'my first attribute', 'text'),
+            AttributeSpec('attribute2', 'my second attribute', 'text')
         ]
 
     def test_constructor(self):
@@ -60,6 +80,29 @@ class DatasetSpecTests(unittest.TestCase):
         self.assertListEqual(spec['attributes'], self.attributes)
         self.assertIs(spec, self.attributes[0].parent)
         self.assertIs(spec, self.attributes[1].parent)
+
+    def test_constructor_invalidate_dtype(self):
+        with self.assertRaises(ValueError):
+            DatasetSpec(doc='my first dataset',
+                        dtype='my bad dtype',     # <-- Expect AssertionError due to bad type
+                        name='dataset1',
+                        dimension=(None, None),
+                        attributes=self.attributes,
+                        linkable=False,
+                        namespace='core',
+                        data_type_def='EphysData')
+
+    def test_constructor_ref_spec(self):
+        dtype = RefSpec('TimeSeries', 'object')
+        spec = DatasetSpec(doc='my first dataset',
+                           dtype=dtype,
+                           name='dataset1',
+                           dimension=(None, None),
+                           attributes=self.attributes,
+                           linkable=False,
+                           namespace='core',
+                           data_type_def='EphysData')
+        self.assertDictEqual(spec['dtype'], dtype)
 
     def test_datatype_extension(self):
         base = DatasetSpec('my first dataset',
@@ -129,7 +172,7 @@ class DatasetSpecTests(unittest.TestCase):
                            data_type_def='SimpleTable')
         self.assertEqual(base['dtype'], [dtype1, dtype2])
         self.assertEqual(base['doc'], 'my first table')
-        dtype3 = DtypeSpec('column3', 'the third column', 'str')
+        dtype3 = DtypeSpec('column3', 'the third column', 'text')
         ext = DatasetSpec('my first table extension',
                           [dtype3],
                           namespace='core',

--- a/tests/unit/form_tests/spec_tests/test_dataset_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_dataset_spec.py
@@ -13,7 +13,7 @@ class DtypeSpecHelper(unittest.TestCase):
 
     def test_valid_primary_dtypes(self):
         a = set(list(DtypeHelper.primary_dtype_synonyms.keys()) + [vi for v in DtypeHelper.primary_dtype_synonyms.values()
-                                                               for vi in v] + ['number', ])
+                                                               for vi in v])
         self.assertSetEqual(a, DtypeHelper.valid_primary_dtypes)
 
     def test_simplify_cpd_type(self):

--- a/tests/unit/form_tests/spec_tests/test_dataset_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_dataset_spec.py
@@ -2,7 +2,6 @@ import unittest2 as unittest
 import json
 
 from pynwb.form.spec import GroupSpec, DatasetSpec, AttributeSpec, DtypeSpec, RefSpec
-from pynwb.form.spec.spec import ZERO_OR_MANY
 
 
 class DatasetSpecTests(unittest.TestCase):
@@ -46,13 +45,13 @@ class DatasetSpecTests(unittest.TestCase):
         self.assertIs(spec, self.attributes[1].parent)
 
     def test_constructor_shape(self):
-        shape = [None,2]
+        shape = [None, 2]
         spec = DatasetSpec('my first dataset',
                            'int',
                            name='dataset1',
                            shape=shape,
                            attributes=self.attributes)
-        self.assertEqual(spec['shape'],shape)
+        self.assertEqual(spec['shape'], shape)
         self.assertEqual(spec.shape, shape)
 
     def test_constructor_invalidate_dtype(self):

--- a/tests/unit/form_tests/spec_tests/test_dataset_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_dataset_spec.py
@@ -3,6 +3,7 @@ import json
 
 from pynwb.form.spec import GroupSpec, DatasetSpec, AttributeSpec, DtypeSpec, DtypeHelper, RefSpec
 
+
 class DtypeSpecHelper(unittest.TestCase):
     def setUp(self):
         pass
@@ -12,13 +13,13 @@ class DtypeSpecHelper(unittest.TestCase):
                              list(DtypeHelper.primary_dtype_synonyms.keys()))
 
     def test_valid_primary_dtypes(self):
-        a = set(list(DtypeHelper.primary_dtype_synonyms.keys()) + [vi for v in DtypeHelper.primary_dtype_synonyms.values()
-                                                               for vi in v])
+        a = set(list(DtypeHelper.primary_dtype_synonyms.keys()) +
+                [vi for v in DtypeHelper.primary_dtype_synonyms.values() for vi in v])
         self.assertSetEqual(a, DtypeHelper.valid_primary_dtypes)
 
     def test_simplify_cpd_type(self):
-        compound_type =  [DtypeSpec('test', 'test field', 'float'),
-                          DtypeSpec('test2', 'test field2', 'int')]
+        compound_type = [DtypeSpec('test', 'test field', 'float'),
+                         DtypeSpec('test2', 'test field2', 'int')]
         expected_result = ['float', 'int']
         result = DtypeHelper.simplify_cpd_type(compound_type)
         self.assertListEqual(result, expected_result)

--- a/tests/unit/form_tests/spec_tests/test_dtype_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_dtype_spec.py
@@ -1,0 +1,62 @@
+import unittest2 as unittest
+
+from pynwb.form.spec import  DtypeSpec, DtypeHelper, RefSpec
+
+
+class DtypeSpecHelper(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_recommended_dtypes(self):
+        self.assertListEqual(DtypeHelper.recommended_primary_dtypes,
+                             list(DtypeHelper.primary_dtype_synonyms.keys()))
+
+    def test_valid_primary_dtypes(self):
+        a = set(list(DtypeHelper.primary_dtype_synonyms.keys()) +
+                [vi for v in DtypeHelper.primary_dtype_synonyms.values() for vi in v])
+        self.assertSetEqual(a, DtypeHelper.valid_primary_dtypes)
+
+    def test_simplify_cpd_type(self):
+        compound_type = [DtypeSpec('test', 'test field', 'float'),
+                         DtypeSpec('test2', 'test field2', 'int')]
+        expected_result = ['float', 'int']
+        result = DtypeHelper.simplify_cpd_type(compound_type)
+        self.assertListEqual(result, expected_result)
+
+
+class DtypeSpecTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_constructor(self):
+        spec = DtypeSpec('column1', 'an example column', 'int')
+        self.assertEqual(spec.doc, 'an example column')
+        self.assertEqual(spec.name, 'column1')
+        self.assertEqual(spec.dtype, 'int')
+
+    def test_build_spec(self):
+        spec = DtypeSpec.build_spec({'doc': 'an example column', 'name': 'column1', 'dtype': 'int'})
+        self.assertEqual(spec.doc, 'an example column')
+        self.assertEqual(spec.name, 'column1')
+        self.assertEqual(spec.dtype, 'int')
+
+    def test_invalid_refspec_dict(self):
+        with self.assertRaises(AssertionError):
+            DtypeSpec.assertValidDtype( {'no target': 'test',   # <-- missing or here bad target key for RefSpec
+                                         'reftype': 'object'})
+
+    def test_refspec_dtype(self):
+        # just making sure this does not cause an error
+        DtypeSpec('column1', 'an example column', RefSpec('TimeSeries', 'object'))
+
+    def test_invalid_dtype(self):
+        with self.assertRaises(AssertionError):
+            DtypeSpec('column1', 'an example column',
+                      dtype='bad dtype'                     # <-- make sure a bad type string raises an error
+                      )
+
+    def test_is_ref(self):
+        spec = DtypeSpec('column1', 'an example column', RefSpec('TimeSeries', 'object'))
+        self.assertTrue(DtypeSpec.is_ref(spec))
+        spec = DtypeSpec('column1', 'an example column', 'int')
+        self.assertFalse(DtypeSpec.is_ref(spec))

--- a/tests/unit/form_tests/spec_tests/test_dtype_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_dtype_spec.py
@@ -1,6 +1,6 @@
 import unittest2 as unittest
 
-from pynwb.form.spec import  DtypeSpec, DtypeHelper, RefSpec
+from pynwb.form.spec import DtypeSpec, DtypeHelper, RefSpec
 
 
 class DtypeSpecHelper(unittest.TestCase):
@@ -42,8 +42,8 @@ class DtypeSpecTests(unittest.TestCase):
 
     def test_invalid_refspec_dict(self):
         with self.assertRaises(AssertionError):
-            DtypeSpec.assertValidDtype( {'no target': 'test',   # <-- missing or here bad target key for RefSpec
-                                         'reftype': 'object'})
+            DtypeSpec.assertValidDtype({'no target': 'test',   # <-- missing or here bad target key for RefSpec
+                                        'reftype': 'object'})
 
     def test_refspec_dtype(self):
         # just making sure this does not cause an error

--- a/tests/unit/form_tests/spec_tests/test_group_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_group_spec.py
@@ -188,3 +188,31 @@ class GroupSpecTests(unittest.TestCase):
         else:
             for i in range(len(spec1_attr)):
                 self.assertDictEqual(spec1_attr[i], spec2_attr[i])
+
+    def test_add_attribute(self):
+        spec = GroupSpec('A test group',
+                         name='root_constructor',
+                         groups=self.subgroups,
+                         datasets=self.datasets,
+                         linkable=False)
+        for attrspec in self.attributes:
+            spec.add_attribute(**attrspec)
+        self.assertListEqual(spec['attributes'], self.attributes)
+        self.assertListEqual(spec['datasets'], self.datasets)
+        self.assertNotIn('data_type_def', spec)
+        self.assertIs(spec, self.subgroups[0].parent)
+        self.assertIs(spec, self.subgroups[1].parent)
+        self.assertIs(spec, spec.attributes[0].parent)
+        self.assertIs(spec, spec.attributes[1].parent)
+        self.assertIs(spec, self.datasets[0].parent)
+        self.assertIs(spec, self.datasets[1].parent)
+        json.dumps(spec)
+
+    def test_update_attribute_spec(self):
+        spec = GroupSpec('A test group',
+                         name='root_constructor',
+                         attributes=[AttributeSpec('attribute1', 'my first attribute', 'text'),])
+        spec.set_attribute(AttributeSpec('attribute1', 'my first attribute', 'int', value=5))
+        res = spec.get_attribute('attribute1')
+        self.assertEqual(res.value, 5)
+        self.assertEqual(res.dtype, 'int')

--- a/tests/unit/form_tests/spec_tests/test_group_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_group_spec.py
@@ -7,18 +7,18 @@ from pynwb.form.spec import GroupSpec, DatasetSpec, AttributeSpec
 class GroupSpecTests(unittest.TestCase):
     def setUp(self):
         self.attributes = [
-            AttributeSpec('attribute1', 'my first attribute', 'str'),
-            AttributeSpec('attribute2', 'my second attribute', 'str')
+            AttributeSpec('attribute1', 'my first attribute', 'text'),
+            AttributeSpec('attribute2', 'my second attribute', 'text')
         ]
 
         self.dset1_attributes = [
-            AttributeSpec('attribute3', 'my third attribute', 'str'),
-            AttributeSpec('attribute4', 'my fourth attribute', 'str')
+            AttributeSpec('attribute3', 'my third attribute', 'text'),
+            AttributeSpec('attribute4', 'my fourth attribute', 'text')
         ]
 
         self.dset2_attributes = [
-            AttributeSpec('attribute5', 'my fifth attribute', 'str'),
-            AttributeSpec('attribute6', 'my sixth attribute', 'str')
+            AttributeSpec('attribute5', 'my fifth attribute', 'text'),
+            AttributeSpec('attribute6', 'my sixth attribute', 'text')
         ]
 
         self.datasets = [
@@ -120,7 +120,7 @@ class GroupSpecTests(unittest.TestCase):
                          namespace='core',
                          data_type_def='EphysData')
         dset1_attributes_ext = [
-            AttributeSpec('dset1_extra_attribute', 'an extra attribute for the first dataset', 'str')
+            AttributeSpec('dset1_extra_attribute', 'an extra attribute for the first dataset', 'text')
         ]
         ext_datasets = [
             DatasetSpec('my first dataset extension',
@@ -130,7 +130,7 @@ class GroupSpecTests(unittest.TestCase):
                         linkable=True),
         ]
         ext_attributes = [
-            AttributeSpec('ext_extra_attribute', 'an extra attribute for the group', 'str'),
+            AttributeSpec('ext_extra_attribute', 'an extra attribute for the group', 'text'),
         ]
         ext = GroupSpec('A test group extension',
                         name='child_type',

--- a/tests/unit/form_tests/spec_tests/test_group_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_group_spec.py
@@ -211,7 +211,7 @@ class GroupSpecTests(unittest.TestCase):
     def test_update_attribute_spec(self):
         spec = GroupSpec('A test group',
                          name='root_constructor',
-                         attributes=[AttributeSpec('attribute1', 'my first attribute', 'text'),])
+                         attributes=[AttributeSpec('attribute1', 'my first attribute', 'text'), ])
         spec.set_attribute(AttributeSpec('attribute1', 'my first attribute', 'int', value=5))
         res = spec.get_attribute('attribute1')
         self.assertEqual(res.value, 5)

--- a/tests/unit/form_tests/spec_tests/test_load_namespace.py
+++ b/tests/unit/form_tests/spec_tests/test_load_namespace.py
@@ -3,7 +3,7 @@ import ruamel.yaml as yaml
 import json
 import os
 
-from pynwb.form.spec import *  # noqa: F403
+from pynwb.form.spec import AttributeSpec, DatasetSpec, GroupSpec, SpecNamespace, NamespaceCatalog
 
 
 class TestSpecLoad(unittest.TestCase):

--- a/tests/unit/form_tests/spec_tests/test_load_namespace.py
+++ b/tests/unit/form_tests/spec_tests/test_load_namespace.py
@@ -11,16 +11,16 @@ class TestSpecLoad(unittest.TestCase):
 
     def setUp(self):
         self.attributes = [
-            AttributeSpec('attribute1', 'my first attribute', 'str'),  # noqa: F405
-            AttributeSpec('attribute2', 'my second attribute', 'str')  # noqa: F405
+            AttributeSpec('attribute1', 'my first attribute', 'text'),
+            AttributeSpec('attribute2', 'my second attribute', 'text')
         ]
         self.dset1_attributes = [
-            AttributeSpec('attribute3', 'my third attribute', 'str'),  # noqa: F405
-            AttributeSpec('attribute4', 'my fourth attribute', 'str')  # noqa: F405
+            AttributeSpec('attribute3', 'my third attribute', 'text'),
+            AttributeSpec('attribute4', 'my fourth attribute', 'text')
         ]
         self.dset2_attributes = [
-            AttributeSpec('attribute5', 'my fifth attribute', 'str'),  # noqa: F405
-            AttributeSpec('attribute6', 'my sixth attribute', 'str')  # noqa: F405
+            AttributeSpec('attribute5', 'my fifth attribute', 'text'),
+            AttributeSpec('attribute6', 'my sixth attribute', 'text')
         ]
         self.datasets = [
             DatasetSpec('my first dataset',  # noqa: F405
@@ -43,7 +43,7 @@ class TestSpecLoad(unittest.TestCase):
                               linkable=False,
                               data_type_def='EphysData')
         dset1_attributes_ext = [
-            AttributeSpec('dset1_extra_attribute', 'an extra attribute for the first dataset', 'str')  # noqa: F405
+            AttributeSpec('dset1_extra_attribute', 'an extra attribute for the first dataset', 'text')
         ]
         self.ext_datasets = [
             DatasetSpec('my first dataset extension',  # noqa: F405
@@ -53,7 +53,7 @@ class TestSpecLoad(unittest.TestCase):
                         linkable=True),
         ]
         self.ext_attributes = [
-            AttributeSpec('ext_extra_attribute', 'an extra attribute for the group', 'str'),  # noqa: F405
+            AttributeSpec('ext_extra_attribute', 'an extra attribute for the group', 'text'),
         ]
         self.ext_spec = GroupSpec('A test group extension',  # noqa: F405
                                    name='root_constructor_nwbtype',

--- a/tests/unit/form_tests/spec_tests/test_ref_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_ref_spec.py
@@ -1,0 +1,25 @@
+import unittest2 as unittest
+import json
+
+from pynwb.form.spec import RefSpec
+
+
+class RefSpecTests(unittest.TestCase):
+
+    def test_constructor(self):
+        spec = RefSpec('TimeSeries', 'object')
+        self.assertEqual(spec.target_type, 'TimeSeries')
+        self.assertEqual(spec.reftype, 'object')
+        json.dumps(spec)  # to ensure there are no circular links
+
+    def test_invlaud_reftype(self):
+        with self.assertRaises(ValueError):
+            RefSpec('TimeSeries',
+                    'invalid'        # <-- Invalid reftype must raise a ValueError
+                    )
+
+    def test_isregion(self):
+        spec = RefSpec('TimeSeries', 'object')
+        self.assertFalse(spec.is_region())
+        spec = RefSpec('NWBData', 'region')
+        self.assertTrue(spec.is_region())

--- a/tests/unit/form_tests/spec_tests/test_spec_catalog.py
+++ b/tests/unit/form_tests/spec_tests/test_spec_catalog.py
@@ -8,8 +8,8 @@ class SpecCatalogTest(unittest.TestCase):
     def setUp(self):
         self.catalog = SpecCatalog()
         self.attributes = [
-            AttributeSpec('attribute1', 'my first attribute', 'str'),
-            AttributeSpec('attribute2', 'my second attribute', 'str')
+            AttributeSpec('attribute1', 'my first attribute', 'text'),
+            AttributeSpec('attribute2', 'my second attribute', 'text')
         ]
         self.spec = DatasetSpec('my first dataset',
                                 'int',

--- a/tests/unit/pynwb_tests/test_extension.py
+++ b/tests/unit/pynwb_tests/test_extension.py
@@ -33,7 +33,7 @@ class TestExtension(unittest.TestCase):
     def test_export(self):
         ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', self.prefix)
         ext1 = NWBGroupSpec('A custom ElectricalSeries for my lab',
-                            attributes=[NWBAttributeSpec('trode_id', 'int', 'the tetrode id')],
+                            attributes=[NWBAttributeSpec(name='trode_id', doc='the tetrode id', dtype='int')],
                             neurodata_type_inc='ElectricalSeries',
                             neurodata_type_def='TetrodeSeries')
         ns_builder.add_spec(self.ext_source, ext1)
@@ -102,14 +102,14 @@ class TestCatchDupNS(unittest.TestCase):
     def test_catch_dup_name(self):
         ns_builder1 = NWBNamespaceBuilder('Extension for us in my Lab', "pynwb_test_extension1")
         ext1 = NWBGroupSpec('A custom ElectricalSeries for my lab',
-                            attributes=[NWBAttributeSpec('trode_id', 'int', 'the tetrode id')],
+                            attributes=[NWBAttributeSpec(name='trode_id', doc='the tetrode id', dtype='int')],
                             neurodata_type_inc='ElectricalSeries',
                             neurodata_type_def='TetrodeSeries')
         ns_builder1.add_spec(self.ext_source1, ext1)
         ns_builder1.export(self.ns_path1, outdir=self.tempdir)
         ns_builder2 = NWBNamespaceBuilder('Extension for us in my Lab', "pynwb_test_extension1")
         ext2 = NWBGroupSpec('A custom ElectricalSeries for my lab',
-                            attributes=[NWBAttributeSpec('trode_id', 'int', 'the tetrode id')],
+                            attributes=[NWBAttributeSpec(name='trode_id', doc='the tetrode id', dtype='int')],
                             neurodata_type_inc='ElectricalSeries',
                             neurodata_type_def='TetrodeSeries')
         ns_builder2.add_spec(self.ext_source2, ext2)


### PR DESCRIPTION
## Motivation

This pull request fixes several issues:

* Fix #521 . Add validation of dtype strings for ``AttributeSpec`` and ``DatasetSpec``.  This is in part also in response to #520 
* ``nwb.misc.yaml`` specified ``dtype: None`` which is not allowed. Assigned appropriate dtype values instead.
* The following spec files contained `` dtype: number`` which is not allowed. Assigned approbriate dtype values instead:``src/pynwb/data/nwb.behavior.yaml``, ``src/pynwb/data/nwb.ecephys.yaml``, ``src/pynwb/data/nwb.icephys.yaml``, ``src/pynwb/data/nwb.image.yaml``
* Several tests used ``dtype='str'`` in the specification of attributes/datasets. Fixed those tests to use ``dtype='text'`` instead. 
* Updated the validator to use the data type lists from the new ``DtypeHelper`` class to avoid duplication of code 
* Added tests for the ``DtypeHelper`` class and updated constructor behavior of AttributeSpec and DatasetSpec
* Bug fix. ``shape`` constructor argument was not set in ``AttributeSpec``
* Updated ``DtypeSpec.is_ref`` function to also check if a ``DtypeSpec`` defines a reference
* Add some more test cases for the various spec classes

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
