### PR TITLE
fix ruamel issue: + -> '+' in yaml files

### DIFF
--- a/src/pynwb/data/nwb.behavior.yaml
+++ b/src/pynwb/data/nwb.behavior.yaml
@@ -101,7 +101,7 @@ groups:
   groups:
   - doc: TimeSeries object containing time series data on pupil size
     neurodata_type_inc: TimeSeries
-    quantity: +
+    quantity: '+'
   default_name: PupilTracking
   neurodata_type_def: PupilTracking
   neurodata_type_inc: NWBDataInterface
@@ -147,7 +147,7 @@ groups:
   groups:
   - doc: SpatialSeries object containing position data
     neurodata_type_inc: SpatialSeries
-    quantity: +
+    quantity: '+'
   default_name: Position
   neurodata_type_def: Position
   neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -290,7 +290,7 @@ groups:
     will identify which channels are providing LFP data. Filter properties should
     be noted in the ElectricalSeries description or comments field.
   groups:
-  - doc: ElectricalSeries object containing LFP data for one or channels
+  - doc: ElectricalSeries object containing LFP data for one or more channels
     neurodata_type_inc: ElectricalSeries
     quantity: '+'
   default_name: LFP

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -275,7 +275,7 @@ groups:
   groups:
   - doc: ElectricalSeries object containing filtered electrophysiology data
     neurodata_type_inc: ElectricalSeries
-    quantity: +
+    quantity: '+'
   default_name: FilteredEphys
   neurodata_type_def: FilteredEphys
   neurodata_type_inc: NWBDataInterface
@@ -292,7 +292,7 @@ groups:
   groups:
   - doc: ElectricalSeries object containing LFP data for one or channels
     neurodata_type_inc: ElectricalSeries
-    quantity: +
+    quantity: '+'
   default_name: LFP
   neurodata_type_def: LFP
   neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -156,7 +156,7 @@ groups:
   groups:
   - doc: RoiResponseSeries object containing fluorescence data for a ROI
     neurodata_type_inc: RoiResponseSeries
-    quantity: +
+    quantity: '+'
   default_name: Fluorescence
   neurodata_type_def: Fluorescence
   neurodata_type_inc: NWBDataInterface
@@ -323,7 +323,7 @@ groups:
       target_type: ImageSeries
     neurodata_type_def: CorrectedImageStack
     neurodata_type_inc: NWBContainer
-    quantity: +
+    quantity: '+'
   default_name: MotionCorrection
   neurodata_type_def: MotionCorrection
   neurodata_type_inc: NWBDataInterface


### PR DESCRIPTION
## Motivation

The newer version of ruamel does not like `+` signs without quotes. All `+` are changed to `'+'` in the yaml files. This should also be changed in nwb-schema as well.

address #562 and fix #565.
## How to test the behavior?
```
import pynwb
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
