### PR TITLE
fix manifold warning

### DIFF
--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -20,6 +20,8 @@ clarity, we define them here:
 from datetime import datetime
 from dateutil.tz import tzlocal
 
+import numpy as np
+
 from pynwb import NWBFile
 from pynwb.ophys import TwoPhotonSeries, OpticalChannel, ImageSegmentation, Fluorescence
 from pynwb.device import Device
@@ -58,7 +60,8 @@ imaging_plane = nwbfile.create_imaging_plane('my_imgpln',
                                              'a very interesting part of the brain',
                                              device,
                                              600., '2.718', 'GFP', 'my favorite brain location',
-                                             [], 4.0, 'manifold unit', 'A frame to refer to')
+                                             np.ones((5, 5, 3)), 4.0, 'manifold unit',
+                                             'A frame to refer to')
 
 
 ####################


### PR DESCRIPTION
## Motivation

When you use `[]` for `manifold` in `nwbfile.create_imaging_plane` it throws a warning. This change generates some data that passes the validation so that this warning does not show up in the demo.

fix #685

## How to test the behavior?
run the ophys tutorial

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
