### PR TITLE
Validate quantity flag when fixed name is set for dataset

### DIFF
--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -629,10 +629,11 @@ class DatasetSpec(BaseStorageSpec):
         super(DatasetSpec, self).__init__(doc, **kwargs)
         if default_value is not None:
             self['default_value'] = default_value
-            if self.name is not None:
-                self.pop('quantity')
-            else:
-                self['quantity'] = ZERO_OR_MANY
+        if self.name is not None:
+            valid_quant_vals = [1, 'zero_or_one', ZERO_OR_ONE]
+            if self.quantity not in valid_quant_vals:
+                raise ValueError("quantity %s invalid for spec with fixed name. Valid values are: %s" %
+                                 (self.quantity, str(valid_quant_vals)))
 
     @classmethod
     def __get_prec_level(cls, dtype):

--- a/tests/unit/form_tests/spec_tests/test_dataset_spec.py
+++ b/tests/unit/form_tests/spec_tests/test_dataset_spec.py
@@ -151,6 +151,30 @@ class DatasetSpecTests(unittest.TestCase):
                            data_type_def='test')
         self.assertEqual(spec.default_value, 5)
 
+    def test_name_with_incompatible_quantity(self):
+        # Check that we raise an error when the quantity allows more than one instance with a fixed name
+        with self.assertRaises(ValueError):
+            DatasetSpec(doc='my first dataset',
+                        dtype='int',
+                        name='ds1',
+                        quantity='zero_or_many')
+        with self.assertRaises(ValueError):
+            DatasetSpec(doc='my first dataset',
+                        dtype='int',
+                        name='ds1',
+                        quantity='one_or_many')
+
+    def test_name_with_compatible_quantity(self):
+        # Make sure compatible quantity flags pass when name is fixed
+        DatasetSpec(doc='my first dataset',
+                    dtype='int',
+                    name='ds1',
+                    quantity='zero_or_one')
+        DatasetSpec(doc='my first dataset',
+                    dtype='int',
+                    name='ds1',
+                    quantity=1)
+
     def test_datatype_table_extension(self):
         dtype1 = DtypeSpec('column1', 'the first column', 'int')
         dtype2 = DtypeSpec('column2', 'the second column', 'float')


### PR DESCRIPTION
## Motivation

* Validate quantity flag for dataset spec when a fixed name is specified for the dataset
* Fix bug where quantity flag was modified when a default_value was set
* Add test cases for the quantity+name dependence

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
