### PR TITLE
add stimulus_description

### DIFF
--- a/src/pynwb/data/nwb.icephys.yaml
+++ b/src/pynwb/data/nwb.icephys.yaml
@@ -8,9 +8,9 @@ groups:
     dtype: text
     doc: Value is 'Superclass definition for patch-clamp data'
     value: Superclass definition for patch-clamp data
-  - doc: the protocol/stimulus name for this patch-clamp dataset
+  - name: stimulus_description
     dtype: text
-    name: stimulus_description
+    doc: the protocol/stimulus name for this patch-clamp dataset
   datasets:
   - name: data
     dtype: float

--- a/src/pynwb/data/nwb.icephys.yaml
+++ b/src/pynwb/data/nwb.icephys.yaml
@@ -4,6 +4,9 @@ groups:
     dtype: text
     name: help
     value: Superclass definition for patch-clamp data
+  - doc: the protocol/stimulus name for this patch-clamp dataset
+    dtype: text
+    name: stimulus_description
   datasets:
   - dims:
     - num_times

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -103,7 +103,7 @@ class PatchClampSeries(TimeSeries):
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
     def __init__(self, **kwargs):
-        name, source, data, unit = popargs('name', 'source', 'data', 'unit', kwargs)
+        name, source, data, unit, stimulus_description = popargs('name', 'source', 'data', 'unit', 'stimulus_description', kwargs)
         electrode, gain = popargs('electrode', 'gain', kwargs)
         super(PatchClampSeries, self).__init__(name, source, data, unit, **kwargs)
         self.electrode = electrode
@@ -139,7 +139,7 @@ class CurrentClampSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to apply or \
              record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
-            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "NA"},
 
             {'name': 'bias_current', 'type': float, 'doc': 'Unit: Amp'},
             {'name': 'bridge_balance', 'type': float, 'doc': 'Unit: Ohm'},
@@ -205,7 +205,7 @@ class IZeroClampSeries(CurrentClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to apply \
              or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
-            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "NA"},
 
             {'name': 'bias_current', 'type': float, 'doc': 'Unit: Amp', 'default': 0.0},
             {'name': 'bridge_balance', 'type': float, 'doc': 'Unit: Ohm', 'default': 0.0},
@@ -264,7 +264,7 @@ class CurrentClampStimulusSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to \
              apply or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
-            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "NA"},
 
             {'name': 'resolution', 'type': float,
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
@@ -324,7 +324,7 @@ class VoltageClampSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to \
              apply or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
-            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "NA"},
             {'name': 'capacitance_fast', 'type': float, 'doc': 'Unit: Farad'},
             {'name': 'capacitance_slow', 'type': float, 'doc': 'Unit: Farad'},
             {'name': 'resistance_comp_bandwidth', 'type': float, 'doc': 'Unit: Hz'},
@@ -394,7 +394,7 @@ class VoltageClampStimulusSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was \
              used to apply or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
-            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "NA"},
             {'name': 'resolution', 'type': float,
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
              'default': _default_resolution},

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -103,7 +103,8 @@ class PatchClampSeries(TimeSeries):
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
     def __init__(self, **kwargs):
-        name, source, data, unit, stimulus_description = popargs('name', 'source', 'data', 'unit', 'stimulus_description', kwargs)
+        name, source, data, unit, stimulus_description = popargs('name', 'source', 'data',
+                                                                 'unit', 'stimulus_description', kwargs)
         electrode, gain = popargs('electrode', 'gain', kwargs)
         super(PatchClampSeries, self).__init__(name, source, data, unit, **kwargs)
         self.electrode = electrode

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -60,7 +60,8 @@ class PatchClampSeries(TimeSeries):
     '''
 
     __nwbfields__ = ('electrode',
-                     'gain')
+                     'gain',
+                     'stimulus_description')
 
     _ancestry = "TimeSeries,PatchClampSeries"
     _help = "Superclass definition for patch-clamp data."
@@ -78,6 +79,7 @@ class PatchClampSeries(TimeSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to apply \
              or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "NA"},
 
             {'name': 'resolution', 'type': float,
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
@@ -106,6 +108,7 @@ class PatchClampSeries(TimeSeries):
         super(PatchClampSeries, self).__init__(name, source, data, unit, **kwargs)
         self.electrode = electrode
         self.gain = gain
+        self.stimulus_description = stimulus_description
 
 
 @register_class('CurrentClampSeries', CORE_NAMESPACE)
@@ -136,6 +139,7 @@ class CurrentClampSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to apply or \
              record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
 
             {'name': 'bias_current', 'type': float, 'doc': 'Unit: Amp'},
             {'name': 'bridge_balance', 'type': float, 'doc': 'Unit: Ohm'},
@@ -201,6 +205,7 @@ class IZeroClampSeries(CurrentClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to apply \
              or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
 
             {'name': 'bias_current', 'type': float, 'doc': 'Unit: Amp', 'default': 0.0},
             {'name': 'bridge_balance', 'type': float, 'doc': 'Unit: Ohm', 'default': 0.0},
@@ -259,6 +264,7 @@ class CurrentClampStimulusSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to \
              apply or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
 
             {'name': 'resolution', 'type': float,
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
@@ -318,6 +324,7 @@ class VoltageClampSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was used to \
              apply or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
             {'name': 'capacitance_fast', 'type': float, 'doc': 'Unit: Farad'},
             {'name': 'capacitance_slow', 'type': float, 'doc': 'Unit: Farad'},
             {'name': 'resistance_comp_bandwidth', 'type': float, 'doc': 'Unit: Hz'},
@@ -387,6 +394,7 @@ class VoltageClampStimulusSeries(PatchClampSeries):
              'doc': 'IntracellularElectrode group that describes the electrode that was \
              used to apply or record this data.'},
             {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},
+            {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol'},
             {'name': 'resolution', 'type': float,
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
              'default': _default_resolution},


### PR DESCRIPTION
## Motivation

fix #564 

@t-b I made `stimulus_description` a required attribute. I had the *PatchClampSeries* constructor set `stimulus_description` to "NA" by default since it broke the fewest tests.  Feel free to change the that around. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
