### PR TITLE
fix Images test

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -228,18 +228,14 @@ class Image(NWBData):
 
 
 @register_class('Images', CORE_NAMESPACE)
-class Images(NWBDataInterface):
+class Images(MultiContainerInterface):
 
     __clsconf__ = {
         'attr': 'images',
         'add': 'add_image',
         'type': Image,
-        'get': 'get_image'
+        'get': 'get_image',
+        'create': 'create_image'
     }
 
-    @docval({'name': 'name', 'type': str, 'doc': 'The name of this TimeSeries dataset'},
-            {'name': 'images', 'type': (list, tuple, dict), 'doc': 'images'},
-            {'name': 'description', 'type': str, 'doc': 'description of image', 'default': None})
-    def __init__(self, **kwargs):
-        super(Images, self).__init__(name=kwargs['name'])
-        self.description = popargs('description', kwargs)
+    __help = "Contains images"

--- a/tests/unit/pynwb_tests/test_base.py
+++ b/tests/unit/pynwb_tests/test_base.py
@@ -130,4 +130,5 @@ class TestImages(unittest.TestCase):
 
     def test_images(self):
         image = Image(name='test_image', data=np.ones((10, 10)))
-        Images(name='images_name', images=[image, image])
+        image2 = Image(name='test_image2', data=np.ones((10, 10)))
+        Images(name='images_name', images=[image, image2])


### PR DESCRIPTION
## Motivation

I found a bug in the Images object. This fixes it.

## How to test the behavior?
```python
image = Image(name='test_image', data=np.ones((10, 10)))
        image2 = Image(name='test_image2', data=np.ones((10, 10)))
        Images(name='images_name', images=[image, image2])
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
