### PR TITLE
Fix stretched images in docs

### DIFF
--- a/docs/source/overview_software_architecture.rst
+++ b/docs/source/overview_software_architecture.rst
@@ -10,20 +10,20 @@ PyNWB and functionality of the various components.
 .. _fig-software-architecture:
 
 .. figure:: figures/software_architecture.*
-   :scale: 100 %
+   :width: 100%
    :alt: PyNWB Software Architecture
 
-   Overview of the high-level software architecture of PyNWB.
+   Overview of the high-level software architecture of PyNWB (click to enlarge).
 
 
 .. _fig-software-architecture-purpose:
 
 .. figure:: figures/software_architecture_design_choices.*
-   :scale: 100 %
+   :width: 100%
    :alt: PyNWB Software Architecture Functions
 
    We choose a modular design for PyNWB to enable flexibility and separate the
-   various aspects of the NWB:N ecosystem.
+   various aspects of the NWB:N ecosystem (click to enlarge).
 
 .. raw:: latex
 
@@ -37,10 +37,10 @@ Main Concepts
 .. _fig-software-architecture-concepts:
 
 .. figure:: figures/software_architecture_concepts.*
-   :scale: 100 %
+   :width: 100%
    :alt: PyNWB Software Architecture Concepts
 
-   Overview of the main concepts/classes in PyNWB and their location in the overall software architecture.
+   Overview of the main concepts/classes in PyNWB and their location in the overall software architecture (click to enlarge).
 
 Container
 ^^^^^^^^^
@@ -128,7 +128,7 @@ ObjectMapper
 .. _fig-software-architecture-mainconcepts:
 
 .. figure:: figures/software_architecture_mainconcepts.*
-   :scale: 100 %
+   :width: 100%
    :alt: PyNWB Software Architecture Main Concepts
 
    Relationship between ``Containers``, ``Builders``, ``ObjectMappers``, and ``Specs``
@@ -183,10 +183,10 @@ BuildManager
 .. _fig-software-architecture-buildmanager:
 
 .. figure:: figures/software_architecture_buildmanager.*
-   :scale: 100 %
+   :width: 100%
    :alt: PyNWB Software Architecture BuildManager and TypeMap
 
-   Overview of ``BuildManager`` (and ``TypeMap``).
+   Overview of ``BuildManager`` (and ``TypeMap``) (click to enlarge).
 
 
 FORMIO
@@ -210,7 +210,7 @@ FORMIO
 .. _fig-software-architecture-formio:
 
 .. figure:: figures/software_architecture_formio.*
-   :scale: 100 %
+   :width: 100%
    :alt: PyNWB Software Architecture FormIO
 
-   Overview of ``FORMIO``.
+   Overview of ``FORMIO`` (click to enlarge).


### PR DESCRIPTION
## Motivation

Minor update that fixes all the stretched images found on this page: https://pynwb.readthedocs.io/en/latest/overview_software_architecture.html

## How to test the behavior?

```sh
$ cd docs
$ make html
$ serve _build/html
# Navigate your browser to http://localhost:5000/overview_software_architecture
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
