### PR TITLE
WIP: mk/datetime

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+arrow==0.10.0
 certifi==2018.1.18
 chardet==3.0.4
 h5py==2.7.1

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -15,12 +15,14 @@ groups:
     value: 2.0b
   datasets:
   - name: file_create_date
-    dtype: text
-    doc: 'Time file was created, UTC, and subsequent modifications to file. COMMENT:
-      Date + time, Use ISO format (eg, ISO 8601) or a format that is easy to read
-      and unambiguous. File can be created after the experiment was run, so this may
-      differ from experiment start time. Each modification to file adds new entry
-      to array.'
+    dtype: isodatetime
+    doc: 'A record of the date the file was created and of subsequent modifications.
+      COMMENT:
+        - The date is stored in UTC with local timezone offset as ISO 8601
+          formatted string: 2018-09-28T14:43:54+02:00
+        - The file can be created after the experiment was run, so this may
+          differ from the experiment start time.
+        - Each modification to the nwb file adds a new entry to the array.'
     dims:
     - '*unlimited*'
     shape:
@@ -34,10 +36,12 @@ groups:
     dtype: text
     doc: One or two sentences describing the experiment and data in the file.
   - name: session_start_time
-    dtype: text
-    doc: 'Time of experiment/session start, UTC.  COMMENT: Date + time, Use ISO format
-      (eg, ISO 8601) or an easy-to-read and unambiguous format. All times stored in
-      the file use this time as reference (ie, time zero).'
+    dtype: isodatetime
+    doc: 'Date and time of the experiment/session start.
+      COMMENT:
+        - The date is stored in UTC with local timezone offset as ISO 8601
+          formatted string: 2018-09-28T14:43:54+02:00
+        - All times stored in the file use this time as reference (ie, time zero).'
   groups:
   - name: acquisition
     doc: 'Data streams recorded from the system, including ephys, ophys, tracking,

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -447,6 +447,7 @@ class HDF5IO(FORMIO):
         "utf-8": H5_TEXT,
         "ascii": H5_BINARY,
         "str": H5_BINARY,
+        "isodatetime": H5_TEXT, # no direct mapping for np.datetime64 in hdf5 possible
         "uint32": np.uint32,
         "uint16": np.uint16,
         "uint8": np.uint8,

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -253,6 +253,7 @@ class HDF5IO(FORMIO):
             "links": dict()
         }
 
+        # why convert all byte attributes to utf8 here shouldn't this be done on write or never at all?
         for key, val in kwargs['attributes'].items():
             if isinstance(val, bytes):
                 kwargs['attributes'][key] = val.decode('UTF-8')
@@ -337,6 +338,7 @@ class HDF5IO(FORMIO):
             if h5obj.dtype.kind == 'O':    # read list of strings or list of references
                 elem1 = h5obj[0]
                 if isinstance(elem1, (text_type, binary_type)):
+                    # true for datetime
                     d = h5obj[()]
                 elif isinstance(elem1, RegionReference):
                     d = H5RegionDataset(h5obj, self)
@@ -447,7 +449,7 @@ class HDF5IO(FORMIO):
         "utf-8": H5_TEXT,
         "ascii": H5_BINARY,
         "str": H5_BINARY,
-        "isodatetime": H5_TEXT, # no direct mapping for np.datetime64 in hdf5 possible
+        "isodatetime": H5_TEXT,    # no direct mapping for np.datetime64 in hdf5 possible
         "uint32": np.uint32,
         "uint16": np.uint16,
         "uint8": np.uint8,
@@ -823,6 +825,9 @@ class HDF5IO(FORMIO):
 
     @classmethod
     def __list_fill__(cls, parent, name, data, options=None):
+
+        # this function writes the hdf5 dataset
+
         # define the io settings and data type if necessary
         io_settings = {}
         dtype = None

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -391,7 +391,7 @@ class DatasetBuilder(BaseBuilder):
     @docval({'name': 'name', 'type': str, 'doc': 'the name of the dataset'},
             {'name': 'data', 'type': ('array_data', 'scalar_data', 'data', 'DatasetBuilder', 'RegionBuilder', Iterable),
              'doc': 'the data in this dataset', 'default': None},
-            {'name': 'dtype', 'type': (type, np.dtype, str, list),
+            {'name': 'dtype', 'type': (type, np.dtype, str, list),    # does not accept datetime at this stage
              'doc': 'the datatype of this dataset', 'default': None},
             {'name': 'attributes', 'type': dict,
              'doc': 'a dictionary of attributes to create in this dataset', 'default': dict()},

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -3,8 +3,9 @@ import re
 import warnings
 from collections import OrderedDict
 from copy import copy
-
+from datetime import datetime
 from six import with_metaclass, raise_from, text_type, binary_type
+
 from ..utils import docval, getargs, ExtenderMeta, get_docval, fmt_docval_args, call_docval_func
 from ..container import Container, Data, DataRegion
 from ..spec import Spec, AttributeSpec, DatasetSpec, GroupSpec, LinkSpec, NAME_WILDCARD, NamespaceCatalog, RefSpec,\
@@ -568,6 +569,8 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                         string_type = text_type
                     elif 'ascii' in spec.dtype:
                         string_type = binary_type
+                    elif 'isodatetime' in spec.dtype:
+                        string_type = datetime.isoformat
                     if string_type is not None:
                         if spec.dims is not None:
                             ret = list(map(string_type, value))
@@ -1008,7 +1011,8 @@ class TypeMap(object):
         'float': float,
         'float64': float,
         'int': int,
-        'int32': int
+        'int32': int,
+        'isodatetime': datetime
     }
 
     def __get_type(self, spec):

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -570,6 +570,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                     elif 'ascii' in spec.dtype:
                         string_type = binary_type
                     elif 'isodatetime' in spec.dtype:
+                        # raise ValueError if not datetime or no timezone?
                         string_type = datetime.isoformat
                     if string_type is not None:
                         if spec.dims is not None:
@@ -602,6 +603,9 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             returns="the Builder representing the given Container", rtype=Builder)
     def build(self, **kwargs):
         ''' Convert an Container to a Builder representation '''
+
+        # this is the place where datasets get written to a file.
+
         container, manager, parent, source = getargs('container', 'manager', 'parent', 'source', kwargs)
         builder = getargs('builder', kwargs)
         name = manager.get_builder_name(container)
@@ -861,6 +865,9 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             {'name': 'manager', 'type': BuildManager, 'doc': 'the BuildManager for this build'})
     def construct(self, **kwargs):
         ''' Construct an Container from the given Builder '''
+
+        # the builder has read the hdf5 info and the here they are mapped to the container!
+
         builder, manager = getargs('builder', 'manager', kwargs)
         cls = manager.get_cls(builder)
         # gather all subspecs
@@ -1136,6 +1143,7 @@ class TypeMap(object):
             msg = "builder '%s' does not have a data_type" % builder.name
             raise ValueError(msg)
 
+        # another decode at builder stage without six package (4e9bad3b states legacy file support)
         if isinstance(ret, bytes):
             ret = ret.decode('UTF-8')
 

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -36,7 +36,8 @@ class DtypeHelper():
             'uint32': ["uint32", "uint"],
             'uint64': ["uint64"],
             'object': ['object'],
-            'region': ['region']
+            'region': ['region'],
+            'isodatetime': ["isodatetime", "datetime", "datetime64"]
         }
 
     # List of recommended primary dtype strings. These are the keys of primary_dtype_string_synonyms

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -1,3 +1,5 @@
+import arrow
+
 from ..form.build import ObjectMapper
 from .. import register_map
 from ..file import NWBFile
@@ -45,6 +47,18 @@ class NWBFileMap(ObjectMapper):
 
         self.map_spec('subject', general_spec.get_group('subject'))
         self.map_spec('devices', general_spec.get_group('devices').get_neurodata_type('Device'))
+
+    @ObjectMapper.constructor_arg('session_start_time')
+    def dateconversion(self, builder, manager):
+        datestr = builder.get('session_start_time').data
+        date = arrow.get(datestr).datetime
+        return date
+
+    @ObjectMapper.constructor_arg('file_create_date')
+    def dateconversion_list(self, builder, manager):
+        datestr = builder.get('file_create_date').data
+        dates = list(map(lambda d: arrow.get(d).datetime, datestr))
+        return dates
 
     @ObjectMapper.constructor_arg('file_name')
     def name(self, builder, manager):

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -1,4 +1,4 @@
-import arrow
+import arrow  # `datetime.fromisoformat` is missing in python2.7
 
 from ..form.build import ObjectMapper
 from .. import register_map
@@ -10,6 +10,11 @@ class NWBFileMap(ObjectMapper):
 
     def __init__(self, spec):
         super(NWBFileMap, self).__init__(spec)
+
+        # datetime_spec = self.spec.get_dataset("file_create_date")
+        # datetime_spec['dtype'] = 'datetime' # not changing anything here
+        # self.map_spec('file_create_date', datetime_spec)
+
         raw_ts_spec = self.spec.get_group('acquisition').get_neurodata_type('NWBDataInterface')
         self.map_spec('acquisition', raw_ts_spec)
 
@@ -47,6 +52,9 @@ class NWBFileMap(ObjectMapper):
 
         self.map_spec('subject', general_spec.get_group('subject'))
         self.map_spec('devices', general_spec.get_group('devices').get_neurodata_type('Device'))
+
+    # Note: we could also define a new class extending the ObjectMapper and
+    # override the data method with @ObjectMapper.object_attr('data')
 
     @ObjectMapper.constructor_arg('session_start_time')
     def dateconversion(self, builder, manager):


### PR DESCRIPTION
## Issue
https://github.com/NeurodataWithoutBorders/nwb-schema/issues/50#issuecomment-420761991

## Motivation

Previously, all date formats were allowed in NWB for storing datetime objects. This results in incompatibility, making the program more complicated and making **magic** functions like `dateutil.parse` necessary.

ISO 8601 date strings are a defined way for storing datetime object information as readable strings as UTC with timezone offset.

They are independent from dtype specifications of underlying modules like hdf5 or numpy which only accepts timezone naive utc formats. DateTime naive is not wanted in neuro sciences as specific information about the local time (is it morning or evening) is missing.

## How to test the behavior?
input `datetime.now()` (tz naive) to NWBFile Container class and write to hdf5. The time datasets get written as iso string. Loading a hdf5 file will result in correct datetime object in the Container class.

Simple testing can be performed by executing `docs/gallery/domain/ecephys.py`.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
