### PR TITLE
Avoid double write of spec

### DIFF
--- a/src/pynwb/form/spec/write.py
+++ b/src/pynwb/form/spec/write.py
@@ -33,23 +33,19 @@ class YAMLSpecWriter(SpecWriter):
         self.__outdir = getargs('outdir', kwargs)
 
     def __dump_spec(self, specs, stream):
-        yaml.main.safe_dump(json.loads(json.dumps(specs)), stream, default_flow_style=False)
+        specs_plain_dict = json.loads(json.dumps(specs))
+        yaml.main.safe_dump(specs_plain_dict, stream, default_flow_style=False)
 
     def write_spec(self, spec_file_dict, path):
-        with open(os.path.join(self.__outdir, path), 'w') as stream:
-            self.__dump_spec(spec_file_dict, stream)
-        self.reorder_yaml(os.path.join(self.__outdir, path))
+        out_fullpath = os.path.join(self.__outdir, path)
+        spec_plain_dict = json.loads(json.dumps(spec_file_dict))
+        sorted_data = self.sort_keys(spec_plain_dict)
+        with open(out_fullpath, 'w') as f_out:
+            f_out.write(yaml.dump(sorted_data, Dumper=yaml.dumper.RoundTripDumper))
 
     def write_namespace(self, namespace, path):
         with open(os.path.join(self.__outdir, path), 'w') as stream:
             self.__dump_spec({'namespaces': [namespace]}, stream)
-
-    def reorder_yaml(self, path):
-        with open(path, 'rb') as f_in:
-            data = yaml.load(f_in, Loader=yaml.loader.RoundTripLoader)
-        sorted_data = self.sort_keys(data)
-        with open(path, 'w') as f_out:
-            f_out.write(yaml.dump(sorted_data, Dumper=yaml.dumper.RoundTripDumper))
 
     def sort_keys(self, obj):
 

--- a/src/pynwb/form/spec/write.py
+++ b/src/pynwb/form/spec/write.py
@@ -40,8 +40,8 @@ class YAMLSpecWriter(SpecWriter):
         out_fullpath = os.path.join(self.__outdir, path)
         spec_plain_dict = json.loads(json.dumps(spec_file_dict))
         sorted_data = self.sort_keys(spec_plain_dict)
-        with open(out_fullpath, 'w') as f_out:
-            f_out.write(yaml.dump(sorted_data, Dumper=yaml.dumper.RoundTripDumper))
+        with open(out_fullpath, 'w') as fd_write:
+            yaml.dump(sorted_data, fd_write, Dumper=yaml.dumper.RoundTripDumper)
 
     def write_namespace(self, namespace, path):
         with open(os.path.join(self.__outdir, path), 'w') as stream:

--- a/src/pynwb/form/spec/write.py
+++ b/src/pynwb/form/spec/write.py
@@ -47,6 +47,15 @@ class YAMLSpecWriter(SpecWriter):
         with open(os.path.join(self.__outdir, path), 'w') as stream:
             self.__dump_spec({'namespaces': [namespace]}, stream)
 
+    def reorder_yaml(self, path):
+        """
+        Open a YAML file, load it as python data, sort the data, and write it back out to the
+        same path.
+        """
+        with open(path, 'rb') as fd_read:
+            data = yaml.load(fd_read, Loader=yaml.loader.RoundTripLoader)
+        self.write_spec(data, path)
+
     def sort_keys(self, obj):
 
         # Represent None as null


### PR DESCRIPTION

## Motivation

This is a shot at issue https://github.com/NeurodataWithoutBorders/pynwb/issues/614. I reorganize the YAMLSpecWriter#write_spec method to avoid writing out the spec file twice. Instead, it sorts and then writes the file once. Let me know if you'd like me to tweak anything further. I'm still getting a feel for the codebase.

(cc @oruebel)

P.S. I assume the use of `json.loads(json.dumps(x))` in this module is just a generic way to convert objects to plain dict/lists. I imagine this is not a very efficient approach, maybe there is another way to go about it. 
## How to test the behavior?

I didn't add new tests; looks like 7 existing tests hit this method. Tests pass with these changes.

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
