### PR TITLE
recurse on Proxy objects

### DIFF
--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -542,9 +542,13 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             return None
         attr_val = self.__get_override_attr(attr_name, container, manager)
         if attr_val is None:
-            if not hasattr(container, attr_name):
-                msg = "Container '%s' (%s) does not have attribute '%s'" % (container.name, type(container), attr_name)
-                #warnings.warn(msg)
+            # TODO: A message like this should be used to warn users when an expected attribute
+            # does not exist on a Container object
+            #
+            # if not hasattr(container, attr_name):
+            #     msg = "Container '%s' (%s) does not have attribute '%s'" \
+            #             % (container.name, type(container), attr_name)
+            #     #warnings.warn(msg)
             attr_val = getattr(container, attr_name, None)
             if attr_val is not None:
                 attr_val = self.__convert_value(attr_val, spec)

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -35,11 +35,6 @@ class Proxy(object):
         self.__candidates = list()
 
     @property
-    def candidates(self):
-        """Potential matches to this Proxy object"""
-        return self.__candidates
-
-    @property
     def source(self):
         """The source of the object e.g. file source"""
         return self.__source

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -401,6 +401,7 @@ class TestCacheSpec(unittest.TestCase):
                 types.update(catalog.get_types(source['source']))
         return types
 
+
 class TestLinkResolution(unittest.TestCase):
 
     def test_link_resolve(self):
@@ -428,6 +429,7 @@ class TestLinkResolution(unittest.TestCase):
                                                  data=[1., 2., 3.],
                                                  rate=0.0,
                                                  electrodes=etr)
+            nwbfile.add_acquisition(electrical_series)
         with NWBHDF5IO(self.path, 'w') as io:
             io.write(nwbfile)
         with NWBHDF5IO(self.path, 'r') as io:
@@ -435,6 +437,7 @@ class TestLinkResolution(unittest.TestCase):
 
     def setUp(self):
         self.path = "test_link_resolve.nwb"
+
 
     def tearDown(self):
         if os.path.exists(self.path):

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -438,10 +438,10 @@ class TestLinkResolution(unittest.TestCase):
     def setUp(self):
         self.path = "test_link_resolve.nwb"
 
-
     def tearDown(self):
         if os.path.exists(self.path):
             os.remove(self.path)
+
 
 class NWBHDF5IOMultiFileTest(unittest.TestCase):
     """Tests for h5tools IO tools"""

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -12,6 +12,8 @@ from pynwb.base import TimeSeries
 from pynwb import NWBHDF5IO
 from pynwb.spec import NWBNamespace, NWBGroupSpec, NWBDatasetSpec
 
+from pynwb.ecephys import ElectricalSeries
+
 
 import tempfile
 import warnings
@@ -399,6 +401,44 @@ class TestCacheSpec(unittest.TestCase):
                 types.update(catalog.get_types(source['source']))
         return types
 
+class TestLinkResolution(unittest.TestCase):
+
+    def test_link_resolve(self):
+        print("TEST_LINK_RESOLVE")
+
+        nwbfile = NWBFile("source", "a file with header data", "NB123A", '2018-06-01T00:00:00')
+        device = nwbfile.create_device('device_name', 'source')
+        electrode_group = nwbfile.create_electrode_group(
+            name='electrode_group_name',
+            source='source',
+            description='desc',
+            device=device,
+            location='unknown')
+        nwbfile.add_electrode(0,
+                              1.0, 2.0, 3.0,  # position?
+                              imp=2.718,
+                              location='unknown',
+                              filtering='unknown',
+                              description='desc',
+                              group=electrode_group)
+        etr = nwbfile.create_electrode_table_region([0], 'etr_name')
+        for passband in ('theta', 'gamma'):
+            electrical_series = ElectricalSeries(name=passband + '_phase',
+                                                 source='ephys_analysis',
+                                                 data=[1., 2., 3.],
+                                                 rate=0.0,
+                                                 electrodes=etr)
+        with NWBHDF5IO(self.path, 'w') as io:
+            io.write(nwbfile)
+        with NWBHDF5IO(self.path, 'r') as io:
+            io.read()
+
+    def setUp(self):
+        self.path = "test_link_resolve.nwb"
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
 
 class NWBHDF5IOMultiFileTest(unittest.TestCase):
     """Tests for h5tools IO tools"""


### PR DESCRIPTION
## Motivation

Link resolution on read was breaking. This was exposed by using the same *ElectrodeTableRegion* in multiple places. The bug was presenting itself with the following error: 

```
AttributeError: 'Proxy' object has no attribute 'name'
```

Fix #558 
Fix #568 