### PR TITLE
Add NWBFile.timestamps_reference_time field.

### DIFF
--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -18,7 +18,7 @@ groups:
     dtype: isodatetime
     doc: 'A record of the date the file was created and of subsequent modifications.
       COMMENT:
-        - The date is stored in UTC with local timezone offset as ISO 8601
+        - The date is stored in UTC with local timezone offset as ISO 8601 extended format
           formatted strings: 2018-09-28T14:43:54.123+02:00
         - Dates stored in UTC end in "Z" with no timezone offset.
         - Date accuracy is up to milliseconds.

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -44,6 +44,14 @@ groups:
         - The date is stored in UTC with local timezone offset as ISO 8601
           formatted string: 2018-09-28T14:43:54.123+02:00
         - Dates stored in UTC end in "Z" with no timezone offset.
+        - Date accuracy is up to milliseconds.'
+  - name: timestamps_reference_time
+    dtype: isodatetime
+    doc: 'Date and time corresponding to time zero of all timestamps.
+      COMMENT:
+        - The date is stored in UTC with local timezone offset as ISO 8601
+          formatted string: 2018-09-28T14:43:54.123+02:00
+        - Dates stored in UTC end in "Z" with no timezone offset.
         - Date accuracy is up to milliseconds.
         - All times stored in the file use this time as reference (ie, time zero).'
   groups:

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -18,7 +18,7 @@ groups:
     dtype: isodatetime
     doc: 'A record of the date the file was created and of subsequent modifications.
       COMMENT:
-        - The date is stored in UTC with local timezone offset as ISO 8601 extended format
+        - The date is stored in UTC with local timezone offset as ISO 8601 extended
           formatted strings: 2018-09-28T14:43:54.123+02:00
         - Dates stored in UTC end in "Z" with no timezone offset.
         - Date accuracy is up to milliseconds.
@@ -41,7 +41,7 @@ groups:
     dtype: isodatetime
     doc: 'Date and time of the experiment/session start.
       COMMENT:
-        - The date is stored in UTC with local timezone offset as ISO 8601
+        - The date is stored in UTC with local timezone offset as ISO 8601 extended
           formatted string: 2018-09-28T14:43:54.123+02:00
         - Dates stored in UTC end in "Z" with no timezone offset.
         - Date accuracy is up to milliseconds.'
@@ -49,7 +49,7 @@ groups:
     dtype: isodatetime
     doc: 'Date and time corresponding to time zero of all timestamps.
       COMMENT:
-        - The date is stored in UTC with local timezone offset as ISO 8601
+        - The date is stored in UTC with local timezone offset as ISO 8601 extended
           formatted string: 2018-09-28T14:43:54.123+02:00
         - Dates stored in UTC end in "Z" with no timezone offset.
         - Date accuracy is up to milliseconds.

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -143,14 +143,13 @@ class NWBFile(MultiContainerInterface):
         },
     ]
 
-    __nwbfields__ = ('experimenter',
-                     'data_collection',
-                     'description',
+    __nwbfields__ = ('timestamps_reference_time',
+                     'file_create_date',
+                     'experimenter',
                      'experiment_description',
                      'session_id',
-                     'keywords',
-                     'lab',
                      'institution',
+                     'keywords',
                      'notes',
                      'pharmacology',
                      'protocol',
@@ -158,9 +157,11 @@ class NWBFile(MultiContainerInterface):
                      'slices',
                      'source_script',
                      'source_script_file_name',
+                     'data_collection',
                      'surgery',
                      'virus',
                      'stimulus_notes',
+                     'lab',
                      {'name': 'electrodes', 'child': True,  'required_name': 'electrodes'},
                      {'name': 'epochs', 'child': True, 'required_name': 'epochs'},
                      {'name': 'trials', 'child': True, 'required_name': 'trials'},
@@ -172,9 +173,12 @@ class NWBFile(MultiContainerInterface):
     @docval({'name': 'session_description', 'type': str,
              'doc': 'a description of the session where this data was generated'},
             {'name': 'identifier', 'type': str, 'doc': 'a unique text identifier for the file'},
-            {'name': 'session_start_time', 'type': datetime, 'doc': 'the start time of the recording session'},
+            {'name': 'session_start_time', 'type': datetime, 'doc': 'the start date and time of the recording session'},
             {'name': 'file_create_date', 'type': ('array_data', datetime),
-             'doc': 'the time the file was created and subsequent modifications made', 'default': None},
+             'doc': 'the date and time the file was created and subsequent modifications made', 'default': None},
+            {'name': 'timestamps_reference_time', 'type': datetime,
+             'doc': 'date and time corresponding to time zero of all timestamps; defaults to value '
+                    'of session_start_time', 'default': None},
             {'name': 'experimenter', 'type': str, 'doc': 'name of person who performed experiment', 'default': None},
             {'name': 'experiment_description', 'type': str,
              'doc': 'general description of the experiment', 'default': None},
@@ -199,7 +203,7 @@ class NWBFile(MultiContainerInterface):
             {'name': 'source_script', 'type': str,
              'doc': 'Script file used to create this NWB file.', 'default': None},
             {'name': 'source_script_file_name', 'type': str,
-             'doc': 'Name of the sourc_script file', 'default': None},
+             'doc': 'Name of the source_script file', 'default': None},
             {'name': 'data_collection', 'type': str,
              'doc': 'Notes about data collection and analysis.', 'default': None},
             {'name': 'surgery', 'type': str,
@@ -255,6 +259,12 @@ class NWBFile(MultiContainerInterface):
         self.__session_start_time = getargs('session_start_time', kwargs)
         if self.__session_start_time.tzinfo is None:
             self.__session_start_time = _add_missing_timezone(self.__session_start_time)
+
+        self.__timestamps_reference_time = getargs('timestamps_reference_time', kwargs)
+        if self.__timestamps_reference_time is None:
+            self.__timestamps_reference_time = self.__session_start_time
+        elif self.__timestamps_reference_time.tzinfo is None:
+            raise ValueError("'timestamps_reference_time' must be a timezone-aware datetime object.")
 
         self.__file_create_date = getargs('file_create_date', kwargs)
         if self.__file_create_date is None:
@@ -353,6 +363,10 @@ class NWBFile(MultiContainerInterface):
     @property
     def session_start_time(self):
         return self.__session_start_time
+
+    @property
+    def timestamps_reference_time(self):
+        return self.__timestamps_reference_time
 
     def __check_epochs(self):
         if self.epochs is None:

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -54,6 +54,12 @@ class NWBFileMap(ObjectMapper):
         date = dateutil_parse(datestr)
         return date
 
+    @ObjectMapper.constructor_arg('timestamps_reference_time')
+    def dateconversion_trt(self, builder, manager):
+        datestr = builder.get('timestamps_reference_time').data
+        date = dateutil_parse(datestr)
+        return date
+
     @ObjectMapper.constructor_arg('file_create_date')
     def dateconversion_list(self, builder, manager):
         datestr = builder.get('file_create_date').data

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -101,7 +101,7 @@ class TestNWBFileIO(base.TestMapNWBContainer):
                                 'identifier': DatasetBuilder('identifier', 'TEST123'),
                                 'session_description': DatasetBuilder('session_description', 'a test NWB File'),
                                 'session_start_time': DatasetBuilder('session_start_time', self.start_time.isoformat()),
-                                'timestamps_reference_time': DatasetBuilder('timestamps_reference_time', 
+                                'timestamps_reference_time': DatasetBuilder('timestamps_reference_time',
                                                                             self.ref_time.isoformat())
                                 },
                             attributes={'namespace': base.CORE_NAMESPACE,

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -20,6 +20,7 @@ class TestNWBFileIO(base.TestMapNWBContainer):
 
     def setUp(self):
         self.start_time = datetime(1970, 1, 1, 12, tzinfo=tzutc())
+        self.ref_time = datetime(1979, 1, 1, 0, tzinfo=tzutc())
         self.create_date = datetime(2017, 4, 15, 12, tzinfo=tzlocal())
         super(TestNWBFileIO, self).setUp()
         self.path = "test_pynwb_io_hdf5.h5"
@@ -99,7 +100,9 @@ class TestNWBFileIO(base.TestMapNWBContainer):
                                 DatasetBuilder('file_create_date', [self.create_date.isoformat()]),
                                 'identifier': DatasetBuilder('identifier', 'TEST123'),
                                 'session_description': DatasetBuilder('session_description', 'a test NWB File'),
-                                'session_start_time': DatasetBuilder('session_start_time', self.start_time.isoformat())
+                                'session_start_time': DatasetBuilder('session_start_time', self.start_time.isoformat()),
+                                'timestamps_reference_time': DatasetBuilder('timestamps_reference_time', 
+                                                                            self.ref_time.isoformat())
                                 },
                             attributes={'namespace': base.CORE_NAMESPACE,
                                         'nwb_version': '2.0b',
@@ -109,6 +112,7 @@ class TestNWBFileIO(base.TestMapNWBContainer):
     def setUpContainer(self):
         container = NWBFile('a test NWB File', 'TEST123',
                             self.start_time,
+                            timestamps_reference_time=self.ref_time,
                             file_create_date=self.create_date,
                             experimenter='test experimenter',
                             stimulus_notes='test stimulus notes',

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -283,7 +283,7 @@ class TestTimestampsRefDefault(unittest.TestCase):
         # 'timestamps_reference_time' should default to 'session_start_time'
         self.assertEqual(self.nwbfile.timestamps_reference_time, self.start_time)
 
-        
+
 class TestTimestampsRefAware(unittest.TestCase):
     def setUp(self):
         self.start_time = datetime(2017, 5, 1, 12, 0, 0, tzinfo=tzlocal())


### PR DESCRIPTION
## Motivation

This introduces a new top-level NWBFile field called `Timestamps_reference_time`, as discussed at fix https://github.com/NeurodataWithoutBorders/nwb-schema/issues/49

This field allows users to specify a date and time corresponding to time zero for all timestamps in the nwb file. The `session_start_time` field currently does double-duty in this regard, representing both the start time of the current session, and time zero for timestamps.

## How to test the behavior?
Tests are included in this PR. Briefly, for a file using POSIX timestamps
```python
from datetime import datetime
from dateutil import tz
from pynwb import NWBFile

session_start_time        = datetime(2017, 10, 31,  9, 59,  0, tzinfo=tz.gettz('US/Pacific'))
timestamps_reference_time = datetime(1970,  1,  1,  0,  0,  0, tzinfo=tz.tzutc())

nwbfile = NWBFile('session description', 'TEST124', session_start_time,
                    timestamps_reference_time=timestamps_reference_time)
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?

### Credits:
In collaboration with @AngevineMiller