### PR TITLE
NWBFile#create_electrode_table_region length check

### DIFF
--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -341,6 +341,11 @@ class NWBFile(MultiContainerInterface):
             msg = "no electrodes available. add electrodes before creating a region"
             raise RuntimeError(msg)
         region = getargs('region', kwargs)
+        for idx in region:
+            if idx < 0 or idx >= len(self.ec_electrodes):
+                raise TypeError('The index ' + str(idx) +
+                                ' is out of range for the ElectrodeTable of length '
+                                + str(len(self.ec_electrodes)))
         desc = getargs('description', kwargs)
         name = getargs('name', kwargs)
         return ElectrodeTableRegion(self.ec_electrodes, region, desc, name)

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -343,7 +343,7 @@ class NWBFile(MultiContainerInterface):
         region = getargs('region', kwargs)
         for idx in region:
             if idx < 0 or idx >= len(self.ec_electrodes):
-                raise TypeError('The index ' + str(idx) +
+                raise IndexError('The index ' + str(idx) +
                                 ' is out of range for the ElectrodeTable of length '
                                 + str(len(self.ec_electrodes)))
         desc = getargs('description', kwargs)

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -344,8 +344,8 @@ class NWBFile(MultiContainerInterface):
         for idx in region:
             if idx < 0 or idx >= len(self.ec_electrodes):
                 raise IndexError('The index ' + str(idx) +
-                                ' is out of range for the ElectrodeTable of length '
-                                + str(len(self.ec_electrodes)))
+                                 ' is out of range for the ElectrodeTable of length '
+                                 + str(len(self.ec_electrodes)))
         desc = getargs('description', kwargs)
         name = getargs('name', kwargs)
         return ElectrodeTableRegion(self.ec_electrodes, region, desc, name)

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -60,6 +60,21 @@ class NWBFileTest(unittest.TestCase):
         self.assertEqual(elecgrp.location, loc)
         self.assertIs(elecgrp.device, d)
 
+    def test_create_electrode_group_invalid_index(self):
+        """
+        Test the case where the user creates an electrode table region with
+        indexes that are out of range of the amount of electrodes added.
+        """
+        nwbfile = NWBFile('a', 'b', 'c', datetime.now())
+        device = nwbfile.create_device('a', 'b')
+        elecgrp = nwbfile.create_electrode_group('a', 'b', 'c', device=device, location='a')
+        for i in range(4):
+            nwbfile.add_electrode(i, np.nan, np.nan, np.nan, np.nan, group=elecgrp,
+                                  location='a', filtering='a', description='a')
+        with self.assertRaises(TypeError) as err:
+            nwbfile.create_electrode_table_region(list(range(6)), 'test')
+        self.assertTrue('out of range' in str(err.exception))
+
     def test_epoch_tags(self):
         tags1 = ['t1', 't2']
         tags2 = ['t3', 't4']

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -71,7 +71,7 @@ class NWBFileTest(unittest.TestCase):
         for i in range(4):
             nwbfile.add_electrode(i, np.nan, np.nan, np.nan, np.nan, group=elecgrp,
                                   location='a', filtering='a', description='a')
-        with self.assertRaises(TypeError) as err:
+        with self.assertRaises(IndexError) as err:
             nwbfile.create_electrode_table_region(list(range(6)), 'test')
         self.assertTrue('out of range' in str(err.exception))
 


### PR DESCRIPTION
## Motivation

This addresses https://github.com/NeurodataWithoutBorders/pynwb/issues/549. This adds a check on the indexes provided to `create_electrode_table_region` to make sure that they're within range of the ElectrodeTable for the NWBFile

## How to test the behavior?

See `tests/unit/pynwb_tests/test_file.py`, line 63, for the added test that covers this case (I used some of the code provided in the issue). All tests seem to pass

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
