### PR TITLE
Remove RegionReferences from VectorIndex and make ROITable a DynamicTable

### DIFF
--- a/docs/gallery/domain/brain_observatory.py
+++ b/docs/gallery/domain/brain_observatory.py
@@ -175,9 +175,9 @@ plane_segmentation = image_segmentation_interface.create_plane_segmentation(
     imaging_plane=imaging_plane)
 
 for cell_specimen_id in cell_specimen_ids:
-    curr_name = str(cell_specimen_id)
+    curr_name = cell_specimen_id
     curr_image_mask = dataset.get_roi_mask_array([cell_specimen_id])[0]
-    plane_segmentation.add_roi(curr_name, [], curr_image_mask)
+    plane_segmentation.add_roi(id=curr_name, image_mask=curr_image_mask)
 
 ########################################
 # 7) Next, we add a dF/F  interface to the module.  This allows us to write the dF/F timeseries data associated with
@@ -188,7 +188,6 @@ ophys_module.add_data_interface(dff_interface)
 
 rt_region = plane_segmentation.create_roi_table_region(
     description='segmented cells with cell_specimen_ids',
-    names=[str(x) for x in cell_specimen_ids],
 )
 
 dFF_series = dff_interface.create_roi_response_series(

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -203,10 +203,10 @@ ps = mod['ImageSegmentation'].get_plane_segmentation()
 # image masks and pixel masks using :py:func:`~pynwb.ophys.PlaneSegmentation.get_image_mask`
 # :py:func:`~pynwb.ophys.PlaneSegmentation.get_pixel_mask`, respectively.
 
-img_mask1 = ps.get_image_mask(0)
-pix_mask1 = ps.get_pixel_mask(0)
-img_mask2 = ps.get_image_mask(1)
-pix_mask2 = ps.get_pixel_mask(1)
+img_mask1 = ps['image_mask'][0]
+pix_mask1 = ps['pixel_mask'][0]
+img_mask2 = ps['image_mask'][1]
+pix_mask2 = ps['pixel_mask'][1]
 
 ####################
 # To get back the fluorescence time series data, first access the :py:class:`~pynwb.ophys.Fluorescence` object we added
@@ -223,9 +223,9 @@ rrs_rois = rrs.rois
 
 ####################
 #
-# .. [#] If you pass in the image data directily,
+# .. [#] If you pass in the image data directly,
 #    you will not need to worry about distributing the image files with your NWB file. However, we recognize that
-#    using commong image formats have tools built around them, so working with the original file formats can make
+#    common image formats have tools built around them, so working with the original file formats can make
 #    one's life much simpler. NWB currently does not have the ability to read and parse native image formats. It
 #    is up to downstream users to read these file formats.
 #

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -107,13 +107,13 @@ img_mask1 = [[0.0 for x in range(w)] for y in range(h)]
 img_mask1[0][0] = 1.1
 img_mask1[1][1] = 1.2
 img_mask1[2][2] = 1.3
-ps.add_roi('1234', pix_mask1, img_mask1)
+ps.add_roi(pixel_mask=pix_mask1, image_mask=img_mask1)
 
 pix_mask2 = [(0, 0, 2.1), (1, 1, 2.2)]
 img_mask2 = [[0.0 for x in range(w)] for y in range(h)]
 img_mask2[0][0] = 2.1
 img_mask2[1][1] = 2.2
-ps.add_roi('5678', pix_mask2, img_mask2)
+ps.add_roi(pixel_mask=pix_mask2, image_mask=img_mask2)
 
 
 ####################
@@ -140,14 +140,6 @@ mod.add_data_interface(fl)
 
 
 rt_region = ps.create_roi_table_region('the first of two ROIs', region=[0])
-
-####################
-# Alternatively, you can get create a region using the names of the ROIs you added by passing in
-# the ROI names with the *names* argument. We will create the same region we did above, but
-# by using the name of the ROI.
-
-
-rt_region = ps.create_roi_table_region('the first of two ROIs', names=['1234'])
 
 ####################
 # Now that you have an :py:class:`~pynwb.ophys.ROITableRegion`, you can create your an

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -859,7 +859,7 @@ class DynamicTable(NWBDataInterface):
         if len(columns) > 0:
             if isinstance(columns[0], dict):
                 columns = tuple(TableColumn(**d) for d in columns)
-            elif not isinstance(columns[0], TableColumn):
+            elif not isinstance(columns[0], (VectorData, VectorIndex, TableColumn)):
                 raise ValueError("'columns' must be a list of TableColumns or dicts")
             if not all(len(c) == len(columns[0]) for c in columns if isinstance(c, TableColumn)):
                 raise ValueError("columns must be the same length")

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -318,6 +318,7 @@ class VectorIndex(Index):
             'doc': 'the source of this Container e.g. file name', 'default': None})
     def __init__(self, **kwargs):
         call_docval_func(super(VectorIndex, self).__init__, kwargs)
+        self.target = getargs('target', kwargs)
 
     def add_vector(self, arg):
         self.target.extend(arg)

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -885,7 +885,7 @@ class DynamicTable(NWBDataInterface):
                 elif not all(isinstance(c, (VectorData, VectorIndex, TableColumn)) for c in columns):
                     raise ValueError("'columns' must be a list of TableColumns, VectorData, or VectorIndex")
                 lens = [len(c) for c in columns if isinstance(c, (TableColumn, VectorIndex))]
-                if not all(l == lens[0] for l in lens):
+                if not all(i == lens[0] for i in lens):
                     raise ValueError("columns must be the same length")
                 if lens[0] != len(id):
                     if len(id) > 0:
@@ -894,7 +894,6 @@ class DynamicTable(NWBDataInterface):
                         id.data.extend(range(lens[0]))
         else:
             columns = list()
-            #raise ValueError("must provide both 'id' and 'columns' or neither")
 
         self.id = id
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -970,10 +970,9 @@ class DynamicTable(NWBDataInterface):
     def create_region(self, **kwargs):
         region = getargs('region', kwargs)
         if isinstance(region, slice):
-            if (region.start is not None and region.start < 0) or region.stop > len(self):
+            if (region.start is not None and region.start < 0) or (region.stop is not None and region.stop > len(self)):
                 msg = 'region slice %s is out of range for this DynamicTable of length ' % (str(region), len(self))
                 raise IndexError(msg)
-            region = list(region)
             region = list(range(*region.indices(len(self))))
         else:
             for idx in region:

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -37,6 +37,9 @@ datasets:
     dtype: text
     doc: a help string
     value: Values for a list of elements
+  - name: description
+    dtype: text
+    doc: A short description of what these vectors are
 - neurodata_type_def: VectorIndex
   neurodata_type_inc: Index
   doc: Pointers that index data values

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -16,6 +16,19 @@ datasets:
   - name: description
     dtype: text
     doc: A short description of what this column stores
+- neurodata_type_def: Index
+  neurodata_type_inc: NWBData
+  doc: Pointers that index data values
+  attributes:
+  - name: help
+    dtype: text
+    doc: a help string
+    value: indexes into a list of values for a list of elements
+  - name: target
+    dtype:
+      target_type: NWBData
+      reftype: object
+    doc: the target dataset that this index applies to
 - neurodata_type_def: VectorData
   neurodata_type_inc: NWBData
   doc: Data values indexed by pointer
@@ -24,21 +37,15 @@ datasets:
     dtype: text
     doc: a help string
     value: Values for a list of elements
-  default_name: vector_data
 - neurodata_type_def: VectorIndex
   neurodata_type_inc: NWBData
-  dtype:
-    target_type: VectorData
-    reftype: region
   doc: Pointers that index data values
   attributes:
-  - name: help
-    dtype: text
-    doc: a help string
-    value: indexes into a list of values for a list of elements
-  default_name: vector_index
-  shape:
-  - null
+  - name: target
+    dtype:
+      target_type: VectorData
+      reftype: object
+    doc: the target dataset that this index applies to
 - neurodata_type_def: ElementIdentifiers
   neurodata_type_inc: NWBData
   dtype: int
@@ -275,4 +282,10 @@ groups:
     - null
   - neurodata_type_inc: TableColumn
     doc: The columns in this dynamic table
+    quantity: '*'
+  - neurodata_type_inc: VectorData
+    doc: The vector columns in this dynamic table
+    quantity: '*'
+  - neurodata_type_inc: VectorIndex
+    doc: The indices for the vector columns in this dynamic table
     quantity: '*'

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -38,7 +38,7 @@ datasets:
     doc: a help string
     value: Values for a list of elements
 - neurodata_type_def: VectorIndex
-  neurodata_type_inc: NWBData
+  neurodata_type_inc: Index
   doc: Pointers that index data values
   attributes:
   - name: target

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -106,11 +106,11 @@ groups:
     value: Stores groups of pixels that define regions of interest from one or more
       imaging planes
   groups:
-######### BEGIN: ROITable Refactor
+  ######### BEGIN: ROITable Refactor
   - neurodata_type_def: PlaneSegmentation
     neurodata_type_inc: DynamicTable
-    attributes:
     doc: results for image segmentation of a specific imaging plane
+    attributes:
     - name: help
       dtype: text
       doc: Value is 'Results from segmentation of an imaging plane'
@@ -127,15 +127,16 @@ groups:
       - null
       - null
       - null
-      quantity: ?
+      quantity: '?'
     - neurodata_type_inc: VectorIndex
       name: pixel_mask_index
       doc: index into pixel_mask
-      quantity: ?
+      quantity: '?'
     - neurodata_type_inc: VectorData
       name: pixel_mask
       doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this
         dataset is maintained by the PlaneSegmentation
+      dtype:
       - name: x
         dtype: uint
         doc: the pixel x-coordinate
@@ -145,7 +146,7 @@ groups:
       - name: weight
         dtype: float
         doc: the weight of the pixel
-      quantity: ?
+      quantity: '?'
     groups:
     - name: reference_images
       doc: Stores image stacks segmentation mask apply to.
@@ -158,7 +159,7 @@ groups:
       doc: link to ImagingPlane group from which this TimeSeries data was generated
       target_type: ImagingPlane
     quantity: '*'
-######### END: ROITable Refactor
+  ######### END: ROITable Refactor
   default_name: ImageSegmentation
 - neurodata_type_def: ImagingPlane
   neurodata_type_inc: NWBContainer

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -1,75 +1,3 @@
-datasets:
-- neurodata_type_def: ImageMasks
-  neurodata_type_inc: NWBData
-  dtype: float
-  doc: ROI mask, represented in 2D ([y][x]) intensity image
-  attributes:
-  - name: help
-    dtype: text
-    doc: a help string
-    value: an array of image masks
-  dims:
-  - num_roi
-  - num_x
-  - num_y
-  shape:
-  - null
-  - null
-  - null
-- neurodata_type_def: PixelMasks
-  neurodata_type_inc: VectorData
-  dtype:
-  - name: x
-    dtype: uint
-    doc: the pixel x-coordinate
-  - name: y
-    dtype: uint
-    doc: the pixel y-coordinate
-  - name: weight
-    dtype: float
-    doc: the weight of the pixel
-  doc: a table for storing pixel masks
-  attributes:
-  - name: help
-    dtype: text
-    doc: a help string
-    value: a concatenated array of pixel masks
-- neurodata_type_def: ROITable
-  neurodata_type_inc: NWBData
-  dtype:
-  - name: name
-    dtype: ascii
-    doc: a name for this ROI
-  - name: pixel_mask
-    dtype:
-      reftype: region
-      target_type: PixelMasks
-    doc: a reference into a the dataset of pixel masks
-  - name: image_mask
-    dtype:
-      reftype: region
-      target_type: ImageMasks
-    doc: a reference into a the dataset of image masks
-  doc: A table for storing references to the image mask and pixel mask for each ROI
-  attributes:
-  - name: help
-    dtype: text
-    doc: a help string
-    value: A table for storing ROI data
-- neurodata_type_def: ROITableRegion
-  neurodata_type_inc: NWBData
-  dtype:
-    target_type: ROITable
-    reftype: region
-  doc: A region reference for subsetting an ROITable
-  attributes:
-  - name: help
-    dtype: text
-    doc: a help string
-    value: A region reference to an ROITable
-  - name: description
-    dtype: utf8
-    doc: a description of this subset of ROIs
 groups:
 - neurodata_type_def: TwoPhotonSeries
   neurodata_type_inc: ImageSeries
@@ -123,7 +51,7 @@ groups:
     shape:
     - null
     - null
-  - neurodata_type_inc: ROITableRegion
+  - neurodata_type_inc: DynamicTableRegion
     name: rois
     doc: a dataset referencing into an ROITable containing information on the ROIs
       stored in this timeseries
@@ -178,30 +106,43 @@ groups:
     value: Stores groups of pixels that define regions of interest from one or more
       imaging planes
   groups:
+######### BEGIN: ROITable Refactor
   - neurodata_type_def: PlaneSegmentation
-    neurodata_type_inc: NWBContainer
-    doc: Group name is human-readable description of imaging plane
+    neurodata_type_inc: DynamicTable
     attributes:
+    doc: results for image segmentation of a specific imaging plane
     - name: help
       dtype: text
       doc: Value is 'Results from segmentation of an imaging plane'
       value: Results from segmentation of an imaging plane
     datasets:
-    - name: description
-      dtype: text
-      doc: Description of image plane, recording wavelength, depth, etc
-      quantity: '?'
-    - neurodata_type_inc: PixelMasks
-      name: pixel_masks
-      doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this
-        dataset is maintained by the ROITable
-    - neurodata_type_inc: ImageMasks
-      name: image_masks
+    - neurodata_type_inc: TableColumn
+      name: image_mask
       doc: ROI masks for each ROI
-    - neurodata_type_inc: ROITable
-      name: rois
-      doc: ROIs resulting from the segmentation of the imaging plane linked in this
-        PlaneSegmentation
+      dims:
+      - num_roi
+      - num_x
+      - num_y
+      shape:
+      - null
+      - null
+      - null
+      quantity: ?
+    - neurodata_type_inc: VectorIndex
+      name: pixel_mask_index
+      doc: index into pixel_mask
+      shape:
+      - null
+      - null
+      quantity: ?
+    - neurodata_type_inc: VectorData
+      name: pixel_mask
+      doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this
+        dataset is maintained by the PlaneSegmentation
+      shape:
+      - null
+      - null
+      quantity: ?
     groups:
     - name: reference_images
       doc: Stores image stacks segmentation mask apply to.
@@ -214,6 +155,7 @@ groups:
       doc: link to ImagingPlane group from which this TimeSeries data was generated
       target_type: ImagingPlane
     quantity: '*'
+######### END: ROITable Refactor
   default_name: ImageSegmentation
 - neurodata_type_def: ImagingPlane
   neurodata_type_inc: NWBContainer

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -131,17 +131,20 @@ groups:
     - neurodata_type_inc: VectorIndex
       name: pixel_mask_index
       doc: index into pixel_mask
-      shape:
-      - null
-      - null
       quantity: ?
     - neurodata_type_inc: VectorData
       name: pixel_mask
       doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this
         dataset is maintained by the PlaneSegmentation
-      shape:
-      - null
-      - null
+      - name: x
+        dtype: uint
+        doc: the pixel x-coordinate
+      - name: y
+        dtype: uint
+        doc: the pixel y-coordinate
+      - name: weight
+        dtype: float
+        doc: the weight of the pixel
       quantity: ?
     groups:
     - name: reference_images

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -381,8 +381,6 @@ class NWBFile(MultiContainerInterface):
             {'name': 'location', 'type': str, 'doc': 'the location of electrode within the subject e.g. brain region'},
             {'name': 'filtering', 'type': str, 'doc': 'description of hardware filtering'},
             {'name': 'group', 'type': ElectrodeGroup, 'doc': 'the ElectrodeGroup object to add to this NWBFile'},
-            {'name': 'group_name', 'type': str, 'doc': 'the ElectrodeGroup object to add to this NWBFile',
-             'default': None},
             {'name': 'id', 'type': int, 'doc': 'a unique identifier for the electrode', 'default': None},
             allow_extra=True)
     def add_electrode(self, **kwargs):
@@ -391,7 +389,7 @@ class NWBFile(MultiContainerInterface):
         See :py:meth:`~pynwb.core.DynamicTable.add_row` for more details.
 
         Required fields are *x*, *y*, *z*, *imp*, *location*, *filtering*,
-        *description*, *group* and any columns that have been added
+        *group* and any columns that have been added
         (through calls to `add_electrode_columns`).
         """
         self.__check_electrodes()

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -161,11 +161,11 @@ class NWBFile(MultiContainerInterface):
                      'surgery',
                      'virus',
                      'stimulus_notes',
-                     {'name': 'electrodes', 'child': True},
-                     {'name': 'epochs', 'child': True},
-                     {'name': 'trials', 'child': True},
-                     {'name': 'units', 'child': True},
-                     {'name': 'subject', 'child': True},
+                     {'name': 'electrodes', 'child': True,  'required_name': 'electrodes'},
+                     {'name': 'epochs', 'child': True, 'required_name': 'epochs'},
+                     {'name': 'trials', 'child': True, 'required_name': 'trials'},
+                     {'name': 'units', 'child': True, 'required_name': 'units'},
+                     {'name': 'subject', 'child': True, 'required_name': 'subject'},
                      'epoch_tags',)
 
     @docval({'name': 'source', 'type': str, 'doc': 'the source of the data'},
@@ -266,6 +266,8 @@ class NWBFile(MultiContainerInterface):
         self.modules = getargs('modules', kwargs)
         epochs = getargs('epochs', kwargs)
         if epochs is not None:
+            if epochs.name != 'epochs':
+                raise ValueError("NWBFile.epochs must be named 'epochs'")
             self.epochs = epochs
         self.epoch_tags = getargs('epoch_tags', kwargs)
 

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -369,12 +369,15 @@ class HDF5IO(FORMIO):
         return ret
 
     def __read_ref(self, h5obj):
+        ret = None
         if isinstance(h5obj, Dataset):
-            return self.__read_dataset(h5obj)
+            ret = self.__read_dataset(h5obj)
         elif isinstance(h5obj, Group):
-            return self.__read_group(h5obj)
+            ret = self.__read_group(h5obj)
         else:
             raise ValueError("h5obj must be a Dataset or a Group - got %s" % str(h5obj))
+        self.__set_built(h5obj.file.filename, h5obj.name, ret)
+        return ret
 
     def open(self):
         open_flag = self.__mode

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -370,13 +370,15 @@ class HDF5IO(FORMIO):
 
     def __read_ref(self, h5obj):
         ret = None
-        if isinstance(h5obj, Dataset):
-            ret = self.__read_dataset(h5obj)
-        elif isinstance(h5obj, Group):
-            ret = self.__read_group(h5obj)
-        else:
-            raise ValueError("h5obj must be a Dataset or a Group - got %s" % str(h5obj))
-        self.__set_built(h5obj.file.filename, h5obj.name, ret)
+        ret = self.__get_built(h5obj.file.filename, h5obj.name)
+        if ret is None:
+            if isinstance(h5obj, Dataset):
+                ret = self.__read_dataset(h5obj)
+            elif isinstance(h5obj, Group):
+                ret = self.__read_group(h5obj)
+            else:
+                raise ValueError("h5obj must be a Dataset or a Group - got %s" % str(h5obj))
+            self.__set_built(h5obj.file.filename, h5obj.name, ret)
         return ret
 
     def open(self):

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -266,6 +266,7 @@ class HDF5IO(FORMIO):
             if not (sub_h5obj is None):
                 link_type = h5obj.get(k, getlink=True)
                 if isinstance(link_type, SoftLink) or isinstance(link_type, ExternalLink):
+                    # Reading links might be better suited in its own function
                     # get path of link (the key used for tracking what's been built)
                     target_path = link_type.path
                     builder_name = os.path.basename(target_path)
@@ -278,7 +279,9 @@ class HDF5IO(FORMIO):
                         else:
                             builder = self.__read_group(sub_h5obj, builder_name, ignore=ignore)
                         self.__set_built(sub_h5obj.file.filename, target_path, builder)
-                    kwargs['links'][builder_name] = LinkBuilder(builder, k, source=self.__path)
+                    link_builder = LinkBuilder(builder, k, source=self.__path)
+                    link_builder.written = True
+                    kwargs['links'][builder_name] = link_builder
                 else:
                     builder = self.__get_built(sub_h5obj.file.filename, sub_h5obj.name)
                     obj_type = None
@@ -579,6 +582,9 @@ class HDF5IO(FORMIO):
         else:
             msg = 'cannot create external link to %s' % path
             raise ValueError(msg)
+        if name in parent:
+            import pdb
+            pdb.set_trace()
         parent[name] = link_obj
         builder.written = True
         return link_obj

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -263,7 +263,7 @@ class GroupBuilder(BaseBuilder):
     @docval({'name': 'builder', 'type': 'GroupBuilder', 'doc': 'the GroupBuilder that represents this subgroup'})
     def set_group(self, **kwargs):
         ''' Add a subgroup to this group '''
-        name, builder, = getargs('name', 'builder', kwargs)
+        builder = getargs('builder', kwargs)
         self.__set_builder(builder, GroupBuilder.__group)
 
     @docval({'name': 'target', 'type': ('GroupBuilder', 'DatasetBuilder'), 'doc': 'the target Builder'},

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -37,6 +37,8 @@ class Builder(with_metaclass(ABCMeta, dict)):
 
     @written.setter
     def written(self, s):
+        if self.__written and not s:
+            raise ValueError("cannot change written to not written")
         self.__written = s
 
     @property

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -190,6 +190,8 @@ class BuildManager(object):
             if parent_builder is not None:
                 result.parent = self.__get_proxy_builder(parent_builder)
             else:
+                # we are at the top of the hierarchy,
+                # so it must be time to resolve parents
                 self.__resolve_parents(result)
             self.prebuilt(result, builder)
         result.set_modified(False)
@@ -470,12 +472,6 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             n = spec.name
         elif hasattr(spec, 'data_type_def') and spec.data_type_def is not None:
             n = spec.data_type_def  # noqa: F841
-        # AJTRITT 05-Oct-18 pdb I don't think we need this anymore.
-        # if attr_name in self.__attr2spec:
-        #     existing = self.__attr2spec.pop(attr_name)
-        #     if existing is not spec:
-        #
-        #         self.__spec2attr.pop(existing)
         self.__spec2attr[spec] = attr_name
         self.__attr2spec[attr_name] = spec
 

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -243,6 +243,24 @@ class BuildManager(object):
         spec, builder = getargs('spec', 'builder', kwargs)
         return self.__type_map.get_subspec(spec, builder)
 
+    @docval({'name': 'builder', 'type': (DatasetBuilder, GroupBuilder, LinkBuilder),
+             'doc': 'the builder to get the sub-specification for'})
+    def get_builder_ns(self, **kwargs):
+        '''
+        Get the namespace of a builder
+        '''
+        builder = getargs('builder', kwargs)
+        return self.__type_map.get_builder_ns(builder)
+
+    @docval({'name': 'builder', 'type': (DatasetBuilder, GroupBuilder, LinkBuilder),
+             'doc': 'the builder to get the data_type for'})
+    def get_builder_dt(self, **kwargs):
+        '''
+        Get the data_type of a builder
+        '''
+        builder = getargs('builder', kwargs)
+        return self.__type_map.get_builder_dt(builder)
+
 
 _const_arg = '__constructor_arg'
 
@@ -370,11 +388,6 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         self.__carg2spec = dict()
         self.__map_spec(spec)
 
-        self.spec2attr = self.__spec2attr    # pdb
-        self.attr2spec = self.__attr2spec    # pdb
-        self.spec2carg = self.__spec2carg    # pdb
-        self.carg2spec = self.__carg2spec    # pdb
-
     @property
     def spec(self):
         ''' the Spec used in this ObjectMapper '''
@@ -457,10 +470,12 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
             n = spec.name
         elif hasattr(spec, 'data_type_def') and spec.data_type_def is not None:
             n = spec.data_type_def  # noqa: F841
-        if attr_name in self.__attr2spec:
-            existing = self.__attr2spec.pop(attr_name)
-            if existing is not spec:
-                self.__spec2attr.pop(existing)
+        # AJTRITT 05-Oct-18 pdb I don't think we need this anymore.
+        # if attr_name in self.__attr2spec:
+        #     existing = self.__attr2spec.pop(attr_name)
+        #     if existing is not spec:
+        #
+        #         self.__spec2attr.pop(existing)
         self.__spec2attr[spec] = attr_name
         self.__attr2spec[attr_name] = spec
 
@@ -813,46 +828,96 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
 
     def __get_subspec_values(self, builder, spec, manager):
         ret = dict()
-        for h5attr_name, h5attr_val in builder.attributes.items():
-            subspec = spec.get_attribute(h5attr_name)
-            if subspec is None:
+        # First get attributes
+        attributes = builder.attributes
+        for attr_spec in spec.attributes:
+            attr_val = attributes.get(attr_spec.name)
+            if attr_val is None:
                 continue
-            if isinstance(h5attr_val, (GroupBuilder, DatasetBuilder)):
-                ret[subspec] = manager.construct(h5attr_val)
-            elif isinstance(h5attr_val, RegionBuilder):
+            if isinstance(attr_val, (GroupBuilder, DatasetBuilder)):
+                ret[attr_spec] = manager.construct(attr_val)
+            elif isinstance(attr_val, RegionBuilder):
                 raise ValueError("RegionReferences as attributes is not yet supported")
-            elif isinstance(h5attr_val, ReferenceBuilder):
-                ret[subspec] = manager.construct(h5attr_val.builder)
+            elif isinstance(attr_val, ReferenceBuilder):
+                ret[attr_spec] = manager.construct(attr_val.builder)
             else:
-                ret[subspec] = h5attr_val
-        if isinstance(builder, GroupBuilder):
-            for sub_builder_name, sub_builder in builder.items():
-                # GroupBuilder.items will return attributes as well, need to skip non Builder items
-                if not isinstance(sub_builder, Builder):
-                    continue
-                subspec = manager.get_subspec(spec, sub_builder)
-                link_name = None
-                if isinstance(sub_builder, LinkBuilder):
-                    link_name = sub_builder.name  # noqa: F841
-                if subspec is not None:
-                    if isinstance(sub_builder, LinkBuilder):
-                        sub_builder = sub_builder.builder
-                    if self.__data_type_key in sub_builder.attributes or \
-                       not (subspec.data_type_inc is None and subspec.data_type_def is None):
-                        val = manager.construct(sub_builder)
-                        if subspec.is_many():
-                            if subspec in ret:
-                                ret[subspec].append(val)
-                            else:
-                                ret[subspec] = [val]
-                        else:
-                            ret[subspec] = val
-                    else:
-                        result = self.__get_subspec_values(sub_builder, subspec, manager)
-                        ret.update(result)
-        else:
+                ret[attr_spec] = attr_val
+        if isinstance(spec, GroupSpec):
+            if not isinstance(builder, GroupBuilder):
+                raise ValueError("__get_subspec_values - must pass GroupBuilder with GroupSpec")
+            # first aggregate links by data type and separate them
+            # by group and dataset
+            groups = dict(builder.groups)             # make a copy so we can separate links
+            datasets = dict(builder.datasets)         # make a copy so we can separate links
+            links = builder.links
+            link_dt = dict()
+            for link_builder in links.values():
+                target = link_builder.builder
+                if isinstance(target, DatasetBuilder):
+                    datasets[link_builder.name] = target
+                else:
+                    groups[link_builder.name] = target
+                dt = manager.get_builder_dt(target)
+                if dt is not None:
+                    link_dt.setdefault(dt, list()).append(target)
+            # now assign links to their respective specification
+            for subspec in spec.links:
+                if subspec.name is not None:
+                    ret[subspec] = manager.construct(links[subspec.name].builder)
+                else:
+                    sub_builder = link_dt.get(subspec.target_type)
+                    if sub_builder is not None:
+                        ret[subspec] = self.__flatten(sub_builder, subspec, manager)
+            # now process groups and datasets
+            self.__get_sub_builders(groups, spec.groups, manager, ret)
+            self.__get_sub_builders(datasets, spec.datasets, manager, ret)
+        elif isinstance(spec, DatasetSpec):
+            if not isinstance(builder, DatasetBuilder):
+                raise ValueError("__get_subspec_values - must pass DatasetBuilder with DatasetSpec")
             ret[spec] = builder.data
         return ret
+
+    def __get_sub_builders(self, sub_builders, subspecs, manager, ret):
+        # index builders by data_type
+        builder_dt = dict()
+        for g in sub_builders.values():
+            try:
+                dt = manager.get_builder_dt(g)
+                ns = manager.get_builder_ns(g)
+            except ValueError as v:
+                continue
+            if dt is not None:
+                for parent_dt in manager.namespace_catalog.get_hierarchy(ns, dt):
+                    builder_dt.setdefault(parent_dt, list()).append(g)
+        for subspec in subspecs:
+            # first get data type for the spec
+            if subspec.data_type_def is not None:
+                dt = subspec.data_type_def
+            elif subspec.data_type_inc is not None:
+                dt = subspec.data_type_inc
+            else:
+                dt = None
+            # use name if we can, otherwise use data_data
+            if subspec.name is None:
+                sub_builder = builder_dt.get(dt)
+                if sub_builder is not None:
+                    sub_builder = self.__flatten(sub_builder, subspec, manager)
+                    ret[subspec] = sub_builder
+            else:
+                sub_builder = sub_builders.get(subspec.name)
+                if sub_builder is None:
+                    continue
+                if dt is None:
+                    # recurse
+                    ret.update(self.__get_subspec_values(sub_builder, subspec, manager))
+                else:
+                    ret[subspec] = manager.construct(sub_builder)
+
+    def __flatten(self, sub_builder, subspec, manager):
+        tmp = [manager.construct(b) for b in sub_builder]
+        if len(tmp) == 1 and not subspec.is_many():
+            tmp = tmp[0]
+        return tmp
 
     @docval({'name': 'builder', 'type': (DatasetBuilder, GroupBuilder),
              'doc': 'the builder to construct the Container from'},
@@ -863,7 +928,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         cls = manager.get_cls(builder)
         # gather all subspecs
         subspecs = self.__get_subspec_values(builder, self.spec, manager)
-        # get the constructor argument each specification corresponds to
+        # get the constructor argument that each specification corresponds to
         const_args = dict()
         for subspec, value in subspecs.items():
             const_arg = self.get_const_arg(subspec)
@@ -886,7 +951,6 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                 continue
             kwargs[argname] = val
         try:
-
             obj = cls(**kwargs)
             obj.container_source = builder.source
         except Exception as ex:
@@ -1132,7 +1196,13 @@ class TypeMap(object):
                 self.register_container_type(namespace, data_type, ret)
         return ret
 
-    def get_builder_dt(self, builder):
+    @docval({'name': 'builder', 'type': (DatasetBuilder, GroupBuilder, LinkBuilder),
+             'doc': 'the builder to get the data_type for'})
+    def get_builder_dt(self, **kwargs):
+        '''
+        Get the data_type of a builder
+        '''
+        builder = getargs('builder', kwargs)
         ret = builder.attributes.get(self.__ns_catalog.group_spec_cls.type_key())
         if ret is None:
             msg = "builder '%s' does not have a data_type" % builder.name
@@ -1143,7 +1213,13 @@ class TypeMap(object):
 
         return ret
 
-    def get_builder_ns(self, builder):
+    @docval({'name': 'builder', 'type': (DatasetBuilder, GroupBuilder, LinkBuilder),
+             'doc': 'the builder to get the sub-specification for'})
+    def get_builder_ns(self, **kwargs):
+        '''
+        Get the namespace of a builder
+        '''
+        builder = getargs('builder', kwargs)
         if isinstance(builder, LinkBuilder):
             builder = builder.builder
         ret = builder.attributes.get('namespace')

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -370,6 +370,11 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         self.__carg2spec = dict()
         self.__map_spec(spec)
 
+        self.spec2attr = self.__spec2attr    # pdb
+        self.attr2spec = self.__attr2spec    # pdb
+        self.spec2carg = self.__spec2carg    # pdb
+        self.carg2spec = self.__carg2spec    # pdb
+
     @property
     def spec(self):
         ''' the Spec used in this ObjectMapper '''
@@ -476,10 +481,6 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
     def map_const_arg(self, **kwargs):
         """ Map an attribute to spec. Use this to override default behavior """
         const_arg, spec = getargs('const_arg', 'spec', kwargs)
-        if const_arg in self.__carg2spec:
-            existing = self.__carg2spec.pop(const_arg)
-            if existing is not spec:
-                self.__spec2carg.pop(existing)
         self.__spec2carg[spec] = const_arg
         self.__carg2spec[const_arg] = spec
 
@@ -867,6 +868,10 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         for subspec, value in subspecs.items():
             const_arg = self.get_const_arg(subspec)
             if const_arg is not None:
+                if isinstance(subspec, BaseStorageSpec) and subspec.is_many():
+                    existing_value = const_args.get(const_arg)
+                    if isinstance(existing_value, list):
+                        value = existing_value + value
                 const_args[const_arg] = value
         # build kwargs for the constructor
         kwargs = dict()
@@ -881,6 +886,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                 continue
             kwargs[argname] = val
         try:
+
             obj = cls(**kwargs)
             obj.container_source = builder.source
         except Exception as ex:

--- a/src/pynwb/form/container.py
+++ b/src/pynwb/form/container.py
@@ -83,6 +83,8 @@ class Container(with_metaclass(abc.ABCMeta, object)):
             if isinstance(self.__parent, Container):
                 raise Exception('cannot reassign parent')
             else:
+                if parent_container is None:
+                    raise ValueError("got None for parent of '%s' - cannot overwrite Proxy with NoneType" % self.name)
                 if self.__parent.matches(parent_container):
                     self.__parent = parent_container
                 else:

--- a/src/pynwb/form/container.py
+++ b/src/pynwb/form/container.py
@@ -18,6 +18,9 @@ class Container(with_metaclass(abc.ABCMeta, object)):
         self.__children = list()
         self.__modified = True
 
+    def __repr__(self):
+        return "<%s '%s' at 0x%d>" % (self.__class__.__name__, self.name, id(self))
+
     @property
     def modified(self):
         return self.__modified

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -860,7 +860,6 @@ class GroupSpec(BaseStorageSpec):
                 self.__overridden_links.add(link.name)
                 continue
             self.set_link(link)
-        newdt = self.__new_data_types #pdb
         # resolve inherited data_types
         for dt_spec in data_types:
             if isinstance(dt_spec, LinkSpec):

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -576,8 +576,6 @@ class DtypeSpec(ConstructableDict):
     def build_const_args(cls, spec_dict):
         ''' Build constructor arguments for this Spec class from a dictionary '''
         ret = super(DtypeSpec, cls).build_const_args(spec_dict)
-        if 'dtype' not in ret:
-            print(ret)
         if isinstance(ret['dtype'], list):
             ret['dtype'] = list(map(cls.build_const_args, ret['dtype']))
         elif isinstance(ret['dtype'], dict):

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -11,6 +11,10 @@ class DynamicTableMap(ObjectMapper):
         super(DynamicTableMap, self).__init__(spec)
         columns_spec = spec.get_neurodata_type('TableColumn')
         self.map_spec('columns', columns_spec)
+        vector_data_spec = spec.get_neurodata_type('VectorData')
+        vector_index_spec = spec.get_neurodata_type('VectorIndex')
+        self.map_spec('columns', vector_data_spec)
+        self.map_spec('columns', vector_index_spec)
 
     @ObjectMapper.object_attr('colnames')
     def attr_columns(self, container, manager):

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -12,11 +12,9 @@ class NWBFileMap(ObjectMapper):
         self.map_spec('acquisition', raw_ts_spec)
 
         stimulus_spec = self.spec.get_group('stimulus')
-        presentation_ts_spec = stimulus_spec.get_group('presentation')\
-                                            .get_neurodata_type('TimeSeries')
-        self.map_spec('stimulus', presentation_ts_spec)
-        stimulus_ts_spec = stimulus_spec.get_group('templates').get_neurodata_type('TimeSeries')
-        self.map_spec('stimulus_template', stimulus_ts_spec)
+        self.unmap(stimulus_spec)
+        self.map_spec('stimulus', stimulus_spec.get_group('presentation').get_neurodata_type('TimeSeries'))
+        self.map_spec('stimulus_template', stimulus_spec.get_group('templates').get_neurodata_type('TimeSeries'))
 
         epochs_spec = self.spec.get_group('epochs')
         self.map_spec('epochs', epochs_spec)

--- a/src/pynwb/io/ophys.py
+++ b/src/pynwb/io/ophys.py
@@ -1,4 +1,3 @@
-from ..form.build import ObjectMapper
 from .. import register_map
 
 from ..ophys import PlaneSegmentation

--- a/src/pynwb/io/ophys.py
+++ b/src/pynwb/io/ophys.py
@@ -1,12 +1,12 @@
 from ..form.build import ObjectMapper
 from .. import register_map
 
-from ..ophys import PlaneSegmentation, ROITable, ROITableRegion
-from .core import NWBDataMap, NWBTableRegionMap
+from ..ophys import PlaneSegmentation
+from .core import DynamicTableMap
 
 
 @register_map(PlaneSegmentation)
-class PlaneSegmentationMap(ObjectMapper):
+class PlaneSegmentationMap(DynamicTableMap):
 
     # This might be needed for 2.0 as well
     def __init__(self, spec):
@@ -14,14 +14,3 @@ class PlaneSegmentationMap(ObjectMapper):
 
         reference_images_spec = self.spec.get_group('reference_images').get_neurodata_type('ImageSeries')
         self.map_spec('reference_images', reference_images_spec)
-
-
-@register_map(ROITable)
-class ROITableMap(NWBDataMap):
-    def __init__(self, spec):
-        super(ROITableMap, self).__init__(spec)
-
-
-@register_map(ROITableRegion)
-class ROITableRegionMap(NWBTableRegionMap):
-    pass

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -229,7 +229,7 @@ class UnitTimes(NWBDataInterface):
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'})
     def get_unit_spike_times(self, **kwargs):
         index = getargs('index', kwargs)
-        return np.array(self.spike_times_index[index])
+        return np.asarray(self.spike_times_index[index])
 
     @docval({'name': 'unit_id', 'type': int, 'doc': 'the unit to add spike times for'},
             {'name': 'spike_times', 'type': ('array_data',), 'doc': 'the spike times for the unit'},

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -5,7 +5,7 @@ from .form.utils import docval, getargs, popargs, call_docval_func
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_conversion, _default_resolution
-from .core import NWBContainer, NWBDataInterface, ElementIdentifiers, VectorData, VectorIndex, IndexedVector
+from .core import NWBContainer, NWBDataInterface, ElementIdentifiers, VectorData, VectorIndex
 
 
 @register_class('AnnotationSeries', CORE_NAMESPACE)
@@ -216,17 +216,20 @@ class UnitTimes(NWBDataInterface):
         if not isinstance(spike_times, VectorData):
             spike_times = VectorData('spike_times', spike_times)
         if not isinstance(spike_times_index, VectorIndex):
-            spike_times_index = VectorIndex('spike_times_index', spike_times_index)
+            spike_times_index = VectorIndex('spike_times_index', spike_times_index, spike_times)
         self.unit_ids = unit_ids
         self.spike_times = spike_times
         self.spike_times_index = spike_times_index
-        self.__iv = IndexedVector(self.spike_times, self.spike_times_index)
+
+    @property
+    def times(self):
+        return self.spike_times_index
 
     @docval({'name': 'index', 'type': int,
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'})
     def get_unit_spike_times(self, **kwargs):
         index = getargs('index', kwargs)
-        return np.array(self.__iv.get_vector(index))
+        return np.array(self.spike_times_index[index])
 
     @docval({'name': 'unit_id', 'type': int, 'doc': 'the unit to add spike times for'},
             {'name': 'spike_times', 'type': ('array_data',), 'doc': 'the spike times for the unit'},
@@ -234,4 +237,4 @@ class UnitTimes(NWBDataInterface):
     def add_spike_times(self, **kwargs):
         unit_id, spike_times = getargs('unit_id', 'spike_times', kwargs)
         self.unit_ids.append(unit_id)
-        return self.__iv.add_vector(spike_times)
+        return self.spike_times_index.add_vector(spike_times)

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -9,7 +9,7 @@ from .form import get_region_slicer
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, MultiContainerInterface, NWBData, VectorData, NWBTable, NWBTableRegion
+from .core import NWBContainer, MultiContainerInterface, NWBData, VectorData, DynamicTable, DynamicTableRegion
 from .device import Device
 
 
@@ -217,72 +217,13 @@ class MotionCorrection(MultiContainerInterface):
     _help = "Image stacks whose frames have been shifted (registered) to account for motion."
 
 
-_roit_docval = [
-    {'name': 'name', 'type': str, 'help': 'a name for this ROI'},
-    {'name': 'pixel_mask', 'type': RegionSlicer, 'help': 'a region into a PixelMasks'},
-    {'name': 'image_mask', 'type': RegionSlicer, 'help': 'a region into an ImageMasks'},
-]
-
-
-@register_class('ROITable', CORE_NAMESPACE)
-class ROITable(NWBTable):
-
-    __columns__ = _roit_docval
-
-    __defaultname__ = 'rois'
-
-
-@register_class('ROITableRegion', CORE_NAMESPACE)
-class ROITableRegion(NWBTableRegion):
-    '''A subsetting of an ElectrodeTable'''
-
-    __nwbfields__ = ('description',)
-
-    @docval({'name': 'table', 'type': ROITable, 'doc': 'the ElectrodeTable this region applies to'},
-            {'name': 'region', 'type': (slice, list, tuple, RegionReference), 'doc': 'the indices of the table'},
-            {'name': 'description', 'type': str, 'doc': 'a brief description of what this electrode is'},
-            {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'electrodes'})
-    def __init__(self, **kwargs):
-        call_docval_func(super(ROITableRegion, self).__init__, kwargs)
-        self.description = getargs('description', kwargs)
-
-
-@register_class('PixelMasks', CORE_NAMESPACE)
-class PixelMasks(VectorData):
-
-    @docval({'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the pixel mask data'},
-            {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'pixel_masks'},
-            {'name': 'parent', 'type': 'NWBContainer',
-             'doc': 'the parent Container for this Container', 'default': None},
-            {'name': 'container_source', 'type': object,
-            'doc': 'the source of this Container e.g. file name', 'default': None})
-    def __init__(self, **kwargs):
-        call_docval_func(super(PixelMasks, self).__init__, kwargs)
-
-
-@register_class('ImageMasks', CORE_NAMESPACE)
-class ImageMasks(NWBData):
-
-    @docval({'name': 'data', 'type': ('array_data', 'data'), 'doc': 'the image mask data'},
-            {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': 'image_masks'},
-            {'name': 'parent', 'type': 'NWBContainer',
-             'doc': 'the parent Container for this Container', 'default': None},
-            {'name': 'container_source', 'type': object,
-            'doc': 'the source of this Container e.g. file name', 'default': None})
-    def __init__(self, **kwargs):
-        call_docval_func(super(ImageMasks, self).__init__, kwargs)
-
-
 @register_class('PlaneSegmentation', CORE_NAMESPACE)
-class PlaneSegmentation(NWBContainer):
+class PlaneSegmentation(DynamicTable):
     """
     Image segmentation of a specific imaging plane
     """
 
     __nwbfields__ = ('description',
-                     {'name': 'rois', 'child': True},
-                     {'name': 'pixel_masks', 'child': True},
-                     {'name': 'image_masks', 'child': True},
                      'imaging_plane',
                      {'name': 'reference_images', 'child': True})
 
@@ -294,84 +235,43 @@ class PlaneSegmentation(NWBContainer):
             {'name': 'name', 'type': str, 'doc': 'name of PlaneSegmentation.', 'default': None},
             {'name': 'reference_images', 'type': (ImageSeries, list, dict, tuple), 'default': None,
              'doc': 'One or more image stacks that the masks apply to (can be oneelement stack).'},
-            {'name': 'rois', 'type': ROITable, 'default': None,
-             'doc': 'the table holding references to pixel and image masks'},
-            {'name': 'pixel_masks', 'type': ('array_data', 'data', PixelMasks), 'default': list(),
-             'doc': 'a concatenated list of pixel masks for all ROIs stored in this PlaneSegmenation'},
-            {'name': 'image_masks', 'type': ('array_data', ImageMasks), 'default': list(),
-             'doc': 'an image mask for each ROI in this PlaneSegmentation'})
+            {'name': 'columns', 'type': (tuple, list), 'doc': 'the columns in this table', 'default': None},
+            {'name': 'colnames', 'type': 'array_data', 'doc': 'the names of the columns in this table',
+            'default': None})
     def __init__(self, **kwargs):
-        description, imaging_plane, reference_images, rois, pm, im = popargs(
-            'description', 'imaging_plane', 'reference_images', 'rois', 'pixel_masks', 'image_masks', kwargs)
+        description, imaging_plane, reference_images = popargs(
+            'description', 'imaging_plane', 'reference_images', kwargs)
         if kwargs.get('name') is None:
             kwargs['name'] = imaging_plane.name
+        columns, colnames = getargs('columns', 'colnames', kwargs)
         pargs, pkwargs = fmt_docval_args(super(PlaneSegmentation, self).__init__, kwargs)
         super(PlaneSegmentation, self).__init__(*pargs, **pkwargs)
         self.description = description
         self.imaging_plane = imaging_plane
         self.reference_images = reference_images
-        self.pixel_masks = pm if isinstance(pm, PixelMasks) else PixelMasks(pm)
-        self.image_masks = im if isinstance(im, ImageMasks) else ImageMasks(im)
-        self.rois = ROITable() if rois is None else rois
 
-    @docval({'name': 'name', 'type': str, 'help': 'a name for this ROI'},
-            {'name': 'pixel_mask', 'type': 'array_data',
-             'doc': 'the index of the ROI in roi_ids to retrieve the pixel mask for'},
-            {'name': 'image_mask', 'type': 'array_data',
-             'doc': 'the index of the ROI in roi_ids to retrieve the pixel mask for'})
+    def __check_image_mask(self):
+        self.add_column(name='image_mask', description='Image masks for each ROI')
+
+    def __check_pixel_mask(self):
+        self.add_vector_column(name='pixel_mask', description='Pixel masks for each ROI')
+
+    @docval({'name': 'pixel_mask', 'type': 'array_data', 'doc': 'the pixel mask', 'default': None},
+            {'name': 'image_mask', 'type': 'array_data', 'doc': 'the image mask for this ROI', 'default': None},
+            {'name': 'id', 'type': int, 'help': 'the ID for the ROI', 'default': None},
+            allow_extra=True)
     def add_roi(self, **kwargs):
-        name, pixel_mask, image_mask = getargs('name', 'pixel_mask', 'image_mask', kwargs)
-        n_rois = len(self.rois)
-        im_region = get_region_slicer(self.image_masks, [n_rois])
-        self.image_masks.append(image_mask)
-        n_pixels = len(self.pixel_masks)
-        self.pixel_masks.extend(pixel_mask)
-        pm_region = get_region_slicer(self.pixel_masks, slice(n_pixels, n_pixels + len(pixel_mask)))
-        self.rois.add_row(name, pm_region, im_region)
-        return n_rois+1
-
-    @docval({'name': 'index', 'type': int,
-             'doc': 'the index of the ROI to retrieve the pixel mask for'})
-    def get_pixel_mask(self, **kwargs):
-        index = getargs('index', kwargs)
-        return self.rois[index]['pixel_mask']
-
-    @docval({'name': 'index', 'type': int,
-             'doc': 'the index of the ROI to retrieve the image mask for'})
-    def get_image_mask(self, **kwargs):
-        index = getargs('index', kwargs)
-        return self.rois[index]['image_mask']
-
-    @docval({'name': 'description', 'type': str, 'doc': 'a brief description of what this electrode is'},
-            {'name': 'names', 'type': (list, tuple), 'doc': 'the names of the ROIs', 'default': None},
-            {'name': 'region', 'type': (slice, list, tuple, RegionReference), 'doc': 'the indices of the table',
-             'default': None},
-            {'name': 'name', 'type': str, 'doc': 'the name of the ROITableRegion', 'default': 'rois'})
-    def create_roi_table_region(self, **kwargs):
-        desc = getargs('description', kwargs)
-        name = getargs('name', kwargs)
-        region = getargs('region', kwargs)
-        names = getargs('names', kwargs)
-        if region is None and names is None:
-            msg = "must provide 'region' or 'names'"
-            raise ValueError(msg)
-        elif names is not None:
-            region = list()
-            for n in names:
-                idx = self.rois.which(name=n)
-                if len(idx) == 0:
-                    msg = "no ROI named '%s'" % n
-                    raise ValueError(msg)
-                region.append(idx[0])
-            # collapse into a slice if we can
-            consecutive = True
-            for i in range(1, len(region)):
-                if region[i] - region[i-1] != 1:
-                    consecutive = False
-                    break
-            if consecutive:
-                region = slice(region[0], region[-1]+1)
-        return ROITableRegion(self.rois, region, desc, name)
+        """
+        Add ROI data to this
+        """
+        pixel_mask, image_mask = getargs('pixel_mask', 'image_mask', kwargs)
+        if image_mask is None and pixel_mask is None:
+            raise ValueError("Must provide either 'image_mask' or 'pixel_mask' or both")
+        if image_mask is not None:
+            self.__check_image_mask()
+        if pixel_max is not None:
+            self.__check_pixel_mask()
+        return super(PlaneSegmentation, self).add_row(**kwargs)
 
 
 @register_class('ImageSegmentation', CORE_NAMESPACE)
@@ -425,7 +325,7 @@ class RoiResponseSeries(TimeSeries):
              'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)'},
 
-            {'name': 'rois', 'type': ROITableRegion,
+            {'name': 'rois', 'type': DynamicTableRegion,
              'doc': 'a table region corresponding to the ROIs that were used to generate this data'},
 
             {'name': 'resolution', 'type': float,

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -265,14 +265,17 @@ class PlaneSegmentation(DynamicTable):
         """
         Add ROI data to this
         """
-        pixel_mask, image_mask = getargs('pixel_mask', 'image_mask', kwargs)
+        pixel_mask, image_mask = popargs('pixel_mask', 'image_mask', kwargs)
         if image_mask is None and pixel_mask is None:
             raise ValueError("Must provide either 'image_mask' or 'pixel_mask' or both")
+        rkwargs = dict(kwargs)
         if image_mask is not None:
             self.__check_image_mask()
+            rkwargs['image_mask'] = image_mask
         if pixel_mask is not None:
             self.__check_pixel_mask()
-        return super(PlaneSegmentation, self).add_row(**kwargs)
+            rkwargs['pixel_mask'] = pixel_mask
+        return super(PlaneSegmentation, self).add_row(**rkwargs)
 
     @docval({'name': 'description', 'type': str, 'doc': 'a brief description of what the region is'},
             {'name': 'region', 'type': (slice, list, tuple), 'doc': 'the indices of the table', 'default': slice(None)},

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -1,15 +1,12 @@
 from collections import Iterable
-from h5py import RegionReference
 import numpy as np
 
 from .form.utils import docval, getargs, popargs, fmt_docval_args, call_docval_func
-from .form.data_utils import RegionSlicer
-from .form import get_region_slicer
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, MultiContainerInterface, NWBData, VectorData, DynamicTable, DynamicTableRegion
+from .core import NWBContainer, MultiContainerInterface, DynamicTable, DynamicTableRegion
 from .device import Device
 
 

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -6,7 +6,7 @@ from .form.utils import docval, getargs, popargs, fmt_docval_args, call_docval_f
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, MultiContainerInterface, DynamicTable, DynamicTableRegion
+from .core import NWBContainer, MultiContainerInterface, DynamicTable, DynamicTableRegion, ElementIdentifiers
 from .device import Device
 
 
@@ -232,6 +232,8 @@ class PlaneSegmentation(DynamicTable):
             {'name': 'name', 'type': str, 'doc': 'name of PlaneSegmentation.', 'default': None},
             {'name': 'reference_images', 'type': (ImageSeries, list, dict, tuple), 'default': None,
              'doc': 'One or more image stacks that the masks apply to (can be oneelement stack).'},
+            {'name': 'id', 'type': ('array_data', ElementIdentifiers), 'doc': 'the identifiers for this table',
+             'default': None},
             {'name': 'columns', 'type': (tuple, list), 'doc': 'the columns in this table', 'default': None},
             {'name': 'colnames', 'type': 'array_data', 'doc': 'the names of the columns in this table',
             'default': None})

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -1,14 +1,11 @@
 import unittest2 as unittest
 
-import numpy as np
-
-from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder, ReferenceBuilder
+from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder
 
 from pynwb.ecephys import ElectrodeGroup, ElectricalSeries, FilteredEphys, LFP, Clustering, ClusterWaveforms,\
                           SpikeEventSeries, EventWaveform, EventDetection, FeatureExtraction
 from pynwb.device import Device
 from pynwb.core import DynamicTableRegion
-from pynwb.misc import UnitTimes
 from pynwb.file import ElectrodeTable as get_electrode_table
 
 from . import base

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -17,47 +17,6 @@ from abc import ABCMeta
 from six import with_metaclass
 
 
-class TestUnitTimesIO(base.TestDataInterfaceIO):
-
-    def setUpContainer(self):
-        # self.spike_unit1 = SpikeUnit('unit1', [0, 1, 2], 'spike unit1 description', 'spike units source')
-        # self.spike_unit2 = SpikeUnit('unit2', [3, 4, 5], 'spike unit2 description', 'spike units source')
-        ut = UnitTimes('UnitTimes integration test', name='UnitTimesTest')
-        ut.add_spike_times(0, [0, 1, 2])
-        ut.add_spike_times(1, [3, 4, 5])
-        return ut
-
-    def setUpBuilder(self):
-        ids_builder = DatasetBuilder('unit_ids', [0, 1],
-                                     attributes={'neurodata_type': 'ElementIdentifiers',
-                                                 'namespace': 'core',
-                                                 'help': 'unique identifiers for a list of elements'})
-        st_builder = DatasetBuilder('spike_times', [0, 1, 2, 3, 4, 5],
-                                    attributes={'neurodata_type': 'VectorData',
-                                                'namespace': 'core',
-                                                'help': 'Values for a list of elements'})
-        sti_builder = DatasetBuilder('spike_times_index',
-                                     [RegionBuilder(slice(0, 3), st_builder), RegionBuilder(slice(3, 6), st_builder)],
-                                     attributes={'neurodata_type': 'VectorIndex',
-                                                 'namespace': 'core',
-                                                 'help': 'indexes into a list of values for a list of elements'})
-        return GroupBuilder('UnitTimesTest',
-                            attributes={'neurodata_type': 'UnitTimes',
-                                        'namespace': 'core',
-                                        'help': 'Estimated spike times from a single unit',
-                                        'source': 'UnitTimes integration test'},
-                            datasets={'unit_ids': ids_builder,
-                                      'spike_times': st_builder,
-                                      'spike_times_index': sti_builder})
-
-    def test_get_spike_times(self):
-        ut = self.roundtripContainer()
-        received = ut.get_unit_spike_times(0)
-        self.assertTrue(np.array_equal(received, [0, 1, 2]))
-        received = ut.get_unit_spike_times(1)
-        self.assertTrue(np.array_equal(received, [3, 4, 5]))
-
-
 class TestElectrodeGroupIO(base.TestMapRoundTrip):
 
     def setUpContainer(self):

--- a/tests/integration/ui_write/test_misc.py
+++ b/tests/integration/ui_write/test_misc.py
@@ -1,0 +1,48 @@
+import unittest2 as unittest
+from . import base
+
+import numpy as np
+from pynwb.form.build import GroupBuilder, DatasetBuilder, ReferenceBuilder
+
+from pynwb.misc import UnitTimes
+
+class TestUnitTimesIO(base.TestDataInterfaceIO):
+
+    def setUpContainer(self):
+        ut = UnitTimes('UnitTimes integration test', name='UnitTimesTest')
+        ut.add_spike_times(0, [0, 1, 2])
+        ut.add_spike_times(1, [3, 4, 5])
+        return ut
+
+    def setUpBuilder(self):
+        ids_builder = DatasetBuilder('unit_ids', [0, 1],
+                                     attributes={'neurodata_type': 'ElementIdentifiers',
+                                                 'namespace': 'core',
+                                                 'help': 'unique identifiers for a list of elements'})
+        st_builder = DatasetBuilder('spike_times', [0, 1, 2, 3, 4, 5],
+                                    attributes={'neurodata_type': 'VectorData',
+                                                'namespace': 'core',
+                                                'help': 'Values for a list of elements'})
+        sti_builder = DatasetBuilder('spike_times_index',
+                                     [3, 6],
+                                     attributes={'neurodata_type': 'VectorIndex',
+                                                 'namespace': 'core',
+                                                 'target': ReferenceBuilder(st_builder),
+                                                 'help': 'indexes into a list of values for a list of elements'})
+        return GroupBuilder('UnitTimesTest',
+                            attributes={'neurodata_type': 'UnitTimes',
+                                        'namespace': 'core',
+                                        'help': 'Estimated spike times from a single unit',
+                                        'source': 'UnitTimes integration test'},
+                            datasets={'unit_ids': ids_builder,
+                                      'spike_times': st_builder,
+                                      'spike_times_index': sti_builder})
+
+    def test_get_spike_times(self):
+        ut = self.roundtripContainer()
+        received = ut.get_unit_spike_times(0)
+        self.assertTrue(np.array_equal(received, [0, 1, 2]))
+        received = ut.get_unit_spike_times(1)
+        self.assertTrue(np.array_equal(received, [3, 4, 5]))
+
+

--- a/tests/integration/ui_write/test_misc.py
+++ b/tests/integration/ui_write/test_misc.py
@@ -1,10 +1,10 @@
-import unittest2 as unittest
 from . import base
 
 import numpy as np
 from pynwb.form.build import GroupBuilder, DatasetBuilder, ReferenceBuilder
 
 from pynwb.misc import UnitTimes
+
 
 class TestUnitTimesIO(base.TestDataInterfaceIO):
 
@@ -44,5 +44,3 @@ class TestUnitTimesIO(base.TestDataInterfaceIO):
         self.assertTrue(np.array_equal(received, [0, 1, 2]))
         received = ut.get_unit_spike_times(1)
         self.assertTrue(np.array_equal(received, [3, 4, 5]))
-
-

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -258,8 +258,8 @@ class TestEpochsRoundtripDf(base.TestMapRoundTrip):
                 'description': ['q', 'w', 'e', 'r'],
                 'tags': [[], [], ['fizz', 'buzz'], ['qaz']]
             }),
-            'epochs',
-            'epochs integration test'
+            'epochs integration test',
+            'epochs'
         )
 
         # reset the thing
@@ -267,8 +267,3 @@ class TestEpochsRoundtripDf(base.TestMapRoundTrip):
 
     def getContainer(self, nwbfile):
         return nwbfile.epochs
-
-    def test_roundtrip(self):
-        super(TestEpochsRoundtripDf, self).test_roundtrip()
-        obtained = self.read_container.to_dataframe()
-        assert obtained.loc[2, 'bar'] == 'dog'

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 
-from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, RegionBuilder
+from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder
 
 from pynwb.ophys import (
     ImagingPlane,
@@ -199,10 +199,11 @@ class TestPlaneSegmentation(base.TestMapRoundTrip):
 
         self.img_mask = deepcopy(img_mask)
         self.pix_mask = deepcopy(pix_mask)
+        self.pxmsk_index = [3, 5]
         pS = PlaneSegmentation('integration test PlaneSegmentation', 'plane segmentation description',
                                self.imaging_plane, 'test_plane_seg_name', self.image_series)
-        pS.add_roi('1234', pix_mask[0:3], img_mask[0])
-        pS.add_roi('5678', pix_mask[3:5], img_mask[1])
+        pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
+        pS.add_roi(pixel_mask=pix_mask[3:5], image_mask=img_mask[1])
         return pS
 
     @staticmethod
@@ -264,40 +265,44 @@ class TestPlaneSegmentation(base.TestMapRoundTrip):
                                                  'dimension': DatasetBuilder('dimension', [2]),
                                                  })
 
-        self.pixel_masks_builder = DatasetBuilder('pixel_masks', self.pix_mask,
+        self.pixel_masks_builder = DatasetBuilder('pixel_mask', self.pix_mask,
                                                   attributes={
                                                    'namespace': 'core',
-                                                   'neurodata_type': 'PixelMasks',
-                                                   'help': 'a concatenated array of pixel masks'})
+                                                   'neurodata_type': 'VectorData',
+                                                   'description': 'Pixel masks for each ROI',
+                                                   'help': 'Values for a list of elements'})
 
-        self.image_masks_builder = DatasetBuilder('image_masks', self.img_mask,
+        self.pxmsk_index_builder = DatasetBuilder('pixel_mask_index', self.pxmsk_index,
                                                   attributes={
                                                    'namespace': 'core',
-                                                   'neurodata_type': 'ImageMasks',
-                                                   'help': 'an array of image masks'})
+                                                   'neurodata_type': 'VectorIndex',
+                                                   'target': ReferenceBuilder(self.pixel_masks_builder),
+                                                   'help': 'indexes into a list of values for a list of elements'})
 
-        self.rois_builder = DatasetBuilder('rois', [
-                                            ('1234', RegionBuilder(slice(0, 3), self.pixel_masks_builder),
-                                             RegionBuilder([0], self.image_masks_builder)),
-                                            ('5678', RegionBuilder(slice(3, 5), self.pixel_masks_builder),
-                                             RegionBuilder([1], self.image_masks_builder))
-                                        ],
-                                        attributes={
-                                         'namespace': 'core',
-                                         'neurodata_type': 'ROITable',
-                                         'help': 'A table for storing ROI data'})
+        self.image_masks_builder = DatasetBuilder('image_mask', self.img_mask,
+                                                  attributes={
+                                                   'namespace': 'core',
+                                                   'neurodata_type': 'TableColumn',
+                                                   'description': 'Image masks for each ROI',
+                                                   'help': 'One of many columns that can be added to a DynamicTable'})
+
         ps_builder = GroupBuilder(
             'test_plane_seg_name',
             attributes={
                 'neurodata_type': 'PlaneSegmentation',
                 'namespace': 'core',
                 'source': 'integration test PlaneSegmentation',
+                'description': 'plane segmentation description',
+                'colnames': ('image_mask', 'pixel_mask'),
                 'help': 'Results from segmentation of an imaging plane'},
             datasets={
-                'description': DatasetBuilder('description', 'plane segmentation description'),
-                'rois': self.rois_builder,
-                'pixel_masks': self.pixel_masks_builder,
-                'image_masks': self.image_masks_builder,
+                'id': DatasetBuilder('id', data=[0, 1],
+                                     attributes={'help': 'unique identifiers for a list of elements',
+                                                 'namespace': 'core',
+                                                 'neurodata_type': 'ElementIdentifiers'}),
+                'pixel_mask': self.pixel_masks_builder,
+                'pixel_mask_index': self.pxmsk_index_builder,
+                'image_mask': self.image_masks_builder,
             },
             groups={
                 'reference_images': GroupBuilder('reference_images', groups={'test_iS': self.is_builder}),
@@ -343,7 +348,7 @@ class TestRoiResponseSeriesIO(base.TestDataInterfaceIO):
                                  data, 'lumens', self.rt_region, timestamps=timestamps)
 
     def setUpBuilder(self):
-        TestPlaneSegmentation.get_plane_segmentation_builder(self)
+        ps_builder = TestPlaneSegmentation.get_plane_segmentation_builder(self)
         return GroupBuilder(
             'test_roi_response_series',
             attributes={
@@ -364,11 +369,12 @@ class TestRoiResponseSeriesIO(base.TestDataInterfaceIO):
                 ),
                 'timestamps': DatasetBuilder('timestamps', [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
                                              attributes={'unit': 'Seconds', 'interval': 1}),
-                'rois': DatasetBuilder('rois', RegionBuilder([0], self.rois_builder),
-                                       attributes={'help': 'A region reference to an ROITable',
+                'rois': DatasetBuilder('rois', data=[0],
+                                       attributes={'help': 'a subset (i.e. slice or region) of a DynamicTable',
                                                    'description': 'the first of two ROIs',
+                                                   'table': ReferenceBuilder(ps_builder),
                                                    'namespace': 'core',
-                                                   'neurodata_type': 'ROITableRegion'}),
+                                                   'neurodata_type': 'DynamicTableRegion'}),
             })
 
     def addContainer(self, nwbfile):

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -1,3 +1,4 @@
+import unittest2 as unittest
 from copy import deepcopy
 
 from pynwb.form.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder
@@ -333,6 +334,52 @@ class TestPlaneSegmentation(base.TestMapRoundTrip):
         mod = nwbfile.get_processing_module('plane_seg_test_module')
         img_seg = mod.get_data_interface('ImageSegmentation')
         return img_seg.get_plane_segmentation('test_plane_seg_name')
+
+
+class MaskRoundTrip(TestPlaneSegmentation):
+
+    def setBoilerPlateObjects(self):
+        ts = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
+        self.image_series = ImageSeries(name='test_iS', source='a hypothetical source', dimension=[2],
+                                        external_file=['images.tiff'],
+                                        starting_frame=[1, 2, 3], format='tiff', timestamps=ts)
+        self.device = Device(name='dev1', source='a test source')
+        self.optical_channel = OpticalChannel('test_optical_channel', 'optical channel source',
+                                              'optical channel description', 500.)
+        self.imaging_plane = ImagingPlane('test_imaging_plane',
+                                          'ophys integration tests',
+                                          self.optical_channel,
+                                          'imaging plane description',
+                                          self.device,
+                                          600., '2.718', 'GFP', 'somewhere in the brain',
+                                          (1, 2, 1, 2, 3), 4.0, 'manifold unit', 'A frame to refer to')
+        return PlaneSegmentation('test source', 'description', self.imaging_plane, 'test_plane_seg_name',
+                                 self.image_series)
+
+    def setUpBuilder(self):
+        raise unittest.SkipTest("no builder")
+
+
+class PixelMaskRoundtrip(MaskRoundTrip):
+
+    def setUpContainer(self):
+        pix_mask = [(1, 2, 1.0), (3, 4, 1.0), (5, 6, 1.0),
+                    (7, 8, 2.0), (9, 10, 2.)]
+        pS = self.setBoilerPlateObjects()
+        pS.add_roi(pixel_mask=pix_mask[0:3])
+        pS.add_roi(pixel_mask=pix_mask[3:5])
+        return pS
+
+
+class ImageMaskRoundtrip(MaskRoundTrip):
+
+    def setUpContainer(self):
+        w, h = 5, 5
+        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
+        pS = self.setBoilerPlateObjects()
+        pS.add_roi(image_mask=img_mask[0])
+        pS.add_roi(image_mask=img_mask[1])
+        return pS
 
 
 class TestRoiResponseSeriesIO(base.TestDataInterfaceIO):

--- a/tests/unit/form_tests/test_io_hdf5.py
+++ b/tests/unit/form_tests/test_io_hdf5.py
@@ -1,4 +1,4 @@
-import unittest
+import unittest2 as unittest
 from datetime import datetime
 import os
 from h5py import File, Dataset, Reference

--- a/tests/unit/form_tests/test_io_hdf5.py
+++ b/tests/unit/form_tests/test_io_hdf5.py
@@ -263,3 +263,12 @@ class TestHDF5Writer(GroupBuilderTestCase):
         builder = io.read_builder()
         self.assertBuilderEqual(builder, self.builder)
         io.close()
+
+    def test_overwrite_written(self):
+        self.maxDiff = None
+        io = HDF5IO(self.path, self.manager)
+        io.write_builder(self.builder)
+        builder = io.read_builder()
+        with self.assertRaisesRegex(ValueError, "cannot change written to not written"):
+            builder.written = False
+        io.close()

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -68,22 +68,22 @@ class TestDynamicTable(unittest.TestCase):
     def test_constructor_ids(self):
         columns = [TableColumn(name=s['name'], description=s['description'], data=d)
                    for s, d in zip(self.spec, self.data)]
-        table = DynamicTable("with_columns", 'PyNWB unit test', 'a test table', ids=[0, 1, 2, 3, 4], columns=columns)
+        table = DynamicTable("with_columns", 'PyNWB unit test', 'a test table', id=[0, 1, 2, 3, 4], columns=columns)
         self.check_table(table)
 
     def test_constructor_ElementIdentifier_ids(self):
         columns = [TableColumn(name=s['name'], description=s['description'], data=d)
                    for s, d in zip(self.spec, self.data)]
         ids = ElementIdentifiers('ids', [0, 1, 2, 3, 4])
-        table = DynamicTable("with_columns", 'PyNWB unit test', 'a test table', ids=ids, columns=columns)
+        table = DynamicTable("with_columns", 'PyNWB unit test', 'a test table', id=ids, columns=columns)
         self.check_table(table)
 
     def test_constructor_ids_bad_ids(self):
         columns = [TableColumn(name=s['name'], description=s['description'], data=d)
                    for s, d in zip(self.spec, self.data)]
-        msg = "must provide same number of ids as length of columns if specifying ids"
+        msg = "must provide same number of ids as length of columns"
         with self.assertRaisesRegex(ValueError, msg):
-            DynamicTable("with_columns", 'PyNWB unit test', 'a test table', ids=[0, 1], columns=columns)
+            DynamicTable("with_columns", 'PyNWB unit test', 'a test table', id=[0, 1], columns=columns)
 
     def add_rows(self, table):
         table.add_row({'foo': 1, 'bar': 10.0, 'baz': 'cat'})

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -63,10 +63,9 @@ class UnitTimesConstructor(unittest.TestCase):
         ut.add_spike_times(1, [3, 4, 5])
         self.assertEqual(ut.unit_ids.data, [0, 1])
         self.assertEqual(ut.spike_times.data, [0, 1, 2, 3, 4, 5])
-        self.assertEqual(len(ut.spike_times_index), 2)
-        self.assertEqual(ut.spike_times_index[0].target.data, [0, 1, 2, 3, 4, 5])
-        self.assertEqual(ut.spike_times_index[0].slice, slice(0, 3))
-        self.assertEqual(ut.spike_times_index[1].target.data, [0, 1, 2, 3, 4, 5])
+        self.assertEqual(ut.spike_times_index.data, [3, 6])
+        self.assertEqual(ut.spike_times_index[0], [0, 1, 2])
+        self.assertEqual(ut.spike_times_index[1], [3, 4, 5])
 
     def test_get_spike_times(self):
         ut = UnitTimes('UnitTimes add_spike_times unit test')
@@ -74,6 +73,13 @@ class UnitTimesConstructor(unittest.TestCase):
         ut.add_spike_times(1, [3, 4, 5])
         self.assertTrue(all(ut.get_unit_spike_times(0) == np.array([0, 1, 2])))
         self.assertTrue(all(ut.get_unit_spike_times(1) == np.array([3, 4, 5])))
+
+    def test_times(self):
+        ut = UnitTimes('UnitTimes add_spike_times unit test')
+        ut.add_spike_times(0, [0, 1, 2])
+        ut.add_spike_times(1, [3, 4, 5])
+        self.assertTrue(all(ut.times[0] == np.array([0, 1, 2])))
+        self.assertTrue(all(ut.times[1] == np.array([3, 4, 5])))
 
 
 if __name__ == '__main__':

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -24,8 +24,8 @@ def CreatePlaneSegmentation():
                       'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
     pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
-    pS.add_roi("1234", pix_mask[0:3], img_mask[0])
-    pS.add_roi("5678", pix_mask[3:5], img_mask[1])
+    pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
+    pS.add_roi(pixel_mask=pix_mask[3:5], image_mask=img_mask[1])
     return pS
 
 
@@ -164,16 +164,19 @@ class PlaneSegmentationConstructor(unittest.TestCase):
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
 
         pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
-        pS.add_roi("1234", pix_mask[0:3], img_mask[0])
-        pS.add_roi("5678", pix_mask[3:5], img_mask[1])
+        pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
+        pS.add_roi(pixel_mask=pix_mask[3:5], image_mask=img_mask[1])
 
         self.assertEqual(pS.description, 'description')
         self.assertEqual(pS.source, 'test source')
 
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, iSS)
-        self.assertEqual(pS.pixel_masks.data, pix_mask)
-        self.assertEqual(pS.image_masks.data, img_mask)
+
+        self.assertEqual(pS['pixel_mask'].target.data, pix_mask)
+        self.assertEqual(pS['pixel_mask'][0], pix_mask[0:3])
+        self.assertEqual(pS['pixel_mask'][1], pix_mask[3:5])
+        self.assertEqual(pS['image_mask'].data, img_mask)
 
 
 if __name__ == '__main__':

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -149,11 +149,8 @@ class ImageSegmentationConstructor(unittest.TestCase):
 
 
 class PlaneSegmentationConstructor(unittest.TestCase):
-    def test_init(self):
-        w, h = 5, 5
-        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
-        pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
-                    [7, 8, 2.0], [9, 10, 2.0]]
+
+    def getBoilerPlateObjects(self):
 
         iSS = ImageSeries(name='test_iS', source='a hypothetical source', data=list(), unit='unit',
                           external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())
@@ -162,6 +159,16 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         oc = OpticalChannel('test_optical_channel', 'test_source', 'description', 500.)
         ip = ImagingPlane('test_imaging_plane', 'test_source', oc, 'description', device, 600.,
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
+        return (iSS, ip)
+
+
+    def test_init(self):
+        w, h = 5, 5
+        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
+        pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
+                    [7, 8, 2.0], [9, 10, 2.0]]
+
+        iSS, ip = self.getBoilerPlateObjects()
 
         pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
         pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
@@ -176,6 +183,45 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         self.assertEqual(pS['pixel_mask'].target.data, pix_mask)
         self.assertEqual(pS['pixel_mask'][0], pix_mask[0:3])
         self.assertEqual(pS['pixel_mask'][1], pix_mask[3:5])
+        self.assertEqual(pS['image_mask'].data, img_mask)
+
+    def test_init_pixel_mask(self):
+        w, h = 5, 5
+        pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
+                    [7, 8, 2.0], [9, 10, 2.0]]
+
+        iSS, ip = self.getBoilerPlateObjects()
+
+        pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
+        pS.add_roi(pixel_mask=pix_mask[0:3])
+        pS.add_roi(pixel_mask=pix_mask[3:5])
+
+        self.assertEqual(pS.description, 'description')
+        self.assertEqual(pS.source, 'test source')
+
+        self.assertEqual(pS.imaging_plane, ip)
+        self.assertEqual(pS.reference_images, iSS)
+
+        self.assertEqual(pS['pixel_mask'].target.data, pix_mask)
+        self.assertEqual(pS['pixel_mask'][0], pix_mask[0:3])
+        self.assertEqual(pS['pixel_mask'][1], pix_mask[3:5])
+
+    def test_init_image_mask(self):
+        w, h = 5, 5
+        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
+
+        iSS, ip = self.getBoilerPlateObjects()
+
+        pS = PlaneSegmentation('test source', 'description', ip, 'test_name', iSS)
+        pS.add_roi(image_mask=img_mask[0])
+        pS.add_roi(image_mask=img_mask[1])
+
+        self.assertEqual(pS.description, 'description')
+        self.assertEqual(pS.source, 'test source')
+
+        self.assertEqual(pS.imaging_plane, ip)
+        self.assertEqual(pS.reference_images, iSS)
+
         self.assertEqual(pS['image_mask'].data, img_mask)
 
 

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -161,7 +161,6 @@ class PlaneSegmentationConstructor(unittest.TestCase):
                           'imaging_rate', 'indicator', 'location', (1, 2, 1, 2, 3), 4.0, 'unit', 'reference_frame')
         return (iSS, ip)
 
-
     def test_init(self):
         w, h = 5, 5
         img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
@@ -186,7 +185,6 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         self.assertEqual(pS['image_mask'].data, img_mask)
 
     def test_init_pixel_mask(self):
-        w, h = 5, 5
         pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
                     [7, 8, 2.0], [9, 10, 2.0]]
 


### PR DESCRIPTION
## Motivation
Fix #663 

- `pixel_mask` or `image_mask` required, but not both. both can be supplied
- use integer id rather than ROI name
- additional metadata can be added to using `PlaneSegmentation.add_column` or `PlaneSegmentation.add_vector_data`

## How to test the behavior?
```python
w, h = 5, 5
img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
pix_mask = [(1, 2, 1.0), (3, 4, 1.0), (5, 6, 1.0),
            (7, 8, 2.0), (9, 10, 2.)]
imaging_plane = ...
image_series = ...
pS = PlaneSegmentation('integration test PlaneSegmentation', 'plane segmentation description',
                       imaging_plane, 'test_plane_seg_name', image_series)
pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
pS.add_roi(pixel_mask=pix_mask[3:5], image_mask=img_mask[1])

# retrieve data

pS['image_mask'][0]
pS['pixel_mask'][0]
pS['image_mask'][1]
pS['pixel_mask'][1]
```

Also fix #662 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
