### PR TITLE
Increase the timeout for gallery tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,6 +99,7 @@ references:
             . ../venv/bin/activate
             pip install tox
             tox -e $TEST_TOX_ENV
+          no_output_timeout: 30m
       - save_cache:
           key: ophys-data-cache
           paths: ophys_experiment_data


### PR DESCRIPTION
## Motivation

Fixes #543 

Increase circle's default timeout duration to fix the errors while running the tests.
@bendichter 
