### PR TITLE
change UnitTimes.get_unit_spike_times return type and corresponding test

### DIFF
--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -232,7 +232,7 @@ class UnitTimes(NWBDataInterface):
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'})
     def get_unit_spike_times(self, **kwargs):
         index = getargs('index', kwargs)
-        return self.__iv.get_vector(index)
+        return np.array(self.__iv.get_vector(index))
 
     @docval({'name': 'unit_id', 'type': int, 'doc': 'the unit to add spike times for'},
             {'name': 'spike_times', 'type': ('array_data',), 'doc': 'the spike times for the unit'},

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -1,5 +1,7 @@
 import unittest
 
+import numpy as np
+
 from pynwb.misc import AnnotationSeries, AbstractFeatureSeries, IntervalSeries, UnitTimes
 
 
@@ -70,8 +72,8 @@ class UnitTimesConstructor(unittest.TestCase):
         ut = UnitTimes('UnitTimes add_spike_times unit test')
         ut.add_spike_times(0, [0, 1, 2])
         ut.add_spike_times(1, [3, 4, 5])
-        self.assertEqual(ut.get_unit_spike_times(0), [0, 1, 2])
-        self.assertEqual(ut.get_unit_spike_times(1), [3, 4, 5])
+        self.assertTrue(all(ut.get_unit_spike_times(0) == np.array([0, 1, 2])))
+        self.assertTrue(all(ut.get_unit_spike_times(1) == np.array([3, 4, 5])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

fix #449


## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
