### PR TITLE
Fix wheel install tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ references:
           name: Run the tests
           command: |
             . ../venv/bin/activate
-            pip install tox
+            pip install tox==3.4.0
             tox -e $TEST_TOX_ENV
           # Install is expected to be quick. Increase timeout in case there are some network issues.
           # While pip installing tox does not output by default. Circle thinks task is dead after 10 min.


### PR DESCRIPTION
## Motivation

Fixes broken wheel installation tests.
The reason is: https://github.com/tox-dev/tox/issues/1042

