### PR TITLE
use specified name to name links

### DIFF
--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -835,7 +835,7 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                 if value.container_source != parent_container.container_source or\
                    value.parent is not parent_container:
                     rendered_obj = build_manager.build(value, source=source)
-                    builder.set_link(LinkBuilder(rendered_obj, parent=builder))
+                    builder.set_link(LinkBuilder(rendered_obj, name=spec.name, parent=builder))
             else:
                 raise ValueError("Found unmodified Container with no source - '%s' with parent '%s'" %
                                  (value.name, parent_container.name))


### PR DESCRIPTION
## Motivation

Links were not being named according to their specification. Instead, they were being named after the target object. This change uses the name in the LinkSpec to name LinkBuilders

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
