### PR TITLE
[WIP] added float and int type check

### DIFF
--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -560,7 +560,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                 else:
                     ret = text_type(value)
             elif ('float' in spec.dtype) or ('int' in spec.dtype):
-                ret = np.asscalar(np.array(value, dtype=spec.dtype))
+                ret = np.array(value, dtype=spec.dtype)
         elif isinstance(spec, DatasetSpec):
             # TODO: make sure we can handle specs with data_type_inc set
             if spec.data_type_inc is not None:

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -13,6 +13,8 @@ from ..spec.spec import BaseStorageSpec
 from .builders import DatasetBuilder, GroupBuilder, LinkBuilder, Builder, ReferenceBuilder, RegionBuilder, BaseBuilder
 from .warnings import OrphanContainerWarning, MissingRequiredWarning
 
+import numpy as np
+
 
 class Proxy(object):
     """
@@ -557,6 +559,8 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                     ret = list(map(text_type, value))
                 else:
                     ret = text_type(value)
+            elif ('float' in spec.dtype) or ('int' in spec.dtype):
+                ret = np.asscalar(np.array(value, dtype=spec.dtype))
         elif isinstance(spec, DatasetSpec):
             # TODO: make sure we can handle specs with data_type_inc set
             if spec.data_type_inc is not None:
@@ -672,6 +676,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                 attr_value = self.get_attr_value(spec, container, build_manager)
                 if attr_value is None:
                     attr_value = spec.default_value
+            attr_value = self.__convert_value(attr_value, spec)
 
             # do not write empty or null valued objects
             if attr_value is None:


### PR DESCRIPTION
## Motivation

NaN was being stored as a string and not a float.

## How to test the behavior?

See issue #592

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?

I haven't written a test since I'm not sure this is the right fix for the problem. I'm also not sure whether I would be using the dtype naming conventions from here
https://github.com/NeurodataWithoutBorders/pynwb/blob/c3a1bed686ff291bb0e523573b9b04ea073dcfc7/src/pynwb/form/backends/hdf5/h5tools.py#L404
I'm currently just interpreting the `spec.dtype` strings as numpy dtypes.