### PR TITLE
Fix type of electrode_group in Units table

### DIFF
--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -6,6 +6,7 @@ from .form.utils import docval, getargs, popargs, call_docval_func
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_conversion, _default_resolution
 from .core import NWBContainer, ElementIdentifiers, DynamicTable
+from .ecephys import ElectrodeGroup
 
 
 @register_class('AnnotationSeries', CORE_NAMESPACE)
@@ -199,7 +200,7 @@ class Units(DynamicTable):
     @docval({'name': 'spike_times', 'type': 'array_data', 'doc': 'the spike times for the unit', 'default': None},
             {'name': 'electrode', 'type': int, 'doc': 'the electrode that each spike unit came from',
              'default': None},
-            {'name': 'electrode_group', 'type': 'array_data', 'default': None,
+            {'name': 'electrode_group', 'type': ElectrodeGroup, 'default': None,
              'doc': 'the electrode group that each spike unit came from'},
             {'name': 'waveform_mean', 'type': 'array_data', 'doc': 'the spike waveform mean for each spike unit',
              'default': None},

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -3,6 +3,8 @@ import unittest
 import numpy as np
 
 from pynwb.misc import AnnotationSeries, AbstractFeatureSeries, IntervalSeries, Units
+from pynwb.device import Device
+from pynwb.ecephys import ElectrodeGroup
 
 
 class AnnotationSeriesConstructor(unittest.TestCase):
@@ -73,6 +75,13 @@ class UnitsTests(unittest.TestCase):
         ut.add_unit(spike_times=[3, 4, 5])
         self.assertTrue(all(ut['spike_times'][0] == np.array([0, 1, 2])))
         self.assertTrue(all(ut['spike_times'][1] == np.array([3, 4, 5])))
+
+    def test_elecgroups(self):
+        dev1 = Device('dev1')
+        elec_group = ElectrodeGroup('tetrode1', 'tetrode description', 'tetrode location', dev1)
+        ut = Units()
+        ut.add_unit(electrode_group=elec_group)
+        self.assertEqual(ut['electrode_group'][0], elec_group)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

NB this is a PR against another bugfix branch (#717), because it is actively working on related code.

The `electrode_group` field of the Units table had the type `array_type`, instead of `ElectrodeGroup`. ~Since ElectrodeGroup is a DynamicTableRegion~[EDIT: no it's not, I was thinking of ElectrodeTableRegion], we only need one of them to refer to multiple electrode channels.

However... do we need both? 

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?