### PR TITLE
Remove appveyor python 3.5 env

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,13 +14,6 @@ environment:
       BUILD_TOX_ENV: build-py27
       TEST_WHEELINSTALL_ENV: wheelinstall-py27
 
-    - PYTHON_VERSION: 3.5
-      PYTHON: C:\\Python35-x64
-      TEST_TOX_ENV: py35
-      COVERAGE_TOX_ENV: coverage-py35
-      BUILD_TOX_ENV: build-py35
-      TEST_WHEELINSTALL_ENV: wheelinstall-py35
-
     - PYTHON_VERSION: 3.6
       PYTHON: C:\\Python36-x64
       TEST_TOX_ENV: py36


### PR DESCRIPTION
## Motivation

Addresses #712. It was decided to remove Python 3.5 from Appveyor for the sake of lowering total CI time to increase the speed with which PRs could be merged in.

## How to test the behavior?

Compare the time taken by Appveyor CI in this PR to previous PRs.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
