### PR TITLE
remove redundant 'get' in LFP dict

### DIFF
--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -345,7 +345,6 @@ class LFP(MultiContainerInterface):
         'add': 'add_electrical_series',
         'get': 'get_electrical_series',
         'create': 'create_electrical_series',
-        'get': 'get_electrical_series'
     }
 
     __help = ("LFP data from one or more channels. Filter properties "


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
