### PR TITLE
Bug/missing general meta

### DIFF
--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -158,6 +158,7 @@ class NWBFile(MultiContainerInterface):
                      'source_script',
                      'surgery',
                      'virus',
+                     'stimulus_notes',
                      {'name': 'ec_electrodes', 'child': True},
                      {'name': 'epochs', 'child': True},
                      {'name': 'trials', 'child': True},
@@ -201,6 +202,8 @@ class NWBFile(MultiContainerInterface):
             {'name': 'virus', 'type': str,
              'doc': 'Information about virus(es) used in experiments, including virus ID, '
                     'source, date made, injection location, volume, etc.', 'default': None},
+            {'name': 'stimulus_notes', 'type': str,
+             'doc': 'Notes about stimuli, such as how and where presented.', 'default': None},
             {'name': 'lab', 'type': str, 'doc': 'lab where experiment was performed', 'default': None},
             {'name': 'acquisition', 'type': (list, tuple),
              'doc': 'Raw TimeSeries objects belonging to this NWBFile', 'default': None},
@@ -285,6 +288,7 @@ class NWBFile(MultiContainerInterface):
             'source_script',
             'surgery',
             'virus',
+            'stimulus_notes',
         ]
         for attr in recommended:
             setattr(self, attr, kwargs.get(attr, None))

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -156,6 +156,7 @@ class NWBFile(MultiContainerInterface):
                      'related_publications',
                      'slices',
                      'source_script',
+                     'source_script_file_name',
                      'surgery',
                      'virus',
                      'stimulus_notes',
@@ -194,6 +195,8 @@ class NWBFile(MultiContainerInterface):
              'thickness, orientation, temperature and bath solution', 'default': None},
             {'name': 'source_script', 'type': str,
              'doc': 'Script file used to create this NWB file.', 'default': None},
+            {'name': 'source_script_file_name', 'type': str,
+             'doc': 'Name of the sourc_script file', 'default': None},
             {'name': 'data_collection', 'type': str,
              'doc': 'Notes about data collection and analysis.', 'default': None},
             {'name': 'surgery', 'type': str,
@@ -286,12 +289,16 @@ class NWBFile(MultiContainerInterface):
             'related_publications',
             'slices',
             'source_script',
+            'source_script_file_name',
             'surgery',
             'virus',
             'stimulus_notes',
         ]
         for attr in recommended:
             setattr(self, attr, kwargs.get(attr, None))
+
+        if getargs('source_script', kwargs) is None and getargs('source_script_file_name', kwargs) is not None:
+            raise ValueError("'source_script' cannot be None when 'source_script_file_name' is set")
 
     def all_children(self):
         stack = [self]

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -144,6 +144,7 @@ class NWBFile(MultiContainerInterface):
     ]
 
     __nwbfields__ = ('experimenter',
+                     'data_collection',
                      'description',
                      'experiment_description',
                      'session_id',
@@ -192,6 +193,8 @@ class NWBFile(MultiContainerInterface):
              'thickness, orientation, temperature and bath solution', 'default': None},
             {'name': 'source_script', 'type': str,
              'doc': 'Script file used to create this NWB file.', 'default': None},
+            {'name': 'data_collection', 'type': str,
+             'doc': 'Notes about data collection and analysis.', 'default': None},
             {'name': 'surgery', 'type': str,
              'doc': 'Narrative description about surgery/surgeries, including date(s) '
                     'and who performed surgery.', 'default': None},
@@ -273,6 +276,7 @@ class NWBFile(MultiContainerInterface):
             'session_id',
             'lab',
             'institution',
+            'data_collection',
             'notes',
             'pharmacology',
             'protocol',

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -39,8 +39,9 @@ class NWBFileMap(ObjectMapper):
         self.map_spec(
             'modules',
             self.spec.get_group('processing').get_neurodata_type('ProcessingModule'))
-        #self.unmap(general_spec.get_dataset('stimulus'))
+        # self.unmap(general_spec.get_dataset('stimulus'))
         self.map_spec('stimulus_notes', general_spec.get_dataset('stimulus'))
+        self.map_spec('source_script_file_name', general_spec.get_dataset('source_script').get_attribute('file_name'))
 
         self.map_spec('subject', general_spec.get_group('subject'))
         self.map_spec('devices', general_spec.get_group('devices').get_neurodata_type('Device'))

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -39,7 +39,8 @@ class NWBFileMap(ObjectMapper):
         self.map_spec(
             'modules',
             self.spec.get_group('processing').get_neurodata_type('ProcessingModule'))
-        self.unmap(general_spec.get_dataset('stimulus'))
+        #self.unmap(general_spec.get_dataset('stimulus'))
+        self.map_spec('stimulus_notes', general_spec.get_dataset('stimulus'))
 
         self.map_spec('subject', general_spec.get_group('subject'))
         self.map_spec('devices', general_spec.get_group('devices').get_neurodata_type('Device'))

--- a/tests/build_fake_data.py
+++ b/tests/build_fake_data.py
@@ -20,6 +20,8 @@ f = NWBFile(filename, 'my first synthetic recording', 'EXAMPLE_ID', datetime.now
             lab='Bag End Labatory',
             institution='University of Middle Earth at the Shire',
             experiment_description='I went on an adventure with thirteen dwarves to reclaim vast treasures.',
+            stimulus_notes='The one ring to rule them all has been found',
+            data_collection='The ring was found in cave and stolen from Gollum',
             session_id='LONELYMTN')
 
 # Create the electrode group this simulated data is generated from

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -58,12 +58,34 @@ class TestNWBFileIO(base.TestMapNWBContainer):
                                                            DatasetBuilder('description',
                                                                           "A fake Clustering interface")})})
 
+        general_builder = GroupBuilder('general',
+                                       datasets={
+                                            'experimenter': DatasetBuilder('experimenter', 'test experimenter'),
+                                            'stimulus': DatasetBuilder('stimulus', 'test stimulus notes'),
+                                            'experiment_description': DatasetBuilder('experiment_description',
+                                                                                     'test experiment description'),
+                                            'data_collection': DatasetBuilder('data_collection',
+                                                                              'test data collection notes'),
+                                            'institution': DatasetBuilder('institution', 'nomad'),
+                                            'lab': DatasetBuilder('lab', 'nolab'),
+                                            'notes': DatasetBuilder('notes', 'nonotes'),
+                                            'pharmacology': DatasetBuilder('pharmacology', 'nopharmacology'),
+                                            'protocol': DatasetBuilder('protocol', 'noprotocol'),
+                                            'related_publications': DatasetBuilder('related_publications', 'nopubs'),
+                                            'session_id': DatasetBuilder('session_id', '007'),
+                                            'slices': DatasetBuilder('slices', 'noslices'),
+                                            'source_script': DatasetBuilder('source_script', 'nosources',
+                                                                            attributes={'file_name': 'nofilename'}),
+                                            'surgery': DatasetBuilder('surgery', 'nosurgery'),
+                                            'virus': DatasetBuilder('virus', 'novirus')}
+                                       )
+
         return GroupBuilder('root',
                             groups={'acquisition': GroupBuilder(
                                 'acquisition',
                                 groups={'test_timeseries': ts_builder}),
                                     'analysis': GroupBuilder('analysis'),
-                                    'general': GroupBuilder('general'),
+                                    'general': general_builder,
                                     'processing': GroupBuilder('processing', groups={'test_module': module_builder}),
                                     'stimulus': GroupBuilder(
                                         'stimulus',
@@ -84,7 +106,24 @@ class TestNWBFileIO(base.TestMapNWBContainer):
 
     def setUpContainer(self):
         container = NWBFile('a test source', 'a test NWB File', 'TEST123',
-                            self.start_time, file_create_date=self.create_date)
+                            self.start_time,
+                            file_create_date=self.create_date,
+                            experimenter='test experimenter',
+                            stimulus_notes='test stimulus notes',
+                            experiment_description='test experiment description',
+                            data_collection='test data collection notes',
+                            institution='nomad',
+                            lab='nolab',
+                            notes='nonotes',
+                            pharmacology='nopharmacology',
+                            protocol='noprotocol',
+                            related_publications='nopubs',
+                            session_id='007',
+                            slices='noslices',
+                            source_script='nosources',
+                            surgery='nosurgery',
+                            virus='novirus',
+                            source_script_file_name='nofilename')
         self.ts = TimeSeries('test_timeseries', 'example_source', list(range(100, 200, 10)),
                              'SIunit', timestamps=list(range(10)), resolution=0.1)
         container.add_acquisition(self.ts)

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -28,7 +28,11 @@ class NWBFileTest(unittest.TestCase):
                                related_publications='my pubs',
                                slices='my slices',
                                surgery='surgery',
-                               virus='a virus')
+                               virus='a virus',
+                               source_script='noscript',
+                               source_script_file_name='nofilename',
+                               stimulus_notes='test stimulus notes',
+                               data_collection='test data collection notes')
 
     def test_constructor(self):
         self.assertEqual(self.nwbfile.session_description, 'a test session description for a test NWBFile')
@@ -39,6 +43,10 @@ class NWBFileTest(unittest.TestCase):
         self.assertEqual(self.nwbfile.institution, 'a test institution')
         self.assertEqual(self.nwbfile.experiment_description, 'a test experiment description')
         self.assertEqual(self.nwbfile.session_id, 'test1')
+        self.assertEqual(self.nwbfile.stimulus_notes, 'test stimulus notes')
+        self.assertEqual(self.nwbfile.data_collection, 'test data collection notes')
+        self.assertEqual(self.nwbfile.source_script, 'noscript')
+        self.assertEqual(self.nwbfile.source_script_file_name, 'nofilename')
 
     def test_create_electrode_group(self):
         name = 'example_electrode_group'
@@ -159,6 +167,13 @@ class NWBFileTest(unittest.TestCase):
         self.assertIn(ts2, children)
         self.assertIn(device, children)
         self.assertIn(elecgrp, children)
+
+    def test_fail_if_source_script_file_name_without_source_script(self):
+        with self.assertRaises(ValueError):
+            # <-- source_script_file_name without source_script is not allowed
+            NWBFile('a fake source', 'a test session description for a test NWBFile', 'FILE123', self.start,
+                    source_script=None,
+                    source_script_file_name='nofilename')
 
 
 class SubjectTest(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Fix #547 . The datasets/attributes ``/general/data_collection`` ``/general/stimulus`` ``/general/source_script.file_name`` could not be set via the NWBFile API. This PR adds these missing fields and updates the corresponding unit and integration tests. 

## How to test the behavior?
```
from datetime import datetime
from pynwb import NWBFile

start_time = datetime(2017, 4, 3, 11, 0, 0)
create_date = datetime(2017, 4, 15, 12, 0, 0)

nwbfile = NWBFile('PyNWB tutorial', 'demonstrate NWBFile basics', 'NWB123', start_time,
                  file_create_date=create_date,
                  experimenter='Test Experimenter',
                  data_collection='This is just a test',
                  stimulus_notes='Notes about the stimulus',
                  source_script='test2',
                  source_script_file_name='test')


from pynwb import NWBHDF5IO

io = NWBHDF5IO('temp2.nwb', mode='w')
io.write(nwbfile)
io.close()
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
