### PR TITLE
TimeSeries: Rename rate_unit variable and use it correctly

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -83,7 +83,7 @@ class TimeSeries(NWBDataInterface):
                      "interval",
                      "starting_time",
                      "rate",
-                     "rate_unit",
+                     "starting_time_unit",
                      "control",
                      "control_description")
 
@@ -167,9 +167,9 @@ class TimeSeries(NWBDataInterface):
                 timestamps.__add_link('timestamp_link', self)
         elif rate is not None:
             self.rate = rate
-            self.rate_unit = 'Seconds'
             if starting_time is not None:
                 self.starting_time = starting_time
+                self.starting_time_unit = 'Seconds'
             else:
                 self.starting_time = 0.0
         else:

--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -31,7 +31,7 @@ class TimeSeriesMap(ObjectMapper):
         self.map_attr('timestamps_unit', timestamps_spec.get_attribute('unit'))
         # self.map_attr('interval', timestamps_spec.get_attribute('interval'))
         startingtime_spec = self.spec.get_dataset('starting_time')
-        self.map_attr('rate_unit', startingtime_spec.get_attribute('unit'))
+        self.map_attr('starting_time_unit', startingtime_spec.get_attribute('unit'))
         self.map_attr('rate', startingtime_spec.get_attribute('rate'))
 
     @ObjectMapper.constructor_arg('name')

--- a/src/pynwb/legacy/io/base.py
+++ b/src/pynwb/legacy/io/base.py
@@ -43,7 +43,7 @@ class TimeSeriesMap(ObjectMapper):
         self.map_attr('timestamps_unit', timestamps_spec.get_attribute('unit'))
         # self.map_attr('interval', timestamps_spec.get_attribute('interval'))
         starting_time_spec = self.spec.get_dataset('starting_time')
-        self.map_attr('rate_unit', starting_time_spec.get_attribute('unit'))
+        self.map_attr('starting_time_unit', starting_time_spec.get_attribute('unit'))
         self.map_attr('rate', starting_time_spec.get_attribute('rate'))
 
     @ObjectMapper.constructor_arg('name')


### PR DESCRIPTION
Since 575da105 (moved base TimeSeries class into submodule core,
2017-01-30) the unit of the rate is defined as "Seconds". But in
TimeSeriesMap it is used as starting time unit.

Rename the class variable therefore from rate_unit to
starting_time_unit.

A user visible change is that we now fill starting_time_unit only when a
starting_time is given.