### PR TITLE
PlaneSegmentation.add_roi(voxel_mask=...) support

### DIFF
--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -118,7 +118,8 @@ groups:
     datasets:
     - neurodata_type_inc: TableColumn
       name: image_mask
-      doc: ROI masks for each ROI
+      doc: ROI masks for each ROI. Each image mask is the size of the original imaging
+        plane (or volume) and members of the ROI are finite non-zero
       dims:
       - - num_roi
         - num_x
@@ -142,8 +143,9 @@ groups:
       quantity: '?'
     - neurodata_type_inc: VectorData
       name: pixel_mask
-      doc: Pixel masks for each ROI. Pixel masks are concatenated and parsing of this
-        dataset is maintained by the PlaneSegmentation
+      doc: 'Pixel masks for each ROI: a list of indices and weights for the ROI. Pixel
+        masks are concatenated and parsing of this dataset is maintained by the
+        PlaneSegmentation'
       dtype:
       - name: x
         dtype: uint
@@ -161,8 +163,9 @@ groups:
       quantity: '?'
     - neurodata_type_inc: VectorData
       name: voxel_mask
-      doc: Voxel masks for each ROI. Voxel masks are concatenated and parsing of this
-        dataset is maintained by the PlaneSegmentation
+      doc: 'Voxel masks for each ROI: a list of indices and weights for the ROI. Voxel
+        masks are concatenated and parsing of this dataset is maintained by the
+        PlaneSegmentation'
       dtype:
       - name: x
         dtype: uint

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -219,7 +219,8 @@ class PlaneSegmentation(DynamicTable):
 
     __columns__ = (
         {'name': 'image_mask', 'description': 'Image masks for each ROI'},
-        {'name': 'pixel_mask', 'description': 'Pixel masks for each ROI', 'vector_data': True}
+        {'name': 'pixel_mask', 'description': 'Pixel masks for each ROI', 'vector_data': True},
+        {'name': 'voxel_mask', 'description': 'Voxel masks for each ROI', 'vector_data': True}
     )
 
     @docval({'name': 'description', 'type': str,
@@ -244,22 +245,28 @@ class PlaneSegmentation(DynamicTable):
         self.imaging_plane = imaging_plane
         self.reference_images = reference_images
 
-    @docval({'name': 'pixel_mask', 'type': 'array_data', 'doc': 'the pixel mask', 'default': None},
-            {'name': 'image_mask', 'type': 'array_data', 'doc': 'the image mask for this ROI', 'default': None},
+    @docval({'name': 'pixel_mask', 'type': 'array_data', 'default': None,
+             'doc': 'pixel mask for 2D ROIs: [(x1, y1, weight1), (x2, y2, weight2), ...]'},
+            {'name': 'voxel_mask', 'type': 'array_data', 'default': None,
+             'doc': 'voxel mask for 3D ROIs: [(x1, y1, z1, weight1), (x2, y2, z1, weight2), ...]'},
+            {'name': 'image_mask', 'type': 'array_data', 'default': None,
+             'doc': 'image with the same size of image where positive values mark this ROI', },
             {'name': 'id', 'type': int, 'help': 'the ID for the ROI', 'default': None},
             allow_extra=True)
     def add_roi(self, **kwargs):
         """
         Add ROI data to this
         """
-        pixel_mask, image_mask = popargs('pixel_mask', 'image_mask', kwargs)
-        if image_mask is None and pixel_mask is None:
-            raise ValueError("Must provide either 'image_mask' or 'pixel_mask' or both")
+        pixel_mask, voxel_mask, image_mask = popargs('pixel_mask', 'voxel_mask', 'image_mask', kwargs)
+        if image_mask is None and pixel_mask is None and voxel_mask is None:
+            raise ValueError("Must provide 'image_mask' and/or 'pixel_mask'")
         rkwargs = dict(kwargs)
         if image_mask is not None:
             rkwargs['image_mask'] = image_mask
         if pixel_mask is not None:
             rkwargs['pixel_mask'] = pixel_mask
+        if voxel_mask is not None:
+            rkwargs['voxel_mask'] = voxel_mask
         return super(PlaneSegmentation, self).add_row(**rkwargs)
 
     @docval({'name': 'description', 'type': str, 'doc': 'a brief description of what the region is'},
@@ -321,7 +328,7 @@ class RoiResponseSeries(TimeSeries):
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
              'default': _default_resolution},
             {'name': 'conversion', 'type': float,
-             'doc': 'Scalar to multiply each element by to conver to volts', 'default': _default_conversion},
+             'doc': 'Scalar to multiply each element by to convert to volts', 'default': _default_conversion},
             {'name': 'timestamps', 'type': ('array_data', 'data', TimeSeries),
              'doc': 'Timestamps for samples stored in data', 'default': None},
             {'name': 'starting_time', 'type': float, 'doc': 'The timestamp of the first sample', 'default': None},

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -196,17 +196,36 @@ class PlaneSegmentationConstructor(unittest.TestCase):
         self.assertEqual(pS['pixel_mask'][0], pix_mask[0:3])
         self.assertEqual(pS['pixel_mask'][1], pix_mask[3:5])
 
-    def test_init_3d_pixel_mask(self):
-        pix_masks = np.random.randn(2, 20, 30, 4)
+    def test_init_voxel_mask(self):
+        vox_mask = [[1, 2, 3, 1.0], [3, 4, 1, 1.0], [5, 6, 3, 1.0],
+                    [7, 8, 3, 2.0], [9, 10, 2, 2.0]]
 
         iSS, ip = self.getBoilerPlateObjects()
 
         pS = PlaneSegmentation('description', ip, 'test_name', iSS)
-        pS.add_roi(pixel_mask=pix_masks[0].tolist())
-        pS.add_roi(pixel_mask=pix_masks[1].tolist())
+        pS.add_roi(voxel_mask=vox_mask[0:3])
+        pS.add_roi(voxel_mask=vox_mask[3:5])
 
-        self.assertTrue(np.allclose(pS['pixel_mask'][0], pix_masks[0]))
-        self.assertTrue(np.allclose(pS['pixel_mask'][1], pix_masks[1]))
+        self.assertEqual(pS.description, 'description')
+
+        self.assertEqual(pS.imaging_plane, ip)
+        self.assertEqual(pS.reference_images, iSS)
+
+        self.assertEqual(pS['voxel_mask'].target.data, vox_mask)
+        self.assertEqual(pS['voxel_mask'][0], vox_mask[0:3])
+        self.assertEqual(pS['voxel_mask'][1], vox_mask[3:5])
+
+    def test_init_3d_image_mask(self):
+        img_masks = np.random.randn(2, 20, 30, 4)
+
+        iSS, ip = self.getBoilerPlateObjects()
+
+        pS = PlaneSegmentation('description', ip, 'test_name', iSS)
+        pS.add_roi(image_mask=img_masks[0])
+        pS.add_roi(image_mask=img_masks[1])
+
+        self.assertTrue(np.allclose(pS['image_mask'][0], img_masks[0]))
+        self.assertTrue(np.allclose(pS['image_mask'][1], img_masks[1]))
 
     def test_init_image_mask(self):
         w, h = 5, 5


### PR DESCRIPTION
## Motivation

Add support for voxels in PlaneSegmentation

fix https://github.com/NeurodataWithoutBorders/nwb-schema/issues/211

## How to test the behavior?
```python
PlaneSegmentation.add_roi(voxel_mask=...)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
