### PR TITLE
make IntervalSeries write NaN. fix #592

### DIFF
--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -38,7 +38,7 @@ datasets:
     value: indexes into a list of values for a list of elements
   default_name: vector_index
   shape:
-  - 
+  -
 - neurodata_type_def: ElementIdentifiers
   neurodata_type_inc: NWBData
   dtype: int
@@ -50,7 +50,7 @@ datasets:
     value: unique identifiers for a list of elements
   default_name: element_id
   shape:
-  - 
+  -
 groups:
 - neurodata_type_def: NWBContainer
   doc: The attributes specified here are included in all interfaces.
@@ -98,7 +98,7 @@ groups:
     - num_times
     quantity: '?'
     shape:
-    - 
+    -
   - name: control_description
     dtype: text
     doc: 'Description of each control value. COMMENT: Array length should be as long
@@ -108,7 +108,7 @@ groups:
     - num_control_values
     quantity: '?'
     shape:
-    - 
+    -
   - name: data
     doc: 'Data values. Can also store binary data (eg, image frames) COMMENT: This
       field may be a link to data stored in an external file, especially in the case
@@ -125,7 +125,7 @@ groups:
       doc: 'Smallest meaningful difference between values in data, stored in the specified
         by unit. COMMENT: E.g., the change in value of the least significant bit,
         or a larger number if signal noise is known to be present. If unknown, use
-        NaN'
+        -1.0'
       default_value: 0.0
       required: false
     - name: unit
@@ -137,7 +137,7 @@ groups:
     dims:
     - num_times
     shape:
-    - 
+    -
   - name: starting_time
     dtype: float64
     doc: 'The timestamp of the first sample. COMMENT: When timestamps are uniformly
@@ -170,7 +170,7 @@ groups:
     - num_times
     quantity: '?'
     shape:
-    - 
+    -
   groups:
   - name: sync
     doc: "Lab specific time and sync information as provided directly from hardware\
@@ -245,7 +245,7 @@ groups:
     doc: The names of the columns in this table. This should be used to specifying
       an order to the columns
     shape:
-    - 
+    -
   - name: description
     dtype: text
     doc: Description of what is in this dynamic table
@@ -255,7 +255,7 @@ groups:
     dtype: int
     doc: The unique identifier for the rows in this dynamic table
     shape:
-    - 
+    -
   - neurodata_type_inc: TableColumn
     doc: The columns in this dynamic table
     quantity: '*'

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -33,8 +33,8 @@ groups:
     - num_times
     - num_features
     shape:
-    - 
-    - 
+    -
+    -
   - name: feature_units
     dtype: text
     doc: Units of each feature.
@@ -42,14 +42,14 @@ groups:
     - num_features
     quantity: '?'
     shape:
-    - 
+    -
   - name: features
     dtype: text
     doc: Description of the features represented in TimeSeries::data.
     dims:
     - num_features
     shape:
-    - 
+    -
 - neurodata_type_def: AnnotationSeries
   neurodata_type_inc: TimeSeries
   doc: Stores, eg, user annotations made during an experiment. The TimeSeries::data[]
@@ -69,11 +69,11 @@ groups:
     - name: conversion
       dtype: float
       doc: Value is 'float('NaN')'
-      value: NaN
+      value: .NaN
     - name: resolution
       dtype: float
       doc: Value is 'float('NaN')'
-      value: NaN
+      value: .NaN
     - name: unit
       dtype: text
       doc: Value is 'n/a'
@@ -81,7 +81,7 @@ groups:
     dims:
     - num_times
     shape:
-    - 
+    -
 - neurodata_type_def: IntervalSeries
   neurodata_type_inc: TimeSeries
   doc: Stores intervals of data. The timestamps field stores the beginning and end
@@ -104,11 +104,11 @@ groups:
     - name: conversion
       dtype: float
       doc: Value is 'float('NaN')'
-      value: NaN
+      value: .NaN
     - name: resolution
       dtype: float
       doc: Value is 'float('NaN')'
-      value: NaN
+      value: .NaN
     - name: unit
       dtype: text
       doc: Value is 'n/a'
@@ -116,7 +116,7 @@ groups:
     dims:
     - num_times
     shape:
-    - 
+    -
 - neurodata_type_def: UnitTimes
   neurodata_type_inc: NWBDataInterface
   doc: Event times of observed units (e.g. cell, synapse, etc.). The UnitTimes group

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -66,14 +66,10 @@ groups:
     dtype: text
     doc: Annotations made during an experiment.
     attributes:
-    - name: conversion
-      dtype: float
-      doc: Value is 'float('NaN')'
-      value: .NaN
     - name: resolution
       dtype: float
-      doc: Value is 'float('NaN')'
-      value: .NaN
+      doc: Value is -1.0
+      value: -1.0
     - name: unit
       dtype: text
       doc: Value is 'n/a'
@@ -101,14 +97,10 @@ groups:
     dtype: int8
     doc: '>0 if interval started, <0 if interval ended.'
     attributes:
-    - name: conversion
-      dtype: float
-      doc: Value is 'float('NaN')'
-      value: .NaN
     - name: resolution
       dtype: float
-      doc: Value is 'float('NaN')'
-      value: .NaN
+      doc: Value is -1.0
+      value: -1.0
     - name: unit
       dtype: text
       doc: Value is 'n/a'

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -42,7 +42,7 @@ class AnnotationSeries(TimeSeries):
     def __init__(self, **kwargs):
         name, source, data, timestamps = popargs('name', 'source', 'data', 'timestamps', kwargs)
         super(AnnotationSeries, self).__init__(name, source, data, 'n/a',
-                                               resolution=np.nan, conversion=np.nan,
+                                               resolution=-1.0, conversion=1.0,
                                                timestamps=timestamps, **kwargs)
 
     @docval({'name': 'time', 'type': float, 'doc': 'The time for the anotation'},
@@ -161,8 +161,8 @@ class IntervalSeries(TimeSeries):
         self.__interval_data = data
         super(IntervalSeries, self).__init__(name, source, data, unit,
                                              timestamps=timestamps,
-                                             resolution=np.nan,
-                                             conversion=np.nan,
+                                             resolution=-1.0,
+                                             conversion=1.0,
                                              **kwargs)
 
     @docval({'name': 'start', 'type': float, 'doc': 'The name of this TimeSeries dataset'},

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -161,8 +161,8 @@ class IntervalSeries(TimeSeries):
         self.__interval_data = data
         super(IntervalSeries, self).__init__(name, source, data, unit,
                                              timestamps=timestamps,
-                                             resolution=_default_resolution,
-                                             conversion=_default_conversion,
+                                             resolution=np.nan,
+                                             conversion=np.nan,
                                              **kwargs)
 
     @docval({'name': 'start', 'type': float, 'doc': 'The name of this TimeSeries dataset'},


### PR DESCRIPTION
## Motivation

fix #592 

## How to test the behavior?
```
from pynwb import NWBFile, NWBHDF5IO
from pynwb.misc import IntervalSeries

interval_series = IntervalSeries(data=[-1, 1], timestamps=[1, 2], name='test_interval_series', source='source')

print(interval_series.conversion)

nwbfile = NWBFile("source", "a file with header data", "NB123A", '2018-06-01T00:00:00')
nwbfile.add_acquisition(interval_series)

with NWBHDF5IO('test_interval_series.nwb', 'w') as io:
    io.write(nwbfile)

with NWBHDF5IO('test_interval_series.nwb', 'r') as io:
    nwbfile_in = io.read(nwbfile)
    print(nwbfile_in.acquisition['test_interval_series'].conversion)

import h5py
with h5py.File('test_interval_series.nwb', 'r') as file:
    print(file['acquisition']['test_interval_series']['data'].attrs['conversion'])
```

Should produce:

```
-1.0
-1.0
-1.0
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
