### PR TITLE
Reorder yaml

### DIFF
--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -1,255 +1,261 @@
 datasets:
-- attributes:
-  - doc: Short description of what this type of Interface contains.
-    dtype: text
-    name: help
+- neurodata_type_def: NWBData
   doc: The attributes specified here are included in all interfaces.
-  neurodata_type_def: NWBData
-- attributes:
-  - doc: Value is 'One of many columns that can be added to a DynamicTable'
+  attributes:
+  - name: help
     dtype: text
+    doc: Short description of what this type of Interface contains.
+- neurodata_type_def: TableColumn
+  neurodata_type_inc: NWBData
+  doc: The attributes specified here are included in all interfaces.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'One of many columns that can be added to a DynamicTable'
     value: One of many columns that can be added to a DynamicTable
-    name: help
-  - doc: A short description of what this column stores
+  - name: description
     dtype: text
-    name: description
-  doc: The attributes specified here are included in all interfaces.
-  neurodata_type_def: TableColumn
+    doc: A short description of what this column stores
+- neurodata_type_def: VectorData
   neurodata_type_inc: NWBData
-- default_name: vector_data
-  attributes:
-  - doc: a help string
-    dtype: text
-    name: help
-    value: Values for a list of elements
   doc: Data values indexed by pointer
-  neurodata_type_def: VectorData
-  neurodata_type_inc: NWBData
-- default_name: vector_index
   attributes:
-  - doc: a help string
+  - name: help
     dtype: text
-    name: help
-    value: indexes into a list of values for a list of elements
-  doc: Pointers that index data values
+    doc: a help string
+    value: Values for a list of elements
+  default_name: vector_data
+- neurodata_type_def: VectorIndex
+  neurodata_type_inc: NWBData
   dtype:
     target_type: VectorData
     reftype: region
-  shape:
-  - null
-  neurodata_type_def: VectorIndex
-  neurodata_type_inc: NWBData
-- default_name: element_id
+  doc: Pointers that index data values
   attributes:
-  - doc: a help string
+  - name: help
     dtype: text
-    name: help
-    value: unique identifiers for a list of elements
-  doc: a unique identifier for each element
-  dtype: int
+    doc: a help string
+    value: indexes into a list of values for a list of elements
+  default_name: vector_index
   shape:
-  - null
-  neurodata_type_def: ElementIdentifiers
+  - 
+- neurodata_type_def: ElementIdentifiers
   neurodata_type_inc: NWBData
+  dtype: int
+  doc: a unique identifier for each element
+  attributes:
+  - name: help
+    dtype: text
+    doc: a help string
+    value: unique identifiers for a list of elements
+  default_name: element_id
+  shape:
+  - 
 groups:
-- attributes:
-  - doc: Short description of what this type of NWBContainer contains.
-    dtype: text
-    name: help
-  - doc: Path to the origin of the data represented in this interface.
-    dtype: text
-    name: source
+- neurodata_type_def: NWBContainer
   doc: The attributes specified here are included in all interfaces.
-  neurodata_type_def: NWBContainer
-- doc: An abstract data type for differentiating experimental data from metadata
+  attributes:
+  - name: help
+    dtype: text
+    doc: Short description of what this type of NWBContainer contains.
+  - name: source
+    dtype: text
+    doc: Path to the origin of the data represented in this interface.
+- neurodata_type_def: NWBDataInterface
   neurodata_type_inc: NWBContainer
-  neurodata_type_def: NWBDataInterface
-- attributes:
-  - default_value: no comments
+  doc: An abstract data type for differentiating experimental data from metadata
+- neurodata_type_def: TimeSeries
+  neurodata_type_inc: NWBDataInterface
+  doc: General purpose time series.
+  attributes:
+  - name: comments
+    dtype: text
     doc: Human-readable comments about the TimeSeries. This second descriptive field
       can be used to store additional information, or descriptive information if the
       primary description field is populated with a computer-readable string.
-    dtype: text
-    name: comments
+    default_value: no comments
     required: false
-  - default_value: no description
+  - name: description
+    dtype: text
     doc: Description of TimeSeries
-    dtype: text
-    name: description
+    default_value: no description
     required: false
-  - doc: Value is 'General time series object'
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'General time series object'
     value: General time series object
-  - doc: Name of TimeSeries or Modules that serve as the source for the data contained
-      here. It can also be the name of a device, for stimulus or acquisition data
+  - name: source
     dtype: text
-    name: source
+    doc: Name of TimeSeries or Modules that serve as the source for the data contained
+      here. It can also be the name of a device, for stimulus or acquisition data
   datasets:
-  - dims:
-    - num_times
+  - name: control
+    dtype: uint8
     doc: 'Numerical labels that apply to each element in data[]. COMMENT: Optional
       field. If present, the control array should have the same number of elements
       as data[].'
-    dtype: uint8
-    name: control
+    dims:
+    - num_times
     quantity: '?'
     shape:
-    - null
-  - dims:
-    - num_control_values
+    - 
+  - name: control_description
+    dtype: text
     doc: 'Description of each control value. COMMENT: Array length should be as long
       as the highest number in control minus one, generating an zero-based indexed
       array for control values.'
-    dtype: text
-    name: control_description
+    dims:
+    - num_control_values
     quantity: '?'
     shape:
-    - null
-  - attributes:
-    - default_value: 1.0
+    - 
+  - name: data
+    doc: 'Data values. Can also store binary data (eg, image frames) COMMENT: This
+      field may be a link to data stored in an external file, especially in the case
+      of raw data.'
+    attributes:
+    - name: conversion
+      dtype: float32
       doc: Scalar to multiply each element in data to convert it to the specified
         unit
-      dtype: float32
-      name: conversion
+      default_value: 1.0
       required: false
-    - default_value: 0.0
+    - name: resolution
+      dtype: float32
       doc: 'Smallest meaningful difference between values in data, stored in the specified
         by unit. COMMENT: E.g., the change in value of the least significant bit,
         or a larger number if signal noise is known to be present. If unknown, use
         NaN'
-      dtype: float32
-      name: resolution
+      default_value: 0.0
       required: false
-    - doc: "The base unit of measure used to store data. This should be in the SI\
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
         \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
         \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
         \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
     dims:
     - num_times
-    doc: 'Data values. Can also store binary data (eg, image frames) COMMENT: This
-      field may be a link to data stored in an external file, especially in the case
-      of raw data.'
-    name: data
     shape:
-    - null
-  - attributes:
-    - doc: 'Sampling rate, in Hz COMMENT: Rate information is stored in Hz'
-      dtype: float32
-      name: rate
-    - doc: Value is 'Seconds'
-      dtype: text
-      name: unit
-      value: Seconds
+    - 
+  - name: starting_time
+    dtype: float64
     doc: 'The timestamp of the first sample. COMMENT: When timestamps are uniformly
       spaced, the timestamp of the first sample can be specified and all subsequent
       ones calculated from the sampling rate.'
-    dtype: float64
-    name: starting_time
-    quantity: '?'
-  - attributes:
-    - doc: Value is '1'
-      dtype: int32
-      name: interval
-      value: 1
-    - doc: Value is 'Seconds'
+    attributes:
+    - name: rate
+      dtype: float32
+      doc: 'Sampling rate, in Hz COMMENT: Rate information is stored in Hz'
+    - name: unit
       dtype: text
-      name: unit
+      doc: Value is 'Seconds'
       value: Seconds
-    dims:
-    - num_times
+    quantity: '?'
+  - name: timestamps
+    dtype: float64
     doc: 'Timestamps for samples stored in data.COMMENT: Timestamps here have all
       been corrected to the common experiment master-clock. Time is stored as seconds
       and all timestamps are relative to experiment start time.'
-    dtype: float64
-    name: timestamps
+    attributes:
+    - name: interval
+      dtype: int32
+      doc: Value is '1'
+      value: 1
+    - name: unit
+      dtype: text
+      doc: Value is 'Seconds'
+      value: Seconds
+    dims:
+    - num_times
     quantity: '?'
     shape:
-    - null
-  doc: General purpose time series.
+    - 
   groups:
-  - doc: "Lab specific time and sync information as provided directly from hardware\
+  - name: sync
+    doc: "Lab specific time and sync information as provided directly from hardware\
       \ devices and that is necessary for aligning all acquired time information to\
       \ a common timebase. The timestamp array stores time in the common timebase.\
       \ COMMENT: This group will usually only be populated in TimeSeries that are\
       \ stored external to the NWB file, in files storing raw data. Once timestamp\
       \ data is calculated, the contents of 'sync' are mostly for archival purposes."
-    name: sync
     quantity: '?'
-  neurodata_type_def: TimeSeries
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Description of Module
-    dtype: text
-    name: description
-  - doc: Value is 'A collection of analysis outputs from processing of data'
-    dtype: text
-    name: help
-    value: A collection of analysis outputs from processing of data
+- neurodata_type_def: ProcessingModule
+  neurodata_type_inc: NWBContainer
   doc: Module.  Name should be descriptive. Stores a collection of related data organized
     by contained interfaces.  Each interface is a contract specifying content related
     to a particular type of data.
+  attributes:
+  - name: description
+    dtype: text
+    doc: Description of Module
+  - name: help
+    dtype: text
+    doc: Value is 'A collection of analysis outputs from processing of data'
+    value: A collection of analysis outputs from processing of data
   groups:
-  - doc: Interface objects containing data output from processing steps
-    neurodata_type_inc: NWBDataInterface
+  - neurodata_type_inc: NWBDataInterface
+    doc: Interface objects containing data output from processing steps
     quantity: '*'
-  neurodata_type_def: ProcessingModule
-  neurodata_type_inc: NWBContainer
-- attributes:
-  - doc: Description of images in this container
+- neurodata_type_def: Images
+  neurodata_type_inc: NWBDataInterface
+  doc: A NWBDataInterface for storing images that have some relationship
+  attributes:
+  - name: description
     dtype: text
-    name: description
-  - doc: Value is 'A collection of images that have some meaningful relationship'
+    doc: Description of images in this container
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'A collection of images that have some meaningful relationship'
     value: A collection of images that have some meaningful relationship
   datasets:
-    - doc: Images stored in this NWBDataInterface
-      neurodata_type_inc: Image
-      quantity: '+'
+  - neurodata_type_inc: Image
+    doc: Images stored in this NWBDataInterface
+    quantity: +
   default_name: Images
-  doc: A NWBDataInterface for storing images that have some relationship
-  neurodata_type_def: Images
+- neurodata_type_def: DynamicTable
   neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'A column-centric table'
+  doc: A group containing multiple datasets that are aligned on the first dimension
+    (Currently, this requirement if left up to APIs to check and enforce). Apart from
+    a column that contains unique identifiers for each row there are no other required
+    datasets. Users are free to add any number of TableColumn objects here. Table
+    functionality is already supported through compound types, which is analogous
+    to storing an array-of-structs. DynamicTable can be thought of as a struct-of-arrays.
+    This provides an alternative structure to choose from when optimizing storage
+    for anticipated access patterns. Additionally, this type provides a way of creating
+    a table without having to define a compound type up front. Although this convenience
+    may be attractive, users should think carefully about how data will be accessed.
+    DynamicTable is more appropriate for column-centric access, whereas a dataset
+    with a compound type would be more appropriate for row-centric access. Finally,
+    data size should also be taken into account. For small tables, performance loss
+    may be an acceptable trade-off for the flexibility of a DynamicTable. For example,
+    DynamicTable was originally developed for storing trial data and spike unit metadata.
+    Both of these use cases are expected to produce relatively small tables, so the
+    spatial locality of multiple datasets present in a DynamicTable is not expected
+    to have a significant performance impact. Additionally, requirements of trial
+    and unit metadata tables are sufficiently diverse that performance implications
+    can be overlooked in favor of usability.
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'A column-centric table'
     value: A column-centric table
-  - doc: The names of the columns in this table. This should be used to specifying an order to the columns
+  - name: colnames
     dtype: text
-    name: colnames
+    doc: The names of the columns in this table. This should be used to specifying
+      an order to the columns
     shape:
-      - null
-  - doc: Description of what is in this dynamic table
+    - 
+  - name: description
     dtype: text
-    name: description
+    doc: Description of what is in this dynamic table
   datasets:
-    - name: id
-      neurodata_type_inc: ElementIdentifiers
-      doc: The unique identifier for the rows in this dynamic table
-      dtype: int
-      shape:
-        - null
-    - doc: The columns in this dynamic table
-      neurodata_type_inc: TableColumn
-      quantity: '*'
-  doc: A group containing multiple datasets that are aligned on the first dimension (Currently, this requirement
-    if left up to APIs to check and enforce). Apart from a column that contains unique identifiers for each row
-    there are no other required datasets. Users are free to add any number of TableColumn objects here. Table
-    functionality is already supported through compound types, which is analogous to storing an array-of-structs.
-    DynamicTable can be thought of as a struct-of-arrays. This provides an alternative structure to choose from
-    when optimizing storage for anticipated access patterns. Additionally, this type provides a way of creating a
-    table without having to define a compound type up front. Although this convenience may be attractive, users
-    should think carefully about how data will be accessed. DynamicTable is more appropriate for column-centric
-    access, whereas a dataset with a compound type would be more appropriate for row-centric access. Finally,
-    data size should also be taken into account. For small tables, performance loss may be an acceptable trade-off
-    for the flexibility of a DynamicTable. For example, DynamicTable was originally developed for storing trial
-    data and spike unit metadata. Both of these use cases are expected to produce relatively small tables, so
-    the spatial locality of multiple datasets present in a DynamicTable is not expected to have a significant performance
-    impact. Additionally, requirements of trial and unit metadata tables are sufficiently diverse that performance
-    implications can be overlooked in favor of usability.
-  neurodata_type_def: DynamicTable
-  neurodata_type_inc: NWBDataInterface
+  - neurodata_type_inc: ElementIdentifiers
+    name: id
+    dtype: int
+    doc: The unique identifier for the rows in this dynamic table
+    shape:
+    - 
+  - neurodata_type_inc: TableColumn
+    doc: The columns in this dynamic table
+    quantity: '*'

--- a/src/pynwb/data/nwb.behavior.yaml
+++ b/src/pynwb/data/nwb.behavior.yaml
@@ -1,34 +1,6 @@
 groups:
-- attributes:
-  - doc: Value is 'Stores points in space over time. The data[] array structure is
-      [num samples][num spatial dimensions]'
-    dtype: text
-    name: help
-    value: Stores points in space over time. The data[] array structure is [num samples][num
-      spatial dimensions]
-  datasets:
-  - attributes:
-    - default_value: meter
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    dims:
-    - num_times
-    - num_features
-    doc: 2-D array storing position or direction relative to some reference frame.
-    dtype: float
-    name: data
-    shape:
-    - null
-    - null
-  - doc: Description defining what exactly 'straight-ahead' means.
-    dtype: text
-    name: reference_frame
-    quantity: '?'
+- neurodata_type_def: SpatialSeries
+  neurodata_type_inc: TimeSeries
   doc: 'Direction, e.g., of gaze or travel, or position. The TimeSeries::data field
     is a 2D array storing position or direction relative to some reference frame.
     Array structure: [num measurements] [num dimensions]. Each SpatialSeries has a
@@ -38,13 +10,38 @@ groups:
     data, the 0,0 point might be the top-left corner of an enclosure, as viewed from
     the tracking camera. The unit of data will indicate how to interpret SpatialSeries
     values.'
-  neurodata_type_def: SpatialSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'General container for storing behavioral epochs'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: General container for storing behavioral epochs
+    doc: Value is 'Stores points in space over time. The data[] array structure is
+      [num samples][num spatial dimensions]'
+    value: Stores points in space over time. The data[] array structure is [num samples][num
+      spatial dimensions]
+  datasets:
+  - name: data
+    dtype: float
+    doc: 2-D array storing position or direction relative to some reference frame.
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: meter
+      required: false
+    dims:
+    - num_times
+    - num_features
+    shape:
+    - 
+    - 
+  - name: reference_frame
+    dtype: text
+    doc: Description defining what exactly 'straight-ahead' means.
+    quantity: '?'
+- neurodata_type_def: BehavioralEpochs
+  neurodata_type_inc: NWBDataInterface
   doc: TimeSeries for storing behavoioral epochs.  The objective of this and the other
     two Behavioral interfaces (e.g. BehavioralEvents and BehavioralTimeSeries) is
     to provide generic hooks for software tools/scripts. This allows a tool/script
@@ -57,97 +54,100 @@ groups:
     TimeSeries defined in the module sub-group "BehavioralTimeSeries". BehavioralEpochs
     should use IntervalSeries. BehavioralEvents is used for irregular events. BehavioralTimeSeries
     is for continuous data.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'General container for storing behavioral epochs'
+    value: General container for storing behavioral epochs
   groups:
-  - doc: IntervalSeries object containing start and stop times of epochs
-    neurodata_type_inc: IntervalSeries
+  - neurodata_type_inc: IntervalSeries
+    doc: IntervalSeries object containing start and stop times of epochs
     quantity: '*'
   default_name: BehavioralEpochs
-  neurodata_type_def: BehavioralEpochs
+- neurodata_type_def: BehavioralEvents
   neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Position data, whether along the x, xy or xyz axis'
-    dtype: text
-    name: help
-    value: Position data, whether along the x, xy or xyz axis
   doc: TimeSeries for storing behavioral events. See description of <a href="#BehavioralEpochs">BehavioralEpochs</a>
     for more details.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Position data, whether along the x, xy or xyz axis'
+    value: Position data, whether along the x, xy or xyz axis
   groups:
-  - doc: TimeSeries object containing irregular behavioral events
-    neurodata_type_inc: TimeSeries
+  - neurodata_type_inc: TimeSeries
+    doc: TimeSeries object containing irregular behavioral events
     quantity: '*'
   default_name: BehavioralEvents
-  neurodata_type_def: BehavioralEvents
+- neurodata_type_def: BehavioralTimeSeries
   neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'General container for storing continuously sampled behavioral data.'
-    dtype: text
-    name: help
-    value: General container for storing continuously sampled behavioral data.
   doc: TimeSeries for storing Behavoioral time series data.See description of <a href="#BehavioralEpochs">BehavioralEpochs</a>
     for more details.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'General container for storing continuously sampled behavioral data.'
+    value: General container for storing continuously sampled behavioral data.
   groups:
-  - doc: TimeSeries object containing continuous behavioral data
-    neurodata_type_inc: TimeSeries
+  - neurodata_type_inc: TimeSeries
+    doc: TimeSeries object containing continuous behavioral data
     quantity: '*'
   default_name: BehavioralTimeSeries
-  neurodata_type_def: BehavioralTimeSeries
+- neurodata_type_def: PupilTracking
   neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Eye-tracking data, representing pupil size'
-    dtype: text
-    name: help
-    value: Eye-tracking data, representing pupil size
   doc: Eye-tracking data, representing pupil size.
-  groups:
-  - doc: TimeSeries object containing time series data on pupil size
-    neurodata_type_inc: TimeSeries
-    quantity: '+'
-  default_name: PupilTracking
-  neurodata_type_def: PupilTracking
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Eye-tracking data, representing direction of gaze'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Eye-tracking data, representing direction of gaze
-  doc: Eye-tracking data, representing direction of gaze.
+    doc: Value is 'Eye-tracking data, representing pupil size'
+    value: Eye-tracking data, representing pupil size
   groups:
-  - doc: SpatialSeries object containing data measuring direction of gaze
-    neurodata_type_inc: SpatialSeries
+  - neurodata_type_inc: TimeSeries
+    doc: TimeSeries object containing time series data on pupil size
+    quantity: +
+  default_name: PupilTracking
+- neurodata_type_def: EyeTracking
+  neurodata_type_inc: NWBDataInterface
+  doc: Eye-tracking data, representing direction of gaze.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Eye-tracking data, representing direction of gaze'
+    value: Eye-tracking data, representing direction of gaze
+  groups:
+  - neurodata_type_inc: SpatialSeries
+    doc: SpatialSeries object containing data measuring direction of gaze
     quantity: '*'
   default_name: EyeTracking
-  neurodata_type_def: EyeTracking
+- neurodata_type_def: CompassDirection
   neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Direction as measured radially. Spatial series reference frame
-      should indicate which direction corresponds to zero and what is the direction
-      of positive rotation'
-    dtype: text
-    name: help
-    value: Direction as measured radially. Spatial series reference frame should indicate
-      which direction corresponds to zero and what is the direction of positive rotation
   doc: With a CompassDirection interface, a module publishes a SpatialSeries object
     representing a floating point value for theta. The SpatialSeries::reference_frame
     field should indicate what direction corresponds to 0 and which is the direction
     of rotation (this should be clockwise). The si_unit for the SpatialSeries should
     be radians or degrees.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Direction as measured radially. Spatial series reference frame
+      should indicate which direction corresponds to zero and what is the direction
+      of positive rotation'
+    value: Direction as measured radially. Spatial series reference frame should indicate
+      which direction corresponds to zero and what is the direction of positive rotation
   groups:
-  - doc: SpatialSeries object containing direction of gaze travel
-    neurodata_type_inc: SpatialSeries
+  - neurodata_type_inc: SpatialSeries
+    doc: SpatialSeries object containing direction of gaze travel
     quantity: '*'
   default_name: CompassDirection
-  neurodata_type_def: CompassDirection
+- neurodata_type_def: Position
   neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Position data, whether along the x, xy or xyz axis'
-    dtype: text
-    name: help
-    value: Position data, whether along the x, xy or xyz axis
   doc: Position data, whether along the x, x/y or x/y/z axis.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Position data, whether along the x, xy or xyz axis'
+    value: Position data, whether along the x, xy or xyz axis
   groups:
-  - doc: SpatialSeries object containing position data
-    neurodata_type_inc: SpatialSeries
-    quantity: '+'
+  - neurodata_type_inc: SpatialSeries
+    doc: SpatialSeries object containing position data
+    quantity: +
   default_name: Position
-  neurodata_type_def: Position
-  neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -1,322 +1,6 @@
-groups:
-- attributes:
-  - doc: Value is 'Stores acquired voltage data from extracellular recordings'
-    dtype: text
-    name: help
-    value: Stores acquired voltage data from extracellular recordings
-  datasets:
-  - attributes:
-    - default_value: volt
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    dims:
-    - - num_times
-    - - num_times
-      - num_channels
-    doc: Recorded voltage data.
-    dtype: float
-    name: data
-    shape:
-    - - null
-    - - null
-      - null
-  - name: electrodes
-    doc: 'the electrodes that this series was generated from'
-    neurodata_type_inc: ElectrodeTableRegion
-  doc: 'Stores acquired voltage data from extracellular recordings. The data field
-    of an ElectricalSeries is an int or float array storing data in Volts. TimeSeries::data
-    array structure: :blue:`[num times] [num channels] (or [num_times] for single
-    electrode).`'
-  neurodata_type_def: ElectricalSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Snapshots of spike events from data.'
-    dtype: text
-    name: help
-    value: Snapshots of spike events from data.
-  datasets:
-  - attributes:
-    - default_value: volt
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    dims:
-    - - num_events
-      - num_samples
-    - - num_events
-      - num_channels
-      - num_samples
-    doc: Spike waveforms.
-    dtype: float32
-    name: data
-    shape:
-    - - null
-      - null
-    - - null
-      - null
-      - null
-  doc: 'Stores "snapshots" of spike events (i.e., threshold crossings) in data. This
-    may also be raw data, as reported by ephys hardware. If so, the TimeSeries::description
-    field should describing how events were detected. All SpikeEventSeries should
-    reside in a module (under EventWaveform interface) even if the spikes were reported
-    and stored by hardware. All events span the same recording channels and store
-    snapshots of equal duration. TimeSeries::data array structure: :blue:`[num events]
-    [num channels] [num samples] (or [num events] [num samples] for single electrode)`.'
-  neurodata_type_def: SpikeEventSeries
-  neurodata_type_inc: ElectricalSeries
-- attributes:
-  - doc: Value is 'Mean waveform shape of clusters. Waveforms should be high-pass
-      filtered (ie, not the same bandpass filter used waveform analysis and clustering)'
-    dtype: text
-    name: help
-    value: Mean waveform shape of clusters. Waveforms should be high-pass filtered
-      (ie, not the same bandpass filter used waveform analysis and clustering)
-  datasets:
-  - doc: Filtering applied to data before generating mean/sd
-    dtype: text
-    name: waveform_filtering
-  - dims:
-    - num_clusters
-    - num_samples
-    doc: The mean waveform for each cluster, using the same indices for each wave
-      as cluster numbers in the associated Clustering module (i.e, cluster 3 is in
-      array slot [3]). Waveforms corresponding to gaps in cluster sequence should
-      be empty (e.g., zero- filled)
-    dtype: float32
-    name: waveform_mean
-    shape:
-    - null
-    - null
-  - dims:
-    - num_clusters
-    - num_samples
-    doc: Stdev of waveforms for each cluster, using the same indices as in mean
-    dtype: float32
-    name: waveform_sd
-    shape:
-    - null
-    - null
-  doc: The mean waveform shape, including standard deviation, of the different clusters.
-    Ideally, the waveform analysis should be performed on data that is only high-pass
-    filtered. This is a separate module because it is expected to require updating.
-    For example, IMEC probes may require different storage requirements to store/display
-    mean waveforms, requiring a new interface or an extension of this one.
-  links:
-  - doc: HDF5 link to Clustering interface that was the source of the clustered data
-    name: clustering_interface
-    target_type: Clustering
-  default_name: ClusterWaveforms
-  neurodata_type_def: ClusterWaveforms
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Clustered spike data, whether from automatic clustering tools (eg,
-      klustakwik) or as a result of manual sorting'
-    dtype: text
-    name: help
-    value: Clustered spike data, whether from automatic clustering tools (eg, klustakwik)
-      or as a result of manual sorting
-  datasets:
-  - doc: Description of clusters or clustering, (e.g. cluster 0 is noise, clusters
-      curated using Klusters, etc)
-    dtype: text
-    name: description
-  - dims:
-    - num_events
-    doc: Cluster number of each event
-    dtype: int32
-    name: num
-    shape:
-    - null
-  - dims:
-    - num_clusters
-    doc: Maximum ratio of waveform peak to RMS on any channel in the cluster (provides
-      a basic clustering metric).
-    dtype: float32
-    name: peak_over_rms
-    shape:
-    - null
-  - dims:
-    - num_events
-    doc: Times of clustered events, in seconds. This may be a link to times field
-      in associated FeatureExtraction module.
-    dtype: float64
-    name: times
-    shape:
-    - null
-  doc: Clustered spike data, whether from automatic clustering tools (e.g., klustakwik)
-    or as a result of manual sorting.
-  default_name: Clustering
-  neurodata_type_def: Clustering
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Container for salient features of detected events'
-    dtype: text
-    name: help
-    value: Container for salient features of detected events
-  datasets:
-  - dims:
-    - num_features
-    doc: Description of features (eg, "PC1") for each of the extracted features.
-    dtype: text
-    name: description
-    shape:
-    - null
-  - dims:
-    - num_events
-    - num_channels
-    - num_features
-    doc: Multi-dimensional array of features extracted from each event.
-    dtype: float32
-    name: features
-    shape:
-    - null
-    - null
-    - null
-  - dims:
-    - num_events
-    doc: Times of events that features correspond to (can be a link).
-    dtype: float64
-    name: times
-    shape:
-    - null
-  - name: electrodes
-    doc: 'the electrodes that this series was generated from'
-    neurodata_type_inc: ElectrodeTableRegion
-  doc: Features, such as PC1 and PC2, that are extracted from signals stored in a
-    SpikeEvent TimeSeries or other source.
-  default_name: FeatureExtraction
-  neurodata_type_def: FeatureExtraction
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Detected spike events from voltage trace(s)'
-    dtype: text
-    name: help
-    value: Detected spike events from voltage trace(s)
-  datasets:
-  - doc: Description of how events were detected, such as voltage threshold, or dV/dT
-      threshold, as well as relevant values.
-    dtype: text
-    name: detection_method
-  - dims:
-    - num_events
-    doc: Indices (zero-based) into source ElectricalSeries::data array corresponding
-      to time of event. Module description should define what is meant by time of
-      event (e.g., .25msec before action potential peak, zero-crossing time, etc).
-      The index points to each event from the raw data
-    dtype: int32
-    name: source_idx
-    shape:
-    - null
-  - attributes:
-    - default_value: Seconds
-      doc: The string "Seconds"
-      dtype: text
-      name: unit
-      required: false
-    dims:
-    - num_events
-    doc: Timestamps of events, in Seconds
-    dtype: float64
-    name: times
-    shape:
-    - null
-  doc: Detected spike events from voltage trace(s).
-  links:
-  - doc: HDF5 link to ElectricalSeries that this data was calculated from. Metadata
-      about electrodes and their position can be read from that ElectricalSeries so
-      it's not necessary to mandate that information be stored here
-    name: source_electricalseries
-    target_type: ElectricalSeries
-  default_name: EventDetection
-  neurodata_type_def: EventDetection
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Waveform of detected extracellularly recorded spike events'
-    dtype: text
-    name: help
-    value: Waveform of detected extracellularly recorded spike events
-  doc: Represents either the waveforms of detected events, as extracted from a raw
-    data trace in /acquisition, or the event waveforms that were stored during experiment
-    acquisition.
-  groups:
-  - doc: SpikeEventSeries object containing detected spike event waveforms
-    neurodata_type_inc: SpikeEventSeries
-    quantity: '*'
-  default_name: EventWaveform
-  neurodata_type_def: EventWaveform
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Ephys data from one or more channels that is subjected to filtering,
-      such as for gamma or theta oscillations (LFP has its own interface). Filter
-      properties should be noted in the ElectricalSeries'
-    dtype: text
-    name: help
-    value: Ephys data from one or more channels that is subjected to filtering, such
-      as for gamma or theta oscillations (LFP has its own interface). Filter properties
-      should be noted in the ElectricalSeries
-  doc: "Ephys data from one or more channels that has been subjected to filtering.
-    Examples of filtered data include Theta and Gamma (LFP has its own interface).
-    FilteredEphys modules publish an ElectricalSeries for each filtered channel or
-    set of channels. The name of each ElectricalSeries is arbitrary but should be
-    informative. The source of the filtered data, whether this is from analysis of
-    another time series or as acquired by hardware, should be noted in each's TimeSeries::description
-    field. There is no assumed 1::1 correspondence between filtered ephys signals
-    and electrodes, as a single signal can apply to many nearby electrodes, and one
-    electrode may have different filtered (e.g., theta and/or gamma) signals represented."
-  groups:
-  - doc: ElectricalSeries object containing filtered electrophysiology data
-    neurodata_type_inc: ElectricalSeries
-    quantity: '+'
-  default_name: FilteredEphys
-  neurodata_type_def: FilteredEphys
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'LFP data from one or more channels. Filter properties should be
-      noted in the ElectricalSeries'
-    dtype: text
-    name: help
-    value: LFP data from one or more channels. Filter properties should be noted in
-      the ElectricalSeries
-  doc: LFP data from one or more channels. The electrode map in each published ElectricalSeries
-    will identify which channels are providing LFP data. Filter properties should
-    be noted in the ElectricalSeries description or comments field.
-  groups:
-  - doc: ElectricalSeries object containing LFP data for one or more channels
-    neurodata_type_inc: ElectricalSeries
-    quantity: '+'
-  default_name: LFP
-  neurodata_type_def: LFP
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Metadata about a physical grouping of channels'
-    dtype: text
-    name: help
-    value: A physical grouping of channels
-  - doc: description of this electrode group
-    dtype: text
-    name: description
-  - doc: description of location of this electrode group
-    dtype: text
-    name: location
-  doc: One of possibly many groups, one for each electrode group.
-  links:
-  - doc: the device that was used to record from this electrode group
-    name: device
-    quantity: '?'
-    target_type: Device
-  neurodata_type_def: ElectrodeGroup
-  neurodata_type_inc: NWBContainer
 datasets:
-- doc: 'a table for storing queryable information about electrodes in a single table'
+- neurodata_type_def: ElectrodeTable
+  neurodata_type_inc: NWBData
   dtype:
   - name: id
     dtype: int
@@ -344,30 +28,346 @@ datasets:
     doc: a brief description of what this electrode is
   - name: group
     dtype:
-        target_type: ElectrodeGroup
-        reftype: object
+      target_type: ElectrodeGroup
+      reftype: object
     doc: a reference to the ElectrodeGroup this electrode is a part of
   - name: group_name
     dtype: ascii
     doc: the name of the ElectrodeGroup this electrode is a part of
+  doc: a table for storing queryable information about electrodes in a single table
   attributes:
-    - doc: Value is 'a table for storing data about extracellular electrodes'
-      dtype: text
-      name: help
-      value: a table for storing data about extracellular electrodes
-  neurodata_type_inc: NWBData
-  neurodata_type_def: ElectrodeTable
-- doc: 'a dataset for subsetting ElectrodeTables'
-  neurodata_type_def: ElectrodeTableRegion
+  - name: help
+    dtype: text
+    doc: Value is 'a table for storing data about extracellular electrodes'
+    value: a table for storing data about extracellular electrodes
+- neurodata_type_def: ElectrodeTableRegion
   neurodata_type_inc: NWBData
   dtype:
     target_type: ElectrodeTable
     reftype: region
+  doc: a dataset for subsetting ElectrodeTables
   attributes:
-    - name: description
-      doc: 'a description of this subset of electrodes'
-      dtype: utf8
-    - doc: Value is 'a subset (i.e. slice or region) of an ElectrodeTable'
+  - name: description
+    dtype: utf8
+    doc: a description of this subset of electrodes
+  - name: help
+    dtype: text
+    doc: Value is 'a subset (i.e. slice or region) of an ElectrodeTable'
+    value: a subset (i.e. slice or region) of an ElectrodeTable
+groups:
+- neurodata_type_def: ElectricalSeries
+  neurodata_type_inc: TimeSeries
+  doc: 'Stores acquired voltage data from extracellular recordings. The data field
+    of an ElectricalSeries is an int or float array storing data in Volts. TimeSeries::data
+    array structure: :blue:`[num times] [num channels] (or [num_times] for single
+    electrode).`'
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Stores acquired voltage data from extracellular recordings'
+    value: Stores acquired voltage data from extracellular recordings
+  datasets:
+  - name: data
+    dtype: float
+    doc: Recorded voltage data.
+    attributes:
+    - name: unit
       dtype: text
-      name: help
-      value: a subset (i.e. slice or region) of an ElectrodeTable
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: volt
+      required: false
+    dims:
+    - - num_times
+    - - num_times
+      - num_channels
+    shape:
+    - - 
+    - - 
+      - 
+  - neurodata_type_inc: ElectrodeTableRegion
+    name: electrodes
+    doc: the electrodes that this series was generated from
+- neurodata_type_def: SpikeEventSeries
+  neurodata_type_inc: ElectricalSeries
+  doc: 'Stores "snapshots" of spike events (i.e., threshold crossings) in data. This
+    may also be raw data, as reported by ephys hardware. If so, the TimeSeries::description
+    field should describing how events were detected. All SpikeEventSeries should
+    reside in a module (under EventWaveform interface) even if the spikes were reported
+    and stored by hardware. All events span the same recording channels and store
+    snapshots of equal duration. TimeSeries::data array structure: :blue:`[num events]
+    [num channels] [num samples] (or [num events] [num samples] for single electrode)`.'
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Snapshots of spike events from data.'
+    value: Snapshots of spike events from data.
+  datasets:
+  - name: data
+    dtype: float32
+    doc: Spike waveforms.
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: volt
+      required: false
+    dims:
+    - - num_events
+      - num_samples
+    - - num_events
+      - num_channels
+      - num_samples
+    shape:
+    - - 
+      - 
+    - - 
+      - 
+      - 
+- neurodata_type_def: ClusterWaveforms
+  neurodata_type_inc: NWBDataInterface
+  doc: The mean waveform shape, including standard deviation, of the different clusters.
+    Ideally, the waveform analysis should be performed on data that is only high-pass
+    filtered. This is a separate module because it is expected to require updating.
+    For example, IMEC probes may require different storage requirements to store/display
+    mean waveforms, requiring a new interface or an extension of this one.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Mean waveform shape of clusters. Waveforms should be high-pass
+      filtered (ie, not the same bandpass filter used waveform analysis and clustering)'
+    value: Mean waveform shape of clusters. Waveforms should be high-pass filtered
+      (ie, not the same bandpass filter used waveform analysis and clustering)
+  datasets:
+  - name: waveform_filtering
+    dtype: text
+    doc: Filtering applied to data before generating mean/sd
+  - name: waveform_mean
+    dtype: float32
+    doc: The mean waveform for each cluster, using the same indices for each wave
+      as cluster numbers in the associated Clustering module (i.e, cluster 3 is in
+      array slot [3]). Waveforms corresponding to gaps in cluster sequence should
+      be empty (e.g., zero- filled)
+    dims:
+    - num_clusters
+    - num_samples
+    shape:
+    - 
+    - 
+  - name: waveform_sd
+    dtype: float32
+    doc: Stdev of waveforms for each cluster, using the same indices as in mean
+    dims:
+    - num_clusters
+    - num_samples
+    shape:
+    - 
+    - 
+  links:
+  - name: clustering_interface
+    doc: HDF5 link to Clustering interface that was the source of the clustered data
+    target_type: Clustering
+  default_name: ClusterWaveforms
+- neurodata_type_def: Clustering
+  neurodata_type_inc: NWBDataInterface
+  doc: Clustered spike data, whether from automatic clustering tools (e.g., klustakwik)
+    or as a result of manual sorting.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Clustered spike data, whether from automatic clustering tools (eg,
+      klustakwik) or as a result of manual sorting'
+    value: Clustered spike data, whether from automatic clustering tools (eg, klustakwik)
+      or as a result of manual sorting
+  datasets:
+  - name: description
+    dtype: text
+    doc: Description of clusters or clustering, (e.g. cluster 0 is noise, clusters
+      curated using Klusters, etc)
+  - name: num
+    dtype: int32
+    doc: Cluster number of each event
+    dims:
+    - num_events
+    shape:
+    - 
+  - name: peak_over_rms
+    dtype: float32
+    doc: Maximum ratio of waveform peak to RMS on any channel in the cluster (provides
+      a basic clustering metric).
+    dims:
+    - num_clusters
+    shape:
+    - 
+  - name: times
+    dtype: float64
+    doc: Times of clustered events, in seconds. This may be a link to times field
+      in associated FeatureExtraction module.
+    dims:
+    - num_events
+    shape:
+    - 
+  default_name: Clustering
+- neurodata_type_def: FeatureExtraction
+  neurodata_type_inc: NWBDataInterface
+  doc: Features, such as PC1 and PC2, that are extracted from signals stored in a
+    SpikeEvent TimeSeries or other source.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Container for salient features of detected events'
+    value: Container for salient features of detected events
+  datasets:
+  - name: description
+    dtype: text
+    doc: Description of features (eg, "PC1") for each of the extracted features.
+    dims:
+    - num_features
+    shape:
+    - 
+  - name: features
+    dtype: float32
+    doc: Multi-dimensional array of features extracted from each event.
+    dims:
+    - num_events
+    - num_channels
+    - num_features
+    shape:
+    - 
+    - 
+    - 
+  - name: times
+    dtype: float64
+    doc: Times of events that features correspond to (can be a link).
+    dims:
+    - num_events
+    shape:
+    - 
+  - neurodata_type_inc: ElectrodeTableRegion
+    name: electrodes
+    doc: the electrodes that this series was generated from
+  default_name: FeatureExtraction
+- neurodata_type_def: EventDetection
+  neurodata_type_inc: NWBDataInterface
+  doc: Detected spike events from voltage trace(s).
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Detected spike events from voltage trace(s)'
+    value: Detected spike events from voltage trace(s)
+  datasets:
+  - name: detection_method
+    dtype: text
+    doc: Description of how events were detected, such as voltage threshold, or dV/dT
+      threshold, as well as relevant values.
+  - name: source_idx
+    dtype: int32
+    doc: Indices (zero-based) into source ElectricalSeries::data array corresponding
+      to time of event. Module description should define what is meant by time of
+      event (e.g., .25msec before action potential peak, zero-crossing time, etc).
+      The index points to each event from the raw data
+    dims:
+    - num_events
+    shape:
+    - 
+  - name: times
+    dtype: float64
+    doc: Timestamps of events, in Seconds
+    attributes:
+    - name: unit
+      dtype: text
+      doc: The string "Seconds"
+      default_value: Seconds
+      required: false
+    dims:
+    - num_events
+    shape:
+    - 
+  links:
+  - name: source_electricalseries
+    doc: HDF5 link to ElectricalSeries that this data was calculated from. Metadata
+      about electrodes and their position can be read from that ElectricalSeries so
+      it's not necessary to mandate that information be stored here
+    target_type: ElectricalSeries
+  default_name: EventDetection
+- neurodata_type_def: EventWaveform
+  neurodata_type_inc: NWBDataInterface
+  doc: Represents either the waveforms of detected events, as extracted from a raw
+    data trace in /acquisition, or the event waveforms that were stored during experiment
+    acquisition.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Waveform of detected extracellularly recorded spike events'
+    value: Waveform of detected extracellularly recorded spike events
+  groups:
+  - neurodata_type_inc: SpikeEventSeries
+    doc: SpikeEventSeries object containing detected spike event waveforms
+    quantity: '*'
+  default_name: EventWaveform
+- neurodata_type_def: FilteredEphys
+  neurodata_type_inc: NWBDataInterface
+  doc: Ephys data from one or more channels that has been subjected to filtering.
+    Examples of filtered data include Theta and Gamma (LFP has its own interface).
+    FilteredEphys modules publish an ElectricalSeries for each filtered channel or
+    set of channels. The name of each ElectricalSeries is arbitrary but should be
+    informative. The source of the filtered data, whether this is from analysis of
+    another time series or as acquired by hardware, should be noted in each's TimeSeries::description
+    field. There is no assumed 1::1 correspondence between filtered ephys signals
+    and electrodes, as a single signal can apply to many nearby electrodes, and one
+    electrode may have different filtered (e.g., theta and/or gamma) signals represented.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Ephys data from one or more channels that is subjected to filtering,
+      such as for gamma or theta oscillations (LFP has its own interface). Filter
+      properties should be noted in the ElectricalSeries'
+    value: Ephys data from one or more channels that is subjected to filtering, such
+      as for gamma or theta oscillations (LFP has its own interface). Filter properties
+      should be noted in the ElectricalSeries
+  groups:
+  - neurodata_type_inc: ElectricalSeries
+    doc: ElectricalSeries object containing filtered electrophysiology data
+    quantity: +
+  default_name: FilteredEphys
+- neurodata_type_def: LFP
+  neurodata_type_inc: NWBDataInterface
+  doc: LFP data from one or more channels. The electrode map in each published ElectricalSeries
+    will identify which channels are providing LFP data. Filter properties should
+    be noted in the ElectricalSeries description or comments field.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'LFP data from one or more channels. Filter properties should be
+      noted in the ElectricalSeries'
+    value: LFP data from one or more channels. Filter properties should be noted in
+      the ElectricalSeries
+  groups:
+  - neurodata_type_inc: ElectricalSeries
+    doc: ElectricalSeries object containing LFP data for one or more channels
+    quantity: +
+  default_name: LFP
+- neurodata_type_def: ElectrodeGroup
+  neurodata_type_inc: NWBContainer
+  doc: One of possibly many groups, one for each electrode group.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Metadata about a physical grouping of channels'
+    value: A physical grouping of channels
+  - name: description
+    dtype: text
+    doc: description of this electrode group
+  - name: location
+    dtype: text
+    doc: description of location of this electrode group
+  links:
+  - name: device
+    doc: the device that was used to record from this electrode group
+    quantity: '?'
+    target_type: Device

--- a/src/pynwb/data/nwb.epoch.yaml
+++ b/src/pynwb/data/nwb.epoch.yaml
@@ -1,92 +1,93 @@
 datasets:
-- attributes:
-  - doc: Value is 'Data on how an epoch applies to a time series'
-    dtype: text
-    name: help
-    value: Data on how an epoch applies to a time series
-  doc: 'An index into a TimeSeries object'
+- neurodata_type_def: TimeSeriesIndex
+  neurodata_type_inc: NWBData
   dtype:
-  - doc: "Start index into the TimeSeries data[] field. COMMENT: This can be used\
-      \ to calculate location in TimeSeries timestamp[] field"
+  - name: idx_start
     dtype: int32
-    name: idx_start
-  - doc: Number of data samples available in this time series, during this epoch.
+    doc: 'Start index into the TimeSeries data[] field. COMMENT: This can be used
+      to calculate location in TimeSeries timestamp[] field'
+  - name: count
     dtype: int32
-    name: count
-  - doc: the TimeSeries that this index applies to
+    doc: Number of data samples available in this time series, during this epoch.
+  - name: timeseries
     dtype:
       target_type: TimeSeries
       reftype: object
-    name: timeseries
-  neurodata_type_def: TimeSeriesIndex
+    doc: the TimeSeries that this index applies to
+  doc: An index into a TimeSeries object
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Data on how an epoch applies to a time series'
+    value: Data on how an epoch applies to a time series
+- neurodata_type_def: EventTable
   neurodata_type_inc: NWBData
-- attributes:
-  - doc: Value is 'A table for storing start/stop times for events'
-    dtype: text
-    name: help
-    value: A table for storing epoch data
   dtype:
-  - doc: Start time of epoch, in seconds
+  - name: start_time
     dtype: float64
-    name: start_time
-  - doc: Stop time of epoch, in seconds
+    doc: Start time of epoch, in seconds
+  - name: stop_time
     dtype: float64
-    name: stop_time
-  - doc: 'User-defined tags that identify events. Tags are to help identify
-      or categorize events.'
+    doc: Stop time of epoch, in seconds
+  - name: tags
     dtype: text
-    name: tags
-  - doc: Stop time of epoch, in seconds
+    doc: User-defined tags that identify events. Tags are to help identify or categorize
+      events.
+  - name: timeseries
     dtype:
       target_type: TimeSeriesIndex
       reftype: region
-    name: timeseries
-  doc: 'One of possibly many different experimental epoch'
-  neurodata_type_def: EventTable
-  neurodata_type_inc: NWBData
-- attributes:
-  - doc: Value is 'A table for storing epoch data'
+    doc: Stop time of epoch, in seconds
+  doc: One of possibly many different experimental epoch
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'A table for storing start/stop times for events'
     value: A table for storing epoch data
-  dtype:
-  - doc: Description of this epoch.
-    dtype: text
-    name: description
-  doc: 'One of possibly many different experimental epoch'
-  neurodata_type_def: EpochTable
+- neurodata_type_def: EpochTable
   neurodata_type_inc: EventTable
-- doc: 'a dataset for subsetting EpochTables'
-  neurodata_type_def: EpochTableRegion
+  dtype:
+  - name: description
+    dtype: text
+    doc: Description of this epoch.
+  doc: One of possibly many different experimental epoch
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'A table for storing epoch data'
+    value: A table for storing epoch data
+- neurodata_type_def: EpochTableRegion
   neurodata_type_inc: NWBData
   dtype:
     target_type: EpochTable
     reftype: region
+  doc: a dataset for subsetting EpochTables
   attributes:
-    - name: description
-      doc: 'a description of this subset of epochs'
-      dtype: utf8
-    - doc: Value is 'a subset (i.e. slice or region) of an EpochTable'
-      dtype: text
-      name: help
-      value: a subset (i.e. slice or region) of an EpochTable
-groups:
-- attributes:
-  - doc: Value is 'A general epoch object'
+  - name: description
+    dtype: utf8
+    doc: a description of this subset of epochs
+  - name: help
     dtype: text
-    name: help
-    value: A general epoch object
-  groups:
-    - name: metadata
-      doc: a DynamicTable for storing metadata about epochs
-      neurodata_type_inc: DynamicTable
-  datasets:
-    - name: epochs
-      doc: the EpochTable holding information about each Epoch
-      neurodata_type_inc: EpochTable
-    - name: timeseries_index
-      doc: the TimeSeriesIndex table holding indices into each TimeSeries for each Epoch
-      neurodata_type_inc: TimeSeriesIndex
-  doc: 'A container for aggregating epoch data and the TimeSeries that each epoch applies to'
-  neurodata_type_def: Epochs
+    doc: Value is 'a subset (i.e. slice or region) of an EpochTable'
+    value: a subset (i.e. slice or region) of an EpochTable
+groups:
+- neurodata_type_def: Epochs
   neurodata_type_inc: NWBContainer
+  doc: A container for aggregating epoch data and the TimeSeries that each epoch applies
+    to
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'A general epoch object'
+    value: A general epoch object
+  datasets:
+  - neurodata_type_inc: EpochTable
+    name: epochs
+    doc: the EpochTable holding information about each Epoch
+  - neurodata_type_inc: TimeSeriesIndex
+    name: timeseries_index
+    doc: the TimeSeriesIndex table holding indices into each TimeSeries for each Epoch
+  groups:
+  - neurodata_type_inc: DynamicTable
+    name: metadata
+    doc: a DynamicTable for storing metadata about epochs

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -1,42 +1,46 @@
 groups:
-- attributes:
-  - doc: Value is 'an NWB:N file for storing cellular-based neurophysiology data'
+- neurodata_type_def: NWBFile
+  neurodata_type_inc: NWBContainer
+  name: root
+  doc: Top level of NWB file.
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'an NWB:N file for storing cellular-based neurophysiology data'
     value: an NWB:N file for storing cellular-based neurophysiology data
-  - doc: 'File version string. COMMENT: Eg, NWB-1.0.0. This will be the name of the
-      format with trailing major, minor and patch numbers.'
+  - name: nwb_version
     dtype: text
-    value: '2.0b'
-    name: nwb_version
+    doc: 'File version string. COMMENT: Eg, NWB-1.0.0. This will be the name of the
+      format with trailing major, minor and patch numbers.'
+    value: 2.0b
   datasets:
-  - dims:
-    - '*unlimited*'
+  - name: file_create_date
+    dtype: text
     doc: 'Time file was created, UTC, and subsequent modifications to file. COMMENT:
       Date + time, Use ISO format (eg, ISO 8601) or a format that is easy to read
       and unambiguous. File can be created after the experiment was run, so this may
       differ from experiment start time. Each modifictation to file adds new entry
       to array. '
-    dtype: text
-    name: file_create_date
+    dims:
+    - '*unlimited*'
     shape:
-    - null
-  - doc: 'A unique text identifier for the file. COMMENT: Eg, concatenated lab name,
+    - 
+  - name: identifier
+    dtype: text
+    doc: 'A unique text identifier for the file. COMMENT: Eg, concatenated lab name,
       file creation date/time and experimentalist, or a hash of these and/or other
       values. The goal is that the string should be unique to all other files.'
+  - name: session_description
     dtype: text
-    name: identifier
-  - doc: One or two sentences describing the experiment and data in the file.
+    doc: One or two sentences describing the experiment and data in the file.
+  - name: session_start_time
     dtype: text
-    name: session_description
-  - doc: 'Time of experiment/session start, UTC.  COMMENT: Date + time, Use ISO format
+    doc: 'Time of experiment/session start, UTC.  COMMENT: Date + time, Use ISO format
       (eg, ISO 8601) or an easy-to-read and unambiguous format. All times stored in
       the file use this time as reference (ie, time zero)'
-    dtype: text
-    name: session_start_time
-  doc: Top level of NWB file.
   groups:
-  - doc: 'Data streams recorded from the system, including ephys, ophys, tracking,
+  - name: acquisition
+    doc: 'Data streams recorded from the system, including ephys, ophys, tracking,
       etc. COMMENT: This group is read-only after the experiment is completed and
       timestamps are corrected to a common timebase. The data stored here may be links
       to raw data stored in external HDF5 files. This will allow keeping bulky raw
@@ -46,11 +50,11 @@ groups:
       group, the data can exist in a separate HDF5 file that is linked to by the file
       being used for processing and analysis.'
     groups:
-    - doc: Any objects representing acquired data
-      neurodata_type_inc: NWBDataInterface
+    - neurodata_type_inc: NWBDataInterface
+      doc: Any objects representing acquired data
       quantity: '*'
-    name: acquisition
-  - doc: 'Lab-specific and custom scientific analysis of data. There is no defined
+  - name: analysis
+    doc: 'Lab-specific and custom scientific analysis of data. There is no defined
       format for the content of this group - the format is up to the individual user/lab.
       COMMENT: To facilitate sharing analysis data between labs, the contents here
       should be stored in standard types (eg, INCF types) and appropriately documented.
@@ -58,33 +62,33 @@ groups:
       restriction on its form or schema, reducing data formatting restrictions on
       end users. Such data should be placed in the analysis group. The analysis data
       should be documented so that it is sharable with other labs'
-    name: analysis
     groups:
-    - doc: Custom analysis results
-      neurodata_type_inc: NWBContainer
+    - neurodata_type_inc: NWBContainer
+      doc: Custom analysis results
       quantity: '*'
-  - doc: "Experimental intervals, whether that be logically distinct sub-experiments\
-    \ having a particular scientific goal, trials during an experiment, or epochs\
-    \ deriving from analysis of data.  COMMENT: Epochs provide pointers to time\
-    \ series that are relevant to the epoch, and windows into the data in those\
-    \ time series (i.e., the start and end indices of TimeSeries::data[] that overlap\
-    \ with the epoch). This allows easy access to a range of data in specific experimental\
-    \ intervals. MORE_INFO: An experiment can be separated into one or many logical\
-    \ intervals, with the order and duration of these intervals often definable\
-    \ before the experiment starts. In this document, and in the context of NWB,\
-    \ these intervals are called 'epochs'. Epochs have acquisition and stimulus\
-    \ data associated with them, and different epochs can overlap. Examples of epochs\
-    \ are the time when a rat runs around an enclosure or maze as well as intervening\
-    \ sleep sessions; the presentation of a set of visual stimuli to a mouse running\
-    \ on a wheel; or the uninterrupted presentation of current to a patch-clamped\
-    \ cell. Epochs can be limited to the interval of a particular stimulus, or they\
-    \ can span multiple stimuli. Different windows into the same time series can\
-    \ be achieved by including multiple instances of that time series, each with\
-    \ different start/stop times."
-    neurodata_type_inc: Epochs
+  - neurodata_type_inc: Epochs
     name: epochs
+    doc: "Experimental intervals, whether that be logically distinct sub-experiments\
+      \ having a particular scientific goal, trials during an experiment, or epochs\
+      \ deriving from analysis of data.  COMMENT: Epochs provide pointers to time\
+      \ series that are relevant to the epoch, and windows into the data in those\
+      \ time series (i.e., the start and end indices of TimeSeries::data[] that overlap\
+      \ with the epoch). This allows easy access to a range of data in specific experimental\
+      \ intervals. MORE_INFO: An experiment can be separated into one or many logical\
+      \ intervals, with the order and duration of these intervals often definable\
+      \ before the experiment starts. In this document, and in the context of NWB,\
+      \ these intervals are called 'epochs'. Epochs have acquisition and stimulus\
+      \ data associated with them, and different epochs can overlap. Examples of epochs\
+      \ are the time when a rat runs around an enclosure or maze as well as intervening\
+      \ sleep sessions; the presentation of a set of visual stimuli to a mouse running\
+      \ on a wheel; or the uninterrupted presentation of current to a patch-clamped\
+      \ cell. Epochs can be limited to the interval of a particular stimulus, or they\
+      \ can span multiple stimuli. Different windows into the same time series can\
+      \ be achieved by including multiple instances of that time series, each with\
+      \ different start/stop times."
     quantity: '?'
-  - doc: "The home for processing Modules. These modules perform intermediate analysis\
+  - name: processing
+    doc: "The home for processing Modules. These modules perform intermediate analysis\
       \ of data that is necessary to perform before scientific analysis. Examples\
       \ include spike clustering, extracting position from tracking data, stitching\
       \ together image slices. COMMENT: Modules are defined below. They can be large\
@@ -96,11 +100,11 @@ groups:
       \ it more amenable to scientific analysis. These are performed using Modules,\
       \ as defined above. All modules reside in the processing group."
     groups:
-    - doc: Intermediate analysis of acquired data
-      neurodata_type_inc: ProcessingModule
+    - neurodata_type_inc: ProcessingModule
+      doc: Intermediate analysis of acquired data
       quantity: '*'
-    name: processing
-  - doc: 'Data pushed into the system (eg, video stimulus, sound, voltage, etc) and
+  - name: stimulus
+    doc: 'Data pushed into the system (eg, video stimulus, sound, voltage, etc) and
       secondary representations of that data (eg, measurements of something used as
       a stimulus) COMMENT: This group is read-only after experiment complete and timestamps
       are corrected to common timebase. Stores both presented stimuli and stimulus
@@ -113,95 +117,22 @@ groups:
       times. These templates can exist in the present file or can be HDF5-linked to
       a remote library file.'
     groups:
-    - doc: Stimuli presented during the experiment.
+    - name: presentation
+      doc: Stimuli presented during the experiment.
       groups:
-      - doc: TimeSeries objects containing data of presented stimuli
-        neurodata_type_inc: TimeSeries
+      - neurodata_type_inc: TimeSeries
+        doc: TimeSeries objects containing data of presented stimuli
         quantity: '*'
-      name: presentation
-    - doc: "Template stimuli. COMMENT: Time stamps in templates are based on stimulus\
+    - name: templates
+      doc: "Template stimuli. COMMENT: Time stamps in templates are based on stimulus\
         \ design and are relative to the beginning of the stimulus. When templates\
         \ are used, the stimulus instances must convert presentation times to the\
         \ experiment's time reference frame."
       groups:
-      - doc: TimeSeries objects containing template data of presented stimuli
-        neurodata_type_inc: TimeSeries
+      - neurodata_type_inc: TimeSeries
+        doc: TimeSeries objects containing template data of presented stimuli
         quantity: '*'
-      name: templates
-    name: stimulus
-  - datasets:
-    - doc: 'Notes about data collection and analysis.COMMENT: Can be from Methods'
-      dtype: text
-      name: data_collection
-      quantity: '?'
-    - doc: 'General description of the experiment.COMMENT: Can be from Methods'
-      dtype: text
-      name: experiment_description
-      quantity: '?'
-    - doc: 'Name of person who performed the experiment.COMMENT: More than one person
-        OK. Can specify roles of different people involved.'
-      dtype: text
-      name: experimenter
-      quantity: '?'
-    - doc: Institution(s) where experiment was performed
-      dtype: text
-      name: institution
-      quantity: '?'
-    - doc: Lab where experiment was performed
-      dtype: text
-      name: lab
-      quantity: '?'
-    - doc: 'Notes about the experiment.  COMMENT: Things particular to this experiment'
-      dtype: text
-      name: notes
-      quantity: '?'
-    - doc: 'Description of drugs used, including how and when they were administered.
-        COMMENT: Anesthesia(s), painkiller(s), etc., plus dosage, concentration, etc.'
-      dtype: text
-      name: pharmacology
-      quantity: '?'
-    - doc: 'Experimetnal protocol, if applicable.COMMENT: E.g., include IACUC protocol'
-      dtype: text
-      name: protocol
-      quantity: '?'
-    - doc: 'Publication information.COMMENT: PMID, DOI, URL, etc. If multiple, concatenate
-        together and describe which is which. such as PMID, DOI, URL, etc'
-      dtype: text
-      name: related_publications
-      quantity: '?'
-    - doc: 'Lab-specific ID for the session.COMMENT: Only 1 session_id per file, with
-        all time aligned to experiment start time.'
-      dtype: text
-      name: session_id
-      quantity: '?'
-    - doc: Description of slices, including information about preparation thickness,
-        orientation, temperature and bath solution
-      dtype: text
-      name: slices
-      quantity: '?'
-    - attributes:
-      - doc: Name of script file
-        dtype: text
-        name: file_name
-      doc: Script file used to create this NWB file.
-      dtype: text
-      name: source_script
-      quantity: '?'
-    - doc: 'Notes about stimuli, such as how and where presented.COMMENT: Can be from
-        Methods'
-      dtype: text
-      name: stimulus
-      quantity: '?'
-    - doc: 'Narrative description about surgery/surgeries, including date(s) and who
-        performed surgery. COMMENT: Much can be copied from Methods'
-      dtype: text
-      name: surgery
-      quantity: '?'
-    - doc: Information about virus(es) used in experiments, including virus ID, source,
-        date made, injection location, volume, etc
-      dtype: text
-      name: virus
-      quantity: '?'
+  - name: general
     doc: "Experimental metadata, including protocol, notes and description of hardware\
       \ device(s).  COMMENT: The metadata stored in this section should be used to\
       \ describe the experiment. Metadata necessary for interpreting the data is stored\
@@ -217,166 +148,235 @@ groups:
       \ entries in the below table are to be included when data is present. Unused\
       \ groups (e.g., intracellular_ephys in an optophysiology experiment) should\
       \ not be created unless there is data to store within them."
+    datasets:
+    - name: data_collection
+      dtype: text
+      doc: 'Notes about data collection and analysis.COMMENT: Can be from Methods'
+      quantity: '?'
+    - name: experiment_description
+      dtype: text
+      doc: 'General description of the experiment.COMMENT: Can be from Methods'
+      quantity: '?'
+    - name: experimenter
+      dtype: text
+      doc: 'Name of person who performed the experiment.COMMENT: More than one person
+        OK. Can specify roles of different people involved.'
+      quantity: '?'
+    - name: institution
+      dtype: text
+      doc: Institution(s) where experiment was performed
+      quantity: '?'
+    - name: lab
+      dtype: text
+      doc: Lab where experiment was performed
+      quantity: '?'
+    - name: notes
+      dtype: text
+      doc: 'Notes about the experiment.  COMMENT: Things particular to this experiment'
+      quantity: '?'
+    - name: pharmacology
+      dtype: text
+      doc: 'Description of drugs used, including how and when they were administered.
+        COMMENT: Anesthesia(s), painkiller(s), etc., plus dosage, concentration, etc.'
+      quantity: '?'
+    - name: protocol
+      dtype: text
+      doc: 'Experimetnal protocol, if applicable.COMMENT: E.g., include IACUC protocol'
+      quantity: '?'
+    - name: related_publications
+      dtype: text
+      doc: 'Publication information.COMMENT: PMID, DOI, URL, etc. If multiple, concatenate
+        together and describe which is which. such as PMID, DOI, URL, etc'
+      quantity: '?'
+    - name: session_id
+      dtype: text
+      doc: 'Lab-specific ID for the session.COMMENT: Only 1 session_id per file, with
+        all time aligned to experiment start time.'
+      quantity: '?'
+    - name: slices
+      dtype: text
+      doc: Description of slices, including information about preparation thickness,
+        orientation, temperature and bath solution
+      quantity: '?'
+    - name: source_script
+      dtype: text
+      doc: Script file used to create this NWB file.
+      attributes:
+      - name: file_name
+        dtype: text
+        doc: Name of script file
+      quantity: '?'
+    - name: stimulus
+      dtype: text
+      doc: 'Notes about stimuli, such as how and where presented.COMMENT: Can be from
+        Methods'
+      quantity: '?'
+    - name: surgery
+      dtype: text
+      doc: 'Narrative description about surgery/surgeries, including date(s) and who
+        performed surgery. COMMENT: Much can be copied from Methods'
+      quantity: '?'
+    - name: virus
+      dtype: text
+      doc: Information about virus(es) used in experiments, including virus ID, source,
+        date made, injection location, volume, etc
+      quantity: '?'
     groups:
-    - doc: 'Description of hardware devices used during experiment. COMMENT: Eg, monitors,
+    - name: devices
+      doc: 'Description of hardware devices used during experiment. COMMENT: Eg, monitors,
         ADC boards, microscopes, etc'
       groups:
-      - attributes:
-        - doc: Value is 'A recording device e.g. amplifier'
-          dtype: text
-          name: help
-          value: A recording device e.g. amplifier
-        doc: One of possibly many. Information about device and device description.
-        neurodata_type_def: Device
+      - neurodata_type_def: Device
         neurodata_type_inc: NWBContainer
-        quantity: '+'
-      name: devices
+        doc: One of possibly many. Information about device and device description.
+        attributes:
+        - name: help
+          dtype: text
+          doc: Value is 'A recording device e.g. amplifier'
+          value: A recording device e.g. amplifier
+        quantity: +
       quantity: '?'
-    - datasets:
-      - attributes:
-        - default_value: Contents of format specification file.
-          doc: A help statement
-          dtype: text
-          name: help
-          required: false
-        - dims:
-          - num_namespaces
-          doc: Namespaces defined in the file
-          dtype: text
-          name: namespaces
-          shape:
-          - null
+    - name: specifications
+      doc: Group for storing format specification files.
+      datasets:
+      - neurodata_type_def: SpecFile
+        dtype: text
         doc: Dataset for storing contents of a specification file for either the core
           format or an extension.  Name should match name of file.`
-        dtype: text
-        neurodata_type_def: SpecFile
+        attributes:
+        - name: help
+          dtype: text
+          doc: A help statement
+          default_value: Contents of format specification file.
+          required: false
+        - name: namespaces
+          dtype: text
+          doc: Namespaces defined in the file
+          dims:
+          - num_namespaces
+          shape:
+          - 
         quantity: '*'
-      doc: Group for storing format specification files.
-      name: specifications
       quantity: '?'
-    - attributes:
-      - doc: Value is 'Information about the subject'
+    - neurodata_type_def: Subject
+      neurodata_type_inc: NWBContainer
+      name: subject
+      doc: Information about the animal or person from which the data was measured.
+      attributes:
+      - name: help
         dtype: text
-        name: help
+        doc: Value is 'Information about the subject'
         value: Information about the subject
       datasets:
-      - doc: Age of subject
+      - name: age
         dtype: text
-        name: age
+        doc: Age of subject
         quantity: '?'
-      - doc: Description of subject and where subject came from (e.g., breeder, if
+      - name: description
+        dtype: text
+        doc: Description of subject and where subject came from (e.g., breeder, if
           animal)
-        dtype: text
-        name: description
         quantity: '?'
-      - doc: 'Genetic strain COMMENT: If absent, assume Wild Type (WT)'
+      - name: genotype
         dtype: text
-        name: genotype
+        doc: 'Genetic strain COMMENT: If absent, assume Wild Type (WT)'
         quantity: '?'
-      - doc: Gender of subject
+      - name: sex
         dtype: text
-        name: sex
+        doc: Gender of subject
         quantity: '?'
-      - doc: Species of subject
+      - name: species
         dtype: text
-        name: species
+        doc: Species of subject
         quantity: '?'
-      - doc: ID of animal/person used/participating in experiment (lab convention)
+      - name: subject_id
         dtype: text
-        name: subject_id
+        doc: ID of animal/person used/participating in experiment (lab convention)
         quantity: '?'
-      - doc: Weight at time of experiment, at time of surgery and at other important
+      - name: weight
+        dtype: text
+        doc: Weight at time of experiment, at time of surgery and at other important
           times
-        dtype: text
-        name: weight
         quantity: '?'
-      doc: Information about the animal or person from which the data was measured.
-      name: subject
-      neurodata_type_def: Subject
-      neurodata_type_inc: NWBContainer
       quantity: '?'
-    - doc: Metadata related to extracellular electrophysiology.
-      groups:
-      - doc: One of possibly many groups, one for each electrode group.
-        neurodata_type_inc: ElectrodeGroup
-        quantity: '*'
+    - name: extracellular_ephys
+      doc: Metadata related to extracellular electrophysiology.
       datasets:
-      - doc: 'A table of all electrodes (i.e. channels) used for recording'
+      - neurodata_type_inc: ElectrodeTable
         name: electrodes
-        neurodata_type_inc: ElectrodeTable
+        doc: A table of all electrodes (i.e. channels) used for recording
         quantity: '?'
-      name: extracellular_ephys
+      groups:
+      - neurodata_type_inc: ElectrodeGroup
+        doc: One of possibly many groups, one for each electrode group.
+        quantity: '*'
       quantity: '?'
-    - datasets:
-      - doc: 'Description of filtering used. COMMENT: Includes filtering type and
+    - name: intracellular_ephys
+      doc: Metadata related to intracellular electrophysiology
+      datasets:
+      - name: filtering
+        dtype: text
+        doc: 'Description of filtering used. COMMENT: Includes filtering type and
           parameters, frequency fall- off, etc. If this changes between TimeSeries,
           filter description should be stored as a text attribute for each TimeSeries.'
-        dtype: text
-        name: filtering
         quantity: '?'
-      doc: Metadata related to intracellular electrophysiology
       groups:
-      - doc: 'One of possibly many. COMMENT: Name should be informative.'
-        neurodata_type_inc: IntracellularElectrode
+      - neurodata_type_inc: IntracellularElectrode
+        doc: 'One of possibly many. COMMENT: Name should be informative.'
         quantity: '*'
-      name: intracellular_ephys
       quantity: '?'
-    - doc: Metadata describing optogenetic stimuluation
+    - name: optogenetics
+      doc: Metadata describing optogenetic stimuluation
       groups:
-      - doc: 'One of possibly many groups describing an optogenetic stimuluation site.
+      - neurodata_type_inc: OptogeneticStimulusSite
+        doc: 'One of possibly many groups describing an optogenetic stimuluation site.
           COMMENT: Name is arbitrary but should be meaningful. Name is referenced
           by OptogeneticSeries'
-        neurodata_type_inc: OptogeneticStimulusSite
         quantity: '*'
-      name: optogenetics
       quantity: '?'
-    - doc: Metadata related to optophysiology.
+    - name: optophysiology
+      doc: Metadata related to optophysiology.
       groups:
-      - doc: 'One of possibly many groups describing an imaging plane. COMMENT: Name
+      - neurodata_type_inc: ImagingPlane
+        doc: 'One of possibly many groups describing an imaging plane. COMMENT: Name
           is arbitrary but should be meaningful. It is referenced by TwoPhotonSeries
           and also ImageSegmentation and DfOverF interfaces'
-        neurodata_type_inc: ImagingPlane
         quantity: '*'
-      name: optophysiology
       quantity: '?'
-    name: general
-  - doc: 'Data about experimental trials'
+  - neurodata_type_inc: DynamicTable
     name: trials
-    neurodata_type_inc: DynamicTable
-    quantity: '?'
+    doc: Data about experimental trials
     datasets:
-    - doc: The start time of each trial
-      attributes:
-        - name: description
-          value: the start time of each trial
-          dtype: text
-          doc: Value is 'the start time of each trial'
+    - neurodata_type_inc: TableColumn
       name: start
-      neurodata_type_inc: TableColumn
       dtype: float
-    - doc: The end time of each trial
+      doc: The start time of each trial
       attributes:
-        - name: description
-          value: the end time of each trial
-          dtype: text
-          doc: Value is 'the end time of each trial'
+      - name: description
+        dtype: text
+        doc: Value is 'the start time of each trial'
+        value: the start time of each trial
+    - neurodata_type_inc: TableColumn
       name: end
-      neurodata_type_inc: TableColumn
       dtype: float
-  - doc: 'Data about units'
-    name: units
-    neurodata_type_inc: DynamicTable
-    quantity: '?'
-    datasets:
-    - doc: the unique identifier for each unit
+      doc: The end time of each trial
       attributes:
-        - name: description
-          value: the unique identifier for each unit
-          dtype: text
-          doc: Value is 'the unique identifier for each unit'
+      - name: description
+        dtype: text
+        doc: Value is 'the end time of each trial'
+        value: the end time of each trial
+    quantity: '?'
+  - neurodata_type_inc: DynamicTable
+    name: units
+    doc: Data about units
+    datasets:
+    - neurodata_type_inc: TableColumn
       name: id
-      neurodata_type_inc: TableColumn
       dtype: int
-  name: root
-  neurodata_type_def: NWBFile
-  neurodata_type_inc: NWBContainer
+      doc: the unique identifier for each unit
+      attributes:
+      - name: description
+        dtype: text
+        doc: Value is 'the unique identifier for each unit'
+        value: the unique identifier for each unit
+    quantity: '?'

--- a/src/pynwb/data/nwb.icephys.yaml
+++ b/src/pynwb/data/nwb.icephys.yaml
@@ -1,225 +1,225 @@
 groups:
-- attributes:
-  - doc: Value is 'Superclass definition for patch-clamp data'
-    dtype: text
-    name: help
-    value: Superclass definition for patch-clamp data
-  datasets:
-  - dims:
-    - num_times
-    doc: Recorded voltage or current.
-    dtype: float
-    name: data
-    shape:
-    - null
-  - doc: 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'
-    dtype: float
-    name: gain
-    quantity: '?'
+- neurodata_type_def: PatchClampSeries
+  neurodata_type_inc: TimeSeries
   doc: Stores stimulus or response current or voltage. Superclass definition for patch-clamp
     data (this class should not be instantiated directly).
-  links:
-  - doc: link to IntracellularElectrode group that describes th electrode that was
-      used to apply or record this data
-    name: electrode
-    target_type: IntracellularElectrode
-  neurodata_type_def: PatchClampSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Voltage recorded from cell during current-clamp recording'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Voltage recorded from cell during current-clamp recording
+    doc: Value is 'Superclass definition for patch-clamp data'
+    value: Superclass definition for patch-clamp data
   datasets:
-  - doc: 'Unit: Amp'
-    dtype: float32
-    name: bias_current
+  - name: data
+    dtype: float
+    doc: Recorded voltage or current.
+    dims:
+    - num_times
+    shape:
+    - 
+  - name: gain
+    dtype: float
+    doc: 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'
     quantity: '?'
-  - doc: 'Unit: Ohm'
-    dtype: float32
-    name: bridge_balance
-    quantity: '?'
-  - doc: 'Unit: Farad'
-    dtype: float32
-    name: capacitance_compensation
-    quantity: '?'
+  links:
+  - name: electrode
+    doc: link to IntracellularElectrode group that describes th electrode that was
+      used to apply or record this data
+    target_type: IntracellularElectrode
+- neurodata_type_def: CurrentClampSeries
+  neurodata_type_inc: PatchClampSeries
   doc: Stores voltage data recorded from intracellular current-clamp recordings. A
     corresponding CurrentClampStimulusSeries (stored separately as a stimulus) is
     used to store the current injected.
-  neurodata_type_def: CurrentClampSeries
-  neurodata_type_inc: PatchClampSeries
-- attributes:
-  - doc: Value is 'Voltage from intracellular recordings when all current and amplifier
-      settings are off'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Voltage from intracellular recordings when all current and amplifier settings
-      are off
+    doc: Value is 'Voltage recorded from cell during current-clamp recording'
+    value: Voltage recorded from cell during current-clamp recording
+  datasets:
+  - name: bias_current
+    dtype: float32
+    doc: 'Unit: Amp'
+    quantity: '?'
+  - name: bridge_balance
+    dtype: float32
+    doc: 'Unit: Ohm'
+    quantity: '?'
+  - name: capacitance_compensation
+    dtype: float32
+    doc: 'Unit: Farad'
+    quantity: '?'
+- neurodata_type_def: IZeroClampSeries
+  neurodata_type_inc: CurrentClampSeries
   doc: Stores recorded voltage data from intracellular recordings when all current
     and amplifier settings are off (i.e., CurrentClampSeries fields will be zero).
     There is no CurrentClampStimulusSeries associated with an IZero series because
     the amplifier is disconnected and no stimulus can reach the cell.
-  neurodata_type_def: IZeroClampSeries
-  neurodata_type_inc: CurrentClampSeries
-- attributes:
-  - doc: Value is 'Stimulus current applied during current clamp recording'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Stimulus current applied during current clamp recording
+    doc: Value is 'Voltage from intracellular recordings when all current and amplifier
+      settings are off'
+    value: Voltage from intracellular recordings when all current and amplifier settings
+      are off
+- neurodata_type_def: CurrentClampStimulusSeries
+  neurodata_type_inc: PatchClampSeries
   doc: Aliases to standard PatchClampSeries. Its functionality is to better tag PatchClampSeries
     for machine (and human) readability of the file.
-  neurodata_type_def: CurrentClampStimulusSeries
-  neurodata_type_inc: PatchClampSeries
-- attributes:
-  - doc: Value is 'Current recorded from cell during voltage-clamp recording'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Current recorded from cell during voltage-clamp recording
-  datasets:
-  - attributes:
-    - default_value: Farad
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    doc: 'Unit: Farad'
-    dtype: float32
-    name: capacitance_fast
-    quantity: '?'
-  - attributes:
-    - default_value: Farad
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    doc: 'Unit: Farad'
-    dtype: float32
-    name: capacitance_slow
-    quantity: '?'
-  - attributes:
-    - default_value: Hz
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    doc: 'Unit: Hz'
-    dtype: float32
-    name: resistance_comp_bandwidth
-    quantity: '?'
-  - attributes:
-    - default_value: pecent
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    doc: 'Unit: %'
-    dtype: float32
-    name: resistance_comp_correction
-    quantity: '?'
-  - attributes:
-    - default_value: pecent
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    doc: 'Unit: %'
-    dtype: float32
-    name: resistance_comp_prediction
-    quantity: '?'
-  - attributes:
-    - default_value: Farad
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    doc: 'Unit: Farad'
-    dtype: float32
-    name: whole_cell_capacitance_comp
-    quantity: '?'
-  - attributes:
-    - default_value: Ohm
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    doc: 'Unit: Ohm'
-    dtype: float32
-    name: whole_cell_series_resistance_comp
-    quantity: '?'
+    doc: Value is 'Stimulus current applied during current clamp recording'
+    value: Stimulus current applied during current clamp recording
+- neurodata_type_def: VoltageClampSeries
+  neurodata_type_inc: PatchClampSeries
   doc: Stores current data recorded from intracellular voltage-clamp recordings. A
     corresponding VoltageClampStimulusSeries (stored separately as a stimulus) is
     used to store the voltage injected.
-  neurodata_type_def: VoltageClampSeries
-  neurodata_type_inc: PatchClampSeries
-- attributes:
-  - doc: Value is 'Stimulus voltage applied during voltage clamp recording'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Stimulus voltage applied during voltage clamp recording
+    doc: Value is 'Current recorded from cell during voltage-clamp recording'
+    value: Current recorded from cell during voltage-clamp recording
+  datasets:
+  - name: capacitance_fast
+    dtype: float32
+    doc: 'Unit: Farad'
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: Farad
+      required: false
+    quantity: '?'
+  - name: capacitance_slow
+    dtype: float32
+    doc: 'Unit: Farad'
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: Farad
+      required: false
+    quantity: '?'
+  - name: resistance_comp_bandwidth
+    dtype: float32
+    doc: 'Unit: Hz'
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: Hz
+      required: false
+    quantity: '?'
+  - name: resistance_comp_correction
+    dtype: float32
+    doc: 'Unit: %'
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: pecent
+      required: false
+    quantity: '?'
+  - name: resistance_comp_prediction
+    dtype: float32
+    doc: 'Unit: %'
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: pecent
+      required: false
+    quantity: '?'
+  - name: whole_cell_capacitance_comp
+    dtype: float32
+    doc: 'Unit: Farad'
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: Farad
+      required: false
+    quantity: '?'
+  - name: whole_cell_series_resistance_comp
+    dtype: float32
+    doc: 'Unit: Ohm'
+    attributes:
+    - name: unit
+      dtype: text
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: Ohm
+      required: false
+    quantity: '?'
+- neurodata_type_def: VoltageClampStimulusSeries
+  neurodata_type_inc: PatchClampSeries
   doc: Aliases to standard PatchClampSeries. Its functionality is to better tag PatchClampSeries
     for machine (and human) readability of the file.
-  neurodata_type_def: VoltageClampStimulusSeries
-  neurodata_type_inc: PatchClampSeries
-- attributes:
-  - doc: Value is 'Metadata about an intracellular electrode'
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'Stimulus voltage applied during voltage clamp recording'
+    value: Stimulus voltage applied during voltage clamp recording
+- neurodata_type_def: IntracellularElectrode
+  neurodata_type_inc: NWBContainer
+  doc: 'One of possibly many. COMMENT: Name should be informative.'
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Metadata about an intracellular electrode'
     value: Metadata about an intracellular electrode
   datasets:
-  - doc: 'Recording description, description of electrode (e.g.,  whole-cell, sharp,
+  - name: description
+    dtype: text
+    doc: 'Recording description, description of electrode (e.g.,  whole-cell, sharp,
       etc)COMMENT: Free-form text (can be from Methods)'
+  - name: filtering
     dtype: text
-    name: description
-  - doc: Electrode specific filtering.
-    dtype: text
-    name: filtering
+    doc: Electrode specific filtering.
     quantity: '?'
-  - doc: Initial access resistance
+  - name: initial_access_resistance
     dtype: text
-    name: initial_access_resistance
+    doc: Initial access resistance
     quantity: '?'
-  - doc: Area, layer, comments on estimation, stereotaxis coordinates (if in vivo,
+  - name: location
+    dtype: text
+    doc: Area, layer, comments on estimation, stereotaxis coordinates (if in vivo,
       etc)
-    dtype: text
-    name: location
     quantity: '?'
-  - doc: 'Electrode resistance COMMENT: unit: Ohm'
+  - name: resistance
     dtype: text
-    name: resistance
+    doc: 'Electrode resistance COMMENT: unit: Ohm'
     quantity: '?'
-  - doc: Information about seal used for recording
+  - name: seal
     dtype: text
-    name: seal
+    doc: Information about seal used for recording
     quantity: '?'
-  - doc: Information about slice used for recording
+  - name: slice
     dtype: text
-    name: slice
+    doc: Information about slice used for recording
     quantity: '?'
   links:
-  - doc: the device that was used to record from this electrode
-    name: device
+  - name: device
+    doc: the device that was used to record from this electrode
     target_type: Device
-  doc: 'One of possibly many. COMMENT: Name should be informative.'
-  neurodata_type_def: IntracellularElectrode
-  neurodata_type_inc: NWBContainer

--- a/src/pynwb/data/nwb.image.yaml
+++ b/src/pynwb/data/nwb.image.yaml
@@ -1,15 +1,25 @@
 groups:
-- attributes:
-  - doc: Value is 'Storage object for time-series 2-D image data'
+- neurodata_type_def: ImageSeries
+  neurodata_type_inc: TimeSeries
+  doc: 'General image data that is common between acquisition and stimulus time series.
+    Sometimes the image data is stored in the HDF5 file in a raw format while other
+    times it will be stored as an external image file in the host file system. The
+    data field will either be binary data or empty. TimeSeries::data array structure:
+    [frame] [y][x] or [frame][z][y][x].'
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'Storage object for time-series 2-D image data'
     value: Storage object for time-series 2-D image data
   datasets:
-  - doc: Number of bit per image pixel.
+  - name: bits_per_pixel
     dtype: int32
-    name: bits_per_pixel
+    doc: Number of bit per image pixel.
     quantity: '?'
-  - dims:
+  - name: data
+    dtype: int8
+    doc: Either binary data containing image or empty.
+    dims:
     - - x
       - y
     - - frame
@@ -19,137 +29,127 @@ groups:
       - z
       - y
       - x
-    doc: Either binary data containing image or empty.
-    dtype: int8
-    name: data
     shape:
-    - - null
-      - null
-    - - null
-      - null
-      - null
-    - - null
-      - null
-      - null
-      - null
-  - dims:
-    - rank
-    doc: Number of pixels on x, y, (and z) axes.
+    - - 
+      - 
+    - - 
+      - 
+      - 
+    - - 
+      - 
+      - 
+      - 
+  - name: dimension
     dtype: int32
-    name: dimension
+    doc: Number of pixels on x, y, (and z) axes.
+    dims:
+    - rank
     quantity: '?'
     shape:
-    - null
-  - attributes:
-    - dims:
-      - num_files
-      doc: Each entry is the frame number (within the full ImageSeries) of the first
-        frame in the corresponding external_file entry. This serves as an index to
-        what frames each file contains, allowing random access.Zero-based indexing
-        is used.  (The first element will always be zero).
-      dtype: int
-      name: starting_frame
-      shape:
-      - null
-    dims:
-    - num_files
+    - 
+  - name: external_file
+    dtype: text
     doc: 'Path or URL to one or more external file(s). Field only present if format=external.
       NOTE: this is only relevant if the image is stored in the file system as one
       or more image file(s). This field should NOT be used if the image is stored
       in another HDF5 file and that file is HDF5 linked to this file.'
-    dtype: text
-    name: external_file
+    attributes:
+    - name: starting_frame
+      dtype: int
+      doc: Each entry is the frame number (within the full ImageSeries) of the first
+        frame in the corresponding external_file entry. This serves as an index to
+        what frames each file contains, allowing random access.Zero-based indexing
+        is used.  (The first element will always be zero).
+      dims:
+      - num_files
+      shape:
+      - 
+    dims:
+    - num_files
     quantity: '?'
     shape:
-    - null
-  - doc: Format of image. If this is 'external' then the field external_file contains
+    - 
+  - name: format
+    dtype: text
+    doc: Format of image. If this is 'external' then the field external_file contains
       the path or URL information to that file. For tiff, png, jpg, etc, the binary
       representation of the image is stored in data. If the format is raw then the
       fields bit_per_pixel and dimension are used. For raw images, only a single channel
       is stored (eg, red).
-    dtype: text
-    name: format
     quantity: '?'
-  doc: 'General image data that is common between acquisition and stimulus time series.
-    Sometimes the image data is stored in the HDF5 file in a raw format while other
-    times it will be stored as an external image file in the host file system. The
-    data field will either be binary data or empty. TimeSeries::data array structure:
-    [frame] [y][x] or [frame][z][y][x].'
-  neurodata_type_def: ImageSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'An alpha mask that is applied to a presented visual stimulus'
-    dtype: text
-    name: help
-    value: An alpha mask that is applied to a presented visual stimulus
+- neurodata_type_def: ImageMaskSeries
+  neurodata_type_inc: ImageSeries
   doc: An alpha mask that is applied to a presented visual stimulus. The data[] array
     contains an array of mask values that are applied to the displayed image. Mask
     values are stored as RGBA. Mask can vary with time. The timestamps array indicates
     the starting time of a mask, and that mask pattern continues until it's explicitly
     changed.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'An alpha mask that is applied to a presented visual stimulus'
+    value: An alpha mask that is applied to a presented visual stimulus
   links:
-  - doc: Link to ImageSeries that mask is applied to.
-    name: masked_imageseries
+  - name: masked_imageseries
+    doc: Link to ImageSeries that mask is applied to.
     target_type: ImageSeries
-  neurodata_type_def: ImageMaskSeries
+- neurodata_type_def: OpticalSeries
   neurodata_type_inc: ImageSeries
-- attributes:
-  - doc: Value is 'Time-series image stack for optical recording or stimulus'
-    dtype: text
-    name: help
-    value: Time-series image stack for optical recording or stimulus
-  datasets:
-  - doc: Distance from camera/monitor to target/eye.
-    dtype: float32
-    name: distance
-    quantity: '?'
-  - dims:
-    - - width|height
-      - width|height|depth
-    doc: Width, height and depto of image, or imaged area (meters).
-    dtype: float32
-    name: field_of_view
-    quantity: '?'
-    shape:
-    - 2
-  - doc: Description of image relative to some reference frame (e.g., which way is
-      up). Must also specify frame of reference.
-    dtype: text
-    name: orientation
-    quantity: '?'
   doc: Image data that is presented or recorded. A stimulus template movie will be
     stored only as an image. When the image is presented as stimulus, additional data
     is required, such as field of view (eg, how much of the visual field the image
     covers, or how what is the area of the target being imaged). If the OpticalSeries
     represents acquired imaging data, orientation is also important.
-  neurodata_type_def: OpticalSeries
-  neurodata_type_inc: ImageSeries
-- attributes:
-  - doc: Value is 'A sequence that is generated from an existing image stack. Frames
-      can be presented in an arbitrary order. The data[] field stores frame number
-      in reference stack'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: A sequence that is generated from an existing image stack. Frames can be
-      presented in an arbitrary order. The data[] field stores frame number in reference
-      stack
+    doc: Value is 'Time-series image stack for optical recording or stimulus'
+    value: Time-series image stack for optical recording or stimulus
   datasets:
-  - dims:
-    - num_times
-    doc: Index of the frame in the referenced ImageSeries.
-    dtype: int
-    name: data
+  - name: distance
+    dtype: float32
+    doc: Distance from camera/monitor to target/eye.
+    quantity: '?'
+  - name: field_of_view
+    dtype: float32
+    doc: Width, height and depto of image, or imaged area (meters).
+    dims:
+    - - width|height
+      - width|height|depth
+    quantity: '?'
     shape:
-    - null
+    - 2
+  - name: orientation
+    dtype: text
+    doc: Description of image relative to some reference frame (e.g., which way is
+      up). Must also specify frame of reference.
+    quantity: '?'
+- neurodata_type_def: IndexSeries
+  neurodata_type_inc: TimeSeries
   doc: Stores indices to image frames stored in an ImageSeries. The purpose of the
     ImageIndexSeries is to allow a static image stack to be stored somewhere, and
     the images in the stack to be referenced out-of-order. This can be for the display
     of individual images, or of movie segments (as a movie is simply a series of images).
     The data field stores the index of the frame in the referenced ImageSeries, and
     the timestamps array indicates when that image was displayed.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'A sequence that is generated from an existing image stack. Frames
+      can be presented in an arbitrary order. The data[] field stores frame number
+      in reference stack'
+    value: A sequence that is generated from an existing image stack. Frames can be
+      presented in an arbitrary order. The data[] field stores frame number in reference
+      stack
+  datasets:
+  - name: data
+    dtype: int
+    doc: Index of the frame in the referenced ImageSeries.
+    dims:
+    - num_times
+    shape:
+    - 
   links:
-  - doc: HDF5 link to TimeSeries containing images that are indexed.
-    name: indexed_timeseries
+  - name: indexed_timeseries
+    doc: HDF5 link to TimeSeries containing images that are indexed.
     target_type: ImageSeries
-  neurodata_type_def: IndexSeries
-  neurodata_type_inc: TimeSeries

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -1,45 +1,6 @@
 groups:
-- attributes:
-  - doc: Value is 'Features of an applied stimulus. This is useful when storing the
-      raw stimulus is impractical'
-    dtype: text
-    name: help
-    value: Features of an applied stimulus. This is useful when storing the raw stimulus
-      is impractical
-  datasets:
-  - attributes:
-    - default_value: see 'feature_units'
-      doc: "The base unit of measure used to store data. This should be in the SI\
-        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
-        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
-        \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
-      required: false
-    dims:
-    - num_times
-    - num_features
-    doc: Values of each feature at each time.
-    dtype: float32
-    name: data
-    shape:
-    - null
-    - null
-  - dims:
-    - num_features
-    doc: Units of each feature.
-    dtype: text
-    name: feature_units
-    quantity: '?'
-    shape:
-    - null
-  - dims:
-    - num_features
-    doc: Description of the features represented in TimeSeries::data.
-    dtype: text
-    name: features
-    shape:
-    - null
+- neurodata_type_def: AbstractFeatureSeries
+  neurodata_type_inc: TimeSeries
   doc: Abstract features, such as quantitative descriptions of sensory stimuli. The
     TimeSeries::data field is a 2D array, storing those features (e.g., for visual
     grating stimulus this might be orientation, spatial frequency and contrast). Null
@@ -48,66 +9,81 @@ groups:
     or through use of the TimeSeries::control fields. A set of features is considered
     to persist until the next set of features is defined. The final set of features
     stored should be the null set.
-  neurodata_type_def: AbstractFeatureSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Time-stamped annotations about an experiment'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Time-stamped annotations about an experiment
+    doc: Value is 'Features of an applied stimulus. This is useful when storing the
+      raw stimulus is impractical'
+    value: Features of an applied stimulus. This is useful when storing the raw stimulus
+      is impractical
   datasets:
-  - attributes:
-    - doc: Value is 'float('NaN')'
-      dtype: float
-      name: conversion
-      value: NaN
-    - doc: Value is 'float('NaN')'
-      dtype: float
-      name: resolution
-      value: NaN
-    - doc: Value is 'n/a'
+  - name: data
+    dtype: float32
+    doc: Values of each feature at each time.
+    attributes:
+    - name: unit
       dtype: text
-      name: unit
-      value: n/a
+      doc: "The base unit of measure used to store data. This should be in the SI\
+        \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
+        \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
+        \ below describes how to convert the data to the specified SI unit."
+      default_value: see 'feature_units'
+      required: false
     dims:
     - num_times
-    doc: Annotations made during an experiment.
-    dtype: text
-    name: data
+    - num_features
     shape:
-    - null
+    - 
+    - 
+  - name: feature_units
+    dtype: text
+    doc: Units of each feature.
+    dims:
+    - num_features
+    quantity: '?'
+    shape:
+    - 
+  - name: features
+    dtype: text
+    doc: Description of the features represented in TimeSeries::data.
+    dims:
+    - num_features
+    shape:
+    - 
+- neurodata_type_def: AnnotationSeries
+  neurodata_type_inc: TimeSeries
   doc: Stores, eg, user annotations made during an experiment. The TimeSeries::data[]
     field stores a text array, and timestamps are stored for each annotation (ie,
     interval=1). This is largely an alias to a standard TimeSeries storing a text
     array but that is identifiable as storing annotations in a machine-readable way.
-  neurodata_type_def: AnnotationSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Stores the start and stop times for events'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Stores the start and stop times for events
+    doc: Value is 'Time-stamped annotations about an experiment'
+    value: Time-stamped annotations about an experiment
   datasets:
-  - attributes:
-    - doc: Value is 'float('NaN')'
+  - name: data
+    dtype: text
+    doc: Annotations made during an experiment.
+    attributes:
+    - name: conversion
       dtype: float
-      name: conversion
+      doc: Value is 'float('NaN')'
       value: NaN
-    - doc: Value is 'float('NaN')'
+    - name: resolution
       dtype: float
-      name: resolution
+      doc: Value is 'float('NaN')'
       value: NaN
-    - doc: Value is 'n/a'
+    - name: unit
       dtype: text
-      name: unit
+      doc: Value is 'n/a'
       value: n/a
     dims:
     - num_times
-    doc: '>0 if interval started, <0 if interval ended.'
-    dtype: int8
-    name: data
     shape:
-    - null
+    - 
+- neurodata_type_def: IntervalSeries
+  neurodata_type_inc: TimeSeries
   doc: Stores intervals of data. The timestamps field stores the beginning and end
     of intervals. The data field stores whether the interval just started (>0 value)
     or ended (<0 value). Different interval types can be represented in the same series
@@ -115,27 +91,51 @@ groups:
     C, etc). The field data stores an 8-bit integer. This is largely an alias of a
     standard TimeSeries but that is identifiable as representing time intervals in
     a machine-readable way.
-  neurodata_type_def: IntervalSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Estimated spike times from a single unit'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Estimated spike times from a single unit
+    doc: Value is 'Stores the start and stop times for events'
+    value: Stores the start and stop times for events
   datasets:
-  - name: unit_ids
-    doc: a unique identifier for each element
-    neurodata_type_inc: ElementIdentifiers
-  - name: spike_times_index
-    doc: the index into the spike times dataset
-    neurodata_type_inc: VectorIndex
-  - name: spike_times
-    doc: the index into the vector data
-    neurodata_type_inc: VectorData
+  - name: data
+    dtype: int8
+    doc: '>0 if interval started, <0 if interval ended.'
+    attributes:
+    - name: conversion
+      dtype: float
+      doc: Value is 'float('NaN')'
+      value: NaN
+    - name: resolution
+      dtype: float
+      doc: Value is 'float('NaN')'
+      value: NaN
+    - name: unit
+      dtype: text
+      doc: Value is 'n/a'
+      value: n/a
+    dims:
+    - num_times
+    shape:
+    - 
+- neurodata_type_def: UnitTimes
+  neurodata_type_inc: NWBDataInterface
   doc: Event times of observed units (e.g. cell, synapse, etc.). The UnitTimes group
     contains a group for each unit. The name of the group should match the value in
     the source module, if that is possible/relevant (e.g., name of ROIs from Segmentation
     module).
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Estimated spike times from a single unit'
+    value: Estimated spike times from a single unit
+  datasets:
+  - neurodata_type_inc: ElementIdentifiers
+    name: unit_ids
+    doc: a unique identifier for each element
+  - neurodata_type_inc: VectorIndex
+    name: spike_times_index
+    doc: the index into the spike times dataset
+  - neurodata_type_inc: VectorData
+    name: spike_times
+    doc: the index into the vector data
   default_name: UnitTimes
-  neurodata_type_def: UnitTimes
-  neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.namespace.yaml
+++ b/src/pynwb/data/nwb.namespace.yaml
@@ -1,5 +1,7 @@
 namespaces:
-- author:
+- name: core
+  doc: NWB namespace
+  author:
   - Keith Godfrey
   - Jeff Teeters
   - Oliver Ruebel
@@ -9,9 +11,7 @@ namespaces:
   - jteeters@berkeley.edu
   - oruebel@lbl.gov
   - ajtritt@lbl.gov
-  doc: NWB namespace
   full_name: NWB core
-  name: core
   schema:
   - source: nwb.base.yaml
   - source: nwb.epoch.yaml

--- a/src/pynwb/data/nwb.ogen.yaml
+++ b/src/pynwb/data/nwb.ogen.yaml
@@ -1,54 +1,54 @@
 groups:
-- attributes:
-  - doc: Value is 'Optogenetic stimulus'
+- neurodata_type_def: OptogeneticSeries
+  neurodata_type_inc: TimeSeries
+  doc: Optogenetic stimulus.  The data[] field is in unit of watts.
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'Optogenetic stimulus'
     value: Optogenetic stimulus
   datasets:
-  - attributes:
-    - default_value: watt
+  - name: data
+    dtype: float32
+    doc: Applied power for optogenetic stimulus.
+    attributes:
+    - name: unit
+      dtype: text
       doc: "The base unit of measure used to store data. This should be in the SI\
         \ unit. COMMENT: This is the SI unit (when appropriate) of the stored data,\
         \ such as Volts. If the actual data is stored in millivolts, the field 'conversion'\
         \ below describes how to convert the data to the specified SI unit."
-      dtype: text
-      name: unit
+      default_value: watt
       required: false
     dims:
     - num_times
-    doc: Applied power for optogenetic stimulus.
-    dtype: float32
-    name: data
     shape:
-    - null
-  doc: Optogenetic stimulus.  The data[] field is in unit of watts.
+    - 
   links:
-  - doc: link to OptogeneticStimulusSite group that describes the site to which this
+  - name: site
+    doc: link to OptogeneticStimulusSite group that describes the site to which this
       stimulus was applied
-    name: site
     target_type: OptogeneticStimulusSite
-  neurodata_type_def: OptogeneticSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Metadata about an optogenetic stimulus site'
-    dtype: text
-    name: help
-    value: Metadata about an optogenetic stimulus site
-  datasets:
-  - doc: Description of site
-    dtype: text
-    name: description
-  - doc: Name of device in /general/devices
-    dtype: text
-    name: device
-  - doc: Excitation wavelength
-    dtype: text
-    name: excitation_lambda
-  - doc: Location of stimulation site
-    dtype: text
-    name: location
+- neurodata_type_def: OptogeneticStimulusSite
+  neurodata_type_inc: NWBContainer
   doc: 'One of possibly many groups describing an optogenetic stimuluation site. COMMENT:
     Name is arbitrary but should be meaningful. Name is referenced by OptogeneticSeries'
-  neurodata_type_def: OptogeneticStimulusSite
-  neurodata_type_inc: NWBContainer
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Metadata about an optogenetic stimulus site'
+    value: Metadata about an optogenetic stimulus site
+  datasets:
+  - name: description
+    dtype: text
+    doc: Description of site
+  - name: device
+    dtype: text
+    doc: Name of device in /general/devices
+  - name: excitation_lambda
+    dtype: text
+    doc: Excitation wavelength
+  - name: location
+    dtype: text
+    doc: Location of stimulation site
   quantity: '*'

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -1,27 +1,23 @@
 datasets:
-- doc: ROI mask, represented in 2D ([y][x]) intensity image
+- neurodata_type_def: ImageMasks
+  neurodata_type_inc: NWBData
+  dtype: float
+  doc: ROI mask, represented in 2D ([y][x]) intensity image
   attributes:
-  - doc: a help string
-    name: help
+  - name: help
     dtype: text
+    doc: a help string
     value: an array of image masks
   dims:
   - num_roi
   - num_x
   - num_y
-  dtype: float
   shape:
-  - null
-  - null
-  - null
-  neurodata_type_inc: NWBData
-  neurodata_type_def: ImageMasks
-- doc: a table for storing pixel masks
-  attributes:
-  - doc: a help string
-    name: help
-    dtype: text
-    value: a concatenated array of pixel masks
+  - 
+  - 
+  - 
+- neurodata_type_def: PixelMasks
+  neurodata_type_inc: VectorData
   dtype:
   - name: x
     dtype: uint
@@ -32,14 +28,14 @@ datasets:
   - name: weight
     dtype: float
     doc: the weight of the pixel
-  neurodata_type_inc: VectorData
-  neurodata_type_def: PixelMasks
-- doc: A table for storing references to the image mask and pixel mask for each ROI
+  doc: a table for storing pixel masks
   attributes:
-  - doc: a help string
-    name: help
+  - name: help
     dtype: text
-    value: A table for storing ROI data
+    doc: a help string
+    value: a concatenated array of pixel masks
+- neurodata_type_def: ROITable
+  neurodata_type_inc: NWBData
   dtype:
   - name: name
     dtype: ascii
@@ -54,119 +50,119 @@ datasets:
       reftype: region
       target_type: ImageMasks
     doc: a reference into a the dataset of image masks
+  doc: A table for storing references to the image mask and pixel mask for each ROI
+  attributes:
+  - name: help
+    dtype: text
+    doc: a help string
+    value: A table for storing ROI data
+- neurodata_type_def: ROITableRegion
   neurodata_type_inc: NWBData
-  neurodata_type_def: ROITable
-- doc: A region reference for subsetting an ROITable
   dtype:
     target_type: ROITable
     reftype: region
+  doc: A region reference for subsetting an ROITable
   attributes:
-  - doc: a help string
-    name: help
+  - name: help
     dtype: text
+    doc: a help string
     value: A region reference to an ROITable
   - name: description
-    doc: 'a description of this subset of ROIs'
     dtype: utf8
-  neurodata_type_inc: NWBData
-  neurodata_type_def: ROITableRegion
+    doc: a description of this subset of ROIs
 groups:
-- attributes:
-  - doc: Value is 'Image stack recorded from 2-photon microscope'
+- neurodata_type_def: TwoPhotonSeries
+  neurodata_type_inc: ImageSeries
+  doc: A special case of optical imaging.
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'Image stack recorded from 2-photon microscope'
     value: Image stack recorded from 2-photon microscope
-  - doc: Photomultiplier gain
+  - name: pmt_gain
     dtype: float32
-    name: pmt_gain
+    doc: Photomultiplier gain
     quantity: '?'
-  - doc: Lines imaged per second. This is also stored in /general/optophysiology but
+  - name: scan_line_rate
+    dtype: float32
+    doc: Lines imaged per second. This is also stored in /general/optophysiology but
       is kept here as it is useful information for analysis, and so good to be stored
       w/ the actual data.
-    dtype: float32
-    name: scan_line_rate
     quantity: '?'
   datasets:
-  - dims:
-    - width|height|depth
-    doc: Width, height and depth of image, or imaged area (meters).
+  - name: field_of_view
     dtype: float32
-    name: field_of_view
+    doc: Width, height and depth of image, or imaged area (meters).
+    dims:
+    - width|height|depth
     quantity: '?'
     shape:
     - 3
-  doc: A special case of optical imaging.
   links:
-  - doc: link to ImagingPlane group from which this TimeSeries data was generated
-    name: imaging_plane
+  - name: imaging_plane
+    doc: link to ImagingPlane group from which this TimeSeries data was generated
     target_type: ImagingPlane
-  neurodata_type_def: TwoPhotonSeries
-  neurodata_type_inc: ImageSeries
-- attributes:
-  - doc: Value is 'ROI responses over an imaging plane. Each element on the second dimension of data[]
-      should correspond to the signal from one ROI'
-    dtype: text
-    name: help
-    value: ROI responses over an imaging plane. Each element on the second dimension of data[]
-      should correspond to the signal from one ROI
-  datasets:
-  - dims:
-    - num_times
-    - num_ROIs
-    doc: Signals from ROIs
-    dtype: float32
-    name: data
-    shape:
-    - null
-    - null
-  - doc: 'a dataset referencing into an ROITable containing information on the ROIs stored in this timeseries'
-    neurodata_type_inc: ROITableRegion
-    name: rois
+- neurodata_type_def: RoiResponseSeries
+  neurodata_type_inc: TimeSeries
   doc: ROI responses over an imaging plane. Each row in data[] should correspond to
     the signal from one ROI.
-  neurodata_type_def: RoiResponseSeries
-  neurodata_type_inc: TimeSeries
-- attributes:
-  - doc: Value is 'Df/f over time of one or more ROIs. TimeSeries names should correspond
-      to imaging plane names'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Df/f over time of one or more ROIs. TimeSeries names should correspond
-      to imaging plane names
+    doc: Value is 'ROI responses over an imaging plane. Each element on the second
+      dimension of data[] should correspond to the signal from one ROI'
+    value: ROI responses over an imaging plane. Each element on the second dimension
+      of data[] should correspond to the signal from one ROI
+  datasets:
+  - name: data
+    dtype: float32
+    doc: Signals from ROIs
+    dims:
+    - num_times
+    - num_ROIs
+    shape:
+    - 
+    - 
+  - neurodata_type_inc: ROITableRegion
+    name: rois
+    doc: a dataset referencing into an ROITable containing information on the ROIs
+      stored in this timeseries
+- neurodata_type_def: DfOverF
+  neurodata_type_inc: NWBDataInterface
   doc: dF/F information about a region of interest (ROI). Storage hierarchy of dF/F
     should be the same as for segmentation (ie, same names for ROIs and for image
     planes).
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Df/f over time of one or more ROIs. TimeSeries names should correspond
+      to imaging plane names'
+    value: Df/f over time of one or more ROIs. TimeSeries names should correspond
+      to imaging plane names
   groups:
-  - doc: RoiResponseSeries object containing dF/F for a ROI
-    neurodata_type_inc: RoiResponseSeries
+  - neurodata_type_inc: RoiResponseSeries
+    doc: RoiResponseSeries object containing dF/F for a ROI
     quantity: '*'
   default_name: DfOverF
-  neurodata_type_def: DfOverF
+- neurodata_type_def: Fluorescence
   neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Fluorescence over time of one or more ROIs. TimeSeries names should
-      correspond to imaging plane names'
-    dtype: text
-    name: help
-    value: Fluorescence over time of one or more ROIs. TimeSeries names should correspond
-      to imaging plane names
   doc: Fluorescence information about a region of interest (ROI). Storage hierarchy
     of fluorescence should be the same as for segmentation (ie, same names for ROIs
     and for image planes).
-  groups:
-  - doc: RoiResponseSeries object containing fluorescence data for a ROI
-    neurodata_type_inc: RoiResponseSeries
-    quantity: '+'
-  default_name: Fluorescence
-  neurodata_type_def: Fluorescence
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Stores groups of pixels that define regions of interest from one
-      or more imaging planes'
+  attributes:
+  - name: help
     dtype: text
-    name: help
-    value: Stores groups of pixels that define regions of interest from one or more
-      imaging planes
+    doc: Value is 'Fluorescence over time of one or more ROIs. TimeSeries names should
+      correspond to imaging plane names'
+    value: Fluorescence over time of one or more ROIs. TimeSeries names should correspond
+      to imaging plane names
+  groups:
+  - neurodata_type_inc: RoiResponseSeries
+    doc: RoiResponseSeries object containing fluorescence data for a ROI
+    quantity: +
+  default_name: Fluorescence
+- neurodata_type_def: ImageSegmentation
+  neurodata_type_inc: NWBDataInterface
   doc: Stores pixels in an image that represent different regions of interest (ROIs)
     or masks. All segmentation for a given imaging plane is stored together, with
     storage for multiple imaging planes (masks) supported. Each ROI is stored in its
@@ -174,157 +170,164 @@ groups:
     that make up this mask. Segments can also be used for masking neuropil. If segmentation
     is allowed to change with time, a new imaging plane (or module) is required and
     ROI names should remain consistent between them.
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Stores groups of pixels that define regions of interest from one
+      or more imaging planes'
+    value: Stores groups of pixels that define regions of interest from one or more
+      imaging planes
   groups:
-  - attributes:
-    - doc: Value is 'Results from segmentation of an imaging plane'
-      dtype: text
-      name: help
-      value: 'Results from segmentation of an imaging plane'
-    datasets:
-    - doc: Description of image plane, recording wavelength, depth, etc
-      dtype: text
-      name: description
-      quantity: '?'
-    - name: pixel_masks
-      doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this dataset is
-        maintained by the ROITable
-      neurodata_type_inc: PixelMasks
-    - name: image_masks
-      doc: ROI masks for each ROI
-      neurodata_type_inc: ImageMasks
-    - name: rois
-      doc: ROIs resulting from the segmentation of the imaging plane linked in this PlaneSegmentation
-      neurodata_type_inc: ROITable
-    doc: Group name is human-readable description of imaging plane
-    groups:
-    - doc: Stores image stacks segmentation mask apply to.
-      groups:
-      - doc: One or more image stacks that the masks apply to (can be one-element
-          stack)
-        neurodata_type_inc: ImageSeries
-      name: reference_images
-    links:
-    - doc: link to ImagingPlane group from which this TimeSeries data was generated
-      name: imaging_plane
-      target_type: ImagingPlane
-    neurodata_type_def: PlaneSegmentation
+  - neurodata_type_def: PlaneSegmentation
     neurodata_type_inc: NWBContainer
+    doc: Group name is human-readable description of imaging plane
+    attributes:
+    - name: help
+      dtype: text
+      doc: Value is 'Results from segmentation of an imaging plane'
+      value: Results from segmentation of an imaging plane
+    datasets:
+    - name: description
+      dtype: text
+      doc: Description of image plane, recording wavelength, depth, etc
+      quantity: '?'
+    - neurodata_type_inc: PixelMasks
+      name: pixel_masks
+      doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this
+        dataset is maintained by the ROITable
+    - neurodata_type_inc: ImageMasks
+      name: image_masks
+      doc: ROI masks for each ROI
+    - neurodata_type_inc: ROITable
+      name: rois
+      doc: ROIs resulting from the segmentation of the imaging plane linked in this
+        PlaneSegmentation
+    groups:
+    - name: reference_images
+      doc: Stores image stacks segmentation mask apply to.
+      groups:
+      - neurodata_type_inc: ImageSeries
+        doc: One or more image stacks that the masks apply to (can be one-element
+          stack)
+    links:
+    - name: imaging_plane
+      doc: link to ImagingPlane group from which this TimeSeries data was generated
+      target_type: ImagingPlane
     quantity: '*'
   default_name: ImageSegmentation
-  neurodata_type_def: ImageSegmentation
-  neurodata_type_inc: NWBDataInterface
-- attributes:
-  - doc: Value is 'Metadata about an imaging plane'
+- neurodata_type_def: ImagingPlane
+  neurodata_type_inc: NWBContainer
+  doc: 'One of possibly many groups describing an imaging plane. COMMENT: Name is
+    arbitrary but should be meaningful. It is referenced by TwoPhotonSeries and also
+    ImageSegmentation and DfOverF interfaces'
+  attributes:
+  - name: help
     dtype: text
-    name: help
+    doc: Value is 'Metadata about an imaging plane'
     value: Metadata about an imaging plane
   datasets:
-  - doc: Description of &lt;image_plane_X&gt;
+  - name: description
     dtype: text
-    name: description
+    doc: Description of &lt;image_plane_X&gt;
     quantity: '?'
-  - doc: Excitation wavelength
+  - name: excitation_lambda
     dtype: float
-    name: excitation_lambda
-  - doc: Rate images are acquired, in Hz.
+    doc: Excitation wavelength
+  - name: imaging_rate
     dtype: text
-    name: imaging_rate
-  - doc: Calcium indicator
+    doc: Rate images are acquired, in Hz.
+  - name: indicator
     dtype: text
-    name: indicator
-  - doc: Location of image plane
+    doc: Calcium indicator
+  - name: location
     dtype: text
-    name: location
-  - attributes:
-    - default_value: 1.0
+    doc: Location of image plane
+  - name: manifold
+    dtype: float32
+    doc: 'Physical position of each pixel. COMMENT: "xyz" represents the position
+      of the pixel relative to the defined coordinate space'
+    attributes:
+    - name: conversion
+      dtype: float
       doc: Multiplier to get from stored values to specified unit (e.g., 1e-3 for
         millimeters)
-      dtype: float
-      name: conversion
+      default_value: 1.0
       required: false
-    - default_value: Meter
-      doc: Base unit that coordinates are stored in (e.g., Meters)
+    - name: unit
       dtype: text
-      name: unit
+      doc: Base unit that coordinates are stored in (e.g., Meters)
+      default_value: Meter
       required: false
     dims:
     - height
     - weight
     - x|y|z
-    doc: 'Physical position of each pixel. COMMENT: "xyz" represents the position
-      of the pixel relative to the defined coordinate space'
-    dtype: float32
-    name: manifold
     shape:
-    - null
-    - null
+    - 
+    - 
     - 3
-  - doc: 'Describes position and reference frame of manifold based on position of
+  - name: reference_frame
+    dtype: text
+    doc: 'Describes position and reference frame of manifold based on position of
       first element in manifold. For example, text description of anotomical location
       or vectors needed to rotate to common anotomical axis (eg, AP/DV/ML). COMMENT:
       This field is necessary to interpret manifold. If manifold is not present then
       this field is not required'
-    dtype: text
-    name: reference_frame
-  links:
-  - doc: the device that was used to record from this electrode
-    name: device
-    target_type: Device
-  doc: 'One of possibly many groups describing an imaging plane. COMMENT: Name is
-    arbitrary but should be meaningful. It is referenced by TwoPhotonSeries and also
-    ImageSegmentation and DfOverF interfaces'
   groups:
-  - attributes:
-    - doc: Value is 'Metadata about an optical channel used to record from an imaging plane'
-      dtype: text
-      name: help
-      value: Metadata about an optical channel used to record from an imaging plane
-    datasets:
-    - doc: Any notes or comments about the channel
-      dtype: text
-      name: description
-    - doc: Emission lambda for channel
-      dtype: float
-      name: emission_lambda
+  - neurodata_type_def: OpticalChannel
+    neurodata_type_inc: NWBContainer
     doc: 'One of possibly many groups storing channel-specific data COMMENT: Name
       is arbitrary but should be meaningful'
-    neurodata_type_def: OpticalChannel
-    neurodata_type_inc: NWBContainer
-  neurodata_type_def: ImagingPlane
-  neurodata_type_inc: NWBContainer
+    attributes:
+    - name: help
+      dtype: text
+      doc: Value is 'Metadata about an optical channel used to record from an imaging
+        plane'
+      value: Metadata about an optical channel used to record from an imaging plane
+    datasets:
+    - name: description
+      dtype: text
+      doc: Any notes or comments about the channel
+    - name: emission_lambda
+      dtype: float
+      doc: Emission lambda for channel
+  links:
+  - name: device
+    doc: the device that was used to record from this electrode
+    target_type: Device
   quantity: '*'
-- attributes:
-  - doc: Value is 'Image stacks whose frames have been shifted (registered) to account
-      for motion'
-    dtype: text
-    name: help
-    value: Image stacks whose frames have been shifted (registered) to account for
-      motion
+- neurodata_type_def: MotionCorrection
+  neurodata_type_inc: NWBDataInterface
   doc: 'An image stack where all frames are shifted (registered) to a common coordinate
     system, to account for movement and drift between frames. Note: each frame at
     each point in time is assumed to be 2-D (has only x & y dimensions).'
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Image stacks whose frames have been shifted (registered) to account
+      for motion'
+    value: Image stacks whose frames have been shifted (registered) to account for
+      motion
   groups:
-  - attributes:
-    - doc: Value is 'Reuslts from motion correction of an image stack'
-      dtype: text
-      name: help
-      value: Reuslts from motion correction of an image stack
-    doc: One of possibly many.  Name should be informative.
-    groups:
-    - doc: Image stack with frames shifted to the common coordinates.
-      name: corrected
-      neurodata_type_inc: ImageSeries
-    - doc: Stores the x,y delta necessary to align each frame to the common coordinates,
-        for example, to align each frame to a reference image.
-      name: xy_translation
-      neurodata_type_inc: TimeSeries
-    links:
-    - doc: HDF5 Link to image series that is being registered.
-      name: original
-      target_type: ImageSeries
-    neurodata_type_def: CorrectedImageStack
+  - neurodata_type_def: CorrectedImageStack
     neurodata_type_inc: NWBContainer
-    quantity: '+'
+    doc: One of possibly many.  Name should be informative.
+    attributes:
+    - name: help
+      dtype: text
+      doc: Value is 'Reuslts from motion correction of an image stack'
+      value: Reuslts from motion correction of an image stack
+    groups:
+    - neurodata_type_inc: ImageSeries
+      name: corrected
+      doc: Image stack with frames shifted to the common coordinates.
+    - neurodata_type_inc: TimeSeries
+      name: xy_translation
+      doc: Stores the x,y delta necessary to align each frame to the common coordinates,
+        for example, to align each frame to a reference image.
+    links:
+    - name: original
+      doc: HDF5 Link to image series that is being registered.
+      target_type: ImageSeries
+    quantity: +
   default_name: MotionCorrection
-  neurodata_type_def: MotionCorrection
-  neurodata_type_inc: NWBDataInterface

--- a/src/pynwb/data/nwb.retinotopy.yaml
+++ b/src/pynwb/data/nwb.retinotopy.yaml
@@ -1,235 +1,235 @@
 groups:
-- attributes:
-  - doc: Value is 'Intrinsic signal optical imaging or Widefield imaging for measuring
-      retinotopy'
-    dtype: text
-    name: help
-    value: Intrinsic signal optical imaging or Widefield imaging for measuring retinotopy
-  datasets:
-  - attributes:
-    - dims:
-      - row_col
-      doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
-      dtype: int32
-      name: dimension
-      shape:
-      - null
-    - dims:
-      - row|column
-      doc: Size of viewing area, in meters
-      dtype: float
-      name: field_of_view
-      shape:
-      - null
-    - doc: Unit that axis data is stored in (e.g., degrees)
-      dtype: text
-      name: unit
-    dims:
-    - num_rows
-    - num_cols
-    doc: Phase response to stimulus on the first measured axis
-    dtype: float32
-    name: axis_1_phase_map
-    shape:
-    - null
-    - null
-  - attributes:
-    - dims:
-      - row_col
-      doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
-      dtype: int32
-      name: dimension
-      shape:
-      - null
-    - dims:
-      - row_col
-      doc: Size of viewing area, in meters
-      dtype: float
-      name: field_of_view
-      shape:
-      - null
-    - doc: Unit that axis data is stored in (e.g., degrees)
-      dtype: text
-      name: unit
-    dims:
-    - num_rows
-    - num_cols
-    doc: Power response on the first measured axis. Response is scaled so 0.0 is no
-      power in the response and 1.0 is maximum relative power.
-    dtype: float32
-    name: axis_1_power_map
-    quantity: '?'
-    shape:
-    - null
-    - null
-  - attributes:
-    - dims:
-      - row_col
-      doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
-      dtype: int32
-      name: dimension
-      shape:
-      - null
-    - dims:
-      - row_col
-      doc: Size of viewing area, in meters
-      dtype: float
-      name: field_of_view
-      shape:
-      - null
-    - doc: Unit that axis data is stored in (e.g., degrees)
-      dtype: text
-      name: unit
-    dims:
-    - num_rows
-    - num_cols
-    doc: Phase response to stimulus on the second measured axis
-    dtype: float32
-    name: axis_2_phase_map
-    shape:
-    - null
-    - null
-  - attributes:
-    - dims:
-      - row_col
-      doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
-      dtype: int32
-      name: dimension
-      shape:
-      - null
-    - dims:
-      - row_col
-      doc: Size of viewing area, in meters
-      dtype: float
-      name: field_of_view
-      shape:
-      - null
-    - doc: Unit that axis data is stored in (e.g., degrees)
-      dtype: text
-      name: unit
-    dims:
-    - num_rows
-    - num_cols
-    doc: Power response on the second measured axis. Response is scaled so 0.0 is
-      no power in the response and 1.0 is maximum relative power.
-    dtype: float32
-    name: axis_2_power_map
-    quantity: '?'
-    shape:
-    - null
-    - null
-  - dims:
-    - '2'
-    doc: Two-element array describing the contents of the two response axis fields.
-      Description should be something like ['altitude', 'azimuth'] or '['radius',
-      'theta']
-    dtype: text
-    name: axis_descriptions
-    shape:
-    - null
-  - attributes:
-    - doc: Number of bits used to represent each value. This is necessary to determine
-        maximum (white) pixel value
-      dtype: int32
-      name: bits_per_pixel
-    - dims:
-      - row_col
-      doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
-      dtype: int32
-      name: dimension
-      shape:
-      - null
-    - dims:
-      - row_col
-      doc: Size of viewing area, in meters
-      dtype: float
-      name: field_of_view
-      shape:
-      - null
-    - doc: Focal depth offset, in meters
-      dtype: float
-      name: focal_depth
-    - doc: Format of image. Right now only 'raw' supported
-      dtype: text
-      name: format
-    dims:
-    - num_rows
-    - num_cols
-    doc: 'Gray-scale image taken with same settings/parameters (e.g., focal depth,
-      wavelength) as data collection. Array format: [rows][columns]'
-    dtype: uint16
-    name: focal_depth_image
-    shape:
-    - null
-    - null
-  - attributes:
-    - dims:
-      - row_col
-      doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
-      dtype: int32
-      name: dimension
-      shape:
-      - null
-    - dims:
-      - row_col
-      doc: Size of viewing area, in meters.
-      dtype: float
-      name: field_of_view
-      shape:
-      - null
-    dims:
-    - num_rows
-    - num_cols
-    doc: Sine of the angle between the direction of the gradient in axis_1 and axis_2
-    dtype: float32
-    name: sign_map
-    shape:
-    - null
-    - null
-  - attributes:
-    - doc: Number of bits used to represent each value. This is necessary to determine
-        maximum (white) pixel value
-      dtype: int32
-      name: bits_per_pixel
-    - dims:
-      - row_col
-      doc: 'Number of rows and columns in the image. NOTE: row, column representation
-        is equivalent to height,width.'
-      dtype: int32
-      name: dimension
-      shape:
-      - null
-    - dims:
-      - row_col
-      doc: Size of viewing area, in meters
-      dtype: float
-      name: field_of_view
-      shape:
-      - null
-    - doc: Format of image. Right now only 'raw' supported
-      dtype: text
-      name: format
-    dims:
-    - num_rows
-    - num_cols
-    doc: 'Gray-scale anatomical image of cortical surface. Array structure: [rows][columns]'
-    dtype: uint16
-    name: vasculature_image
-    shape:
-    - null
-    - null
+- neurodata_type_def: ImagingRetinotopy
+  neurodata_type_inc: NWBContainer
   doc: 'Intrinsic signal optical imaging or widefield imaging for measuring retinotopy.
     Stores orthogonal maps (e.g., altitude/azimuth; radius/theta) of responses to
     specific stimuli and a combined polarity map from which to identify visual areas.<br
     />Note: for data consistency, all images and arrays are stored in the format [row][column]
     and [row, col], which equates to [y][x]. Field of view and dimension arrays may
     appear backward (i.e., y before x).'
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Intrinsic signal optical imaging or Widefield imaging for measuring
+      retinotopy'
+    value: Intrinsic signal optical imaging or Widefield imaging for measuring retinotopy
+  datasets:
+  - name: axis_1_phase_map
+    dtype: float32
+    doc: Phase response to stimulus on the first measured axis
+    attributes:
+    - name: dimension
+      dtype: int32
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: field_of_view
+      dtype: float
+      doc: Size of viewing area, in meters
+      dims:
+      - row|column
+      shape:
+      - 
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees)
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - 
+    - 
+  - name: axis_1_power_map
+    dtype: float32
+    doc: Power response on the first measured axis. Response is scaled so 0.0 is no
+      power in the response and 1.0 is maximum relative power.
+    attributes:
+    - name: dimension
+      dtype: int32
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: field_of_view
+      dtype: float
+      doc: Size of viewing area, in meters
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees)
+    dims:
+    - num_rows
+    - num_cols
+    quantity: '?'
+    shape:
+    - 
+    - 
+  - name: axis_2_phase_map
+    dtype: float32
+    doc: Phase response to stimulus on the second measured axis
+    attributes:
+    - name: dimension
+      dtype: int32
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: field_of_view
+      dtype: float
+      doc: Size of viewing area, in meters
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees)
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - 
+    - 
+  - name: axis_2_power_map
+    dtype: float32
+    doc: Power response on the second measured axis. Response is scaled so 0.0 is
+      no power in the response and 1.0 is maximum relative power.
+    attributes:
+    - name: dimension
+      dtype: int32
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: field_of_view
+      dtype: float
+      doc: Size of viewing area, in meters
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: unit
+      dtype: text
+      doc: Unit that axis data is stored in (e.g., degrees)
+    dims:
+    - num_rows
+    - num_cols
+    quantity: '?'
+    shape:
+    - 
+    - 
+  - name: axis_descriptions
+    dtype: text
+    doc: Two-element array describing the contents of the two response axis fields.
+      Description should be something like ['altitude', 'azimuth'] or '['radius',
+      'theta']
+    dims:
+    - '2'
+    shape:
+    - 
+  - name: focal_depth_image
+    dtype: uint16
+    doc: 'Gray-scale image taken with same settings/parameters (e.g., focal depth,
+      wavelength) as data collection. Array format: [rows][columns]'
+    attributes:
+    - name: bits_per_pixel
+      dtype: int32
+      doc: Number of bits used to represent each value. This is necessary to determine
+        maximum (white) pixel value
+    - name: dimension
+      dtype: int32
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: field_of_view
+      dtype: float
+      doc: Size of viewing area, in meters
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: focal_depth
+      dtype: float
+      doc: Focal depth offset, in meters
+    - name: format
+      dtype: text
+      doc: Format of image. Right now only 'raw' supported
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - 
+    - 
+  - name: sign_map
+    dtype: float32
+    doc: Sine of the angle between the direction of the gradient in axis_1 and axis_2
+    attributes:
+    - name: dimension
+      dtype: int32
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: field_of_view
+      dtype: float
+      doc: Size of viewing area, in meters.
+      dims:
+      - row_col
+      shape:
+      - 
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - 
+    - 
+  - name: vasculature_image
+    dtype: uint16
+    doc: 'Gray-scale anatomical image of cortical surface. Array structure: [rows][columns]'
+    attributes:
+    - name: bits_per_pixel
+      dtype: int32
+      doc: Number of bits used to represent each value. This is necessary to determine
+        maximum (white) pixel value
+    - name: dimension
+      dtype: int32
+      doc: 'Number of rows and columns in the image. NOTE: row, column representation
+        is equivalent to height,width.'
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: field_of_view
+      dtype: float
+      doc: Size of viewing area, in meters
+      dims:
+      - row_col
+      shape:
+      - 
+    - name: format
+      dtype: text
+      doc: Format of image. Right now only 'raw' supported
+    dims:
+    - num_rows
+    - num_cols
+    shape:
+    - 
+    - 
   default_name: ImagingRetinotopy
-  neurodata_type_def: ImagingRetinotopy
-  neurodata_type_inc: NWBContainer


### PR DESCRIPTION
## Motivation

Re-order yaml for better readability. The order is changed from alphabetical to:
['neurodata_type_def', 'neurodata_type_inc', 'name', 'dtype', 'doc', 'attributes',  'datasets', 'groups']

The core yaml files are re-ordered and any generated extensions are also re-ordered

fix NeurodataWithoutBorders/nwb-schema#139

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
