### PR TITLE
Create a separate file for the Device object

### DIFF
--- a/docs/gallery/domain/ecephys.py
+++ b/docs/gallery/domain/ecephys.py
@@ -45,7 +45,7 @@ nwbfile = NWBFile('the PyNWB tutorial', 'my first synthetic recording', 'EXAMPLE
 device = nwbfile.create_device(name='trodes_rig123', source="a source")
 
 #######################
-# Once you have created the :py:class:`~pynwb.ecephys.Device`, you can create an
+# Once you have created the :py:class:`~pynwb.device.Device`, you can create an
 # :py:class:`~pynwb.ecephys.ElectrodeGroup`.
 
 electrode_name = 'tetrode1'

--- a/docs/gallery/domain/icephys.py
+++ b/docs/gallery/domain/icephys.py
@@ -31,8 +31,8 @@ nwbfile = NWBFile('the PyNWB tutorial', 'my first synthetic recording', 'EXAMPLE
 # Device metadata
 # ^^^^^^^^^^^^^^^
 #
-# Device metadata is represented by :py:class:`~pynwb.ecephys.Device` objects.
-# To create a device, you can use the :py:class:`~pynwb.ecephys.Device` instance method
+# Device metadata is represented by :py:class:`~pynwb.device.Device` objects.
+# To create a device, you can use the :py:class:`~pynwb.device.Device` instance method
 # :py:meth:`~pynwb.file.NWBFile.create_device`.
 
 device = nwbfile.create_device(name='Heka ITC-1600', source='a source')

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -232,6 +232,7 @@ from .base import TimeSeries, ProcessingModule  # noqa: F401,E402
 from .file import NWBFile  # noqa: E402, F401
 
 from . import behavior  # noqa: F401,E402
+from . import device  # noqa: F401,E402
 from . import ecephys  # noqa: F401,E402
 from . import epoch  # noqa: F401,E402
 from . import icephys  # noqa: F401,E402

--- a/src/pynwb/device.py
+++ b/src/pynwb/device.py
@@ -1,0 +1,18 @@
+from .form.utils import docval, call_docval_func
+from . import register_class, CORE_NAMESPACE
+from .core import NWBContainer
+
+
+@register_class('Device', CORE_NAMESPACE)
+class Device(NWBContainer):
+    """
+    """
+
+    __nwbfields__ = ('name',)
+
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this device'},
+            {'name': 'source', 'type': str, 'doc': 'the source of the data'},
+            {'name': 'parent', 'type': 'NWBContainer',
+             'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
+    def __init__(self, **kwargs):
+        call_docval_func(super(Device, self).__init__, kwargs)

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -8,21 +8,7 @@ from .form.data_utils import DataChunkIterator, ShapeValidator
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .core import NWBContainer, NWBTable, NWBTableRegion, NWBDataInterface, MultiContainerInterface
-
-
-@register_class('Device', CORE_NAMESPACE)
-class Device(NWBContainer):
-    """
-    """
-
-    __nwbfields__ = ('name',)
-
-    @docval({'name': 'name', 'type': str, 'doc': 'the name of this device'},
-            {'name': 'source', 'type': str, 'doc': 'the source of the data'},
-            {'name': 'parent', 'type': 'NWBContainer',
-             'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
-    def __init__(self, **kwargs):
-        call_docval_func(super(Device, self).__init__, kwargs)
+from .device import Device
 
 
 @register_class('ElectrodeGroup', CORE_NAMESPACE)


### PR DESCRIPTION
The Device object is currently defined in ecephys.py although both
icephys and ecephys use it. This is unfortunate and will be changed in
this commit.

Fix #443.