### PR TITLE
add list comprehension for reading references in an array after file …

### DIFF
--- a/src/pynwb/form/backends/hdf5/h5_utils.py
+++ b/src/pynwb/form/backends/hdf5/h5_utils.py
@@ -101,7 +101,10 @@ class H5ReferenceDataset(H5Dataset):
 
     def __getitem__(self, arg):
         ref = super(H5ReferenceDataset, self).__getitem__(arg)
-        return self.io.get_container(self.dataset.file[ref])
+        if isinstance(ref, np.ndarray):
+            return [self.io.get_container(self.dataset.file[x]) for x in ref]
+        else:
+            return self.io.get_container(self.dataset.file[ref])
 
     @property
     def dtype(self):

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -80,7 +80,7 @@ class NWBFileTest(unittest.TestCase):
         elecgrp = nwbfile.create_electrode_group('a', 'b', device=device, location='a')
         for i in range(4):
             nwbfile.add_electrode(np.nan, np.nan, np.nan, np.nan, 'a', 'a', elecgrp, id=i)
-        with self.assertRaises(IndexError) as err:
+        with self.assertRaises(IndexError):
             nwbfile.create_electrode_table_region(list(range(6)), 'test')
 
     def test_access_group_after_io(self):

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -90,8 +90,19 @@ class NWBFileTest(unittest.TestCase):
         nwbfile = NWBFile('a', 'b', datetime.now(tzlocal()))
         device = nwbfile.create_device('a')
         elecgrp = nwbfile.create_electrode_group('a', 'b', device=device, location='a')
+        nwbfile.add_electrode(np.nan, np.nan, np.nan, np.nan, 'a', 'a', elecgrp, id=0)
+
+        with NWBHDF5IO('electrodes_mwe.nwb', 'w') as io:
+            io.write(nwbfile)
+
+        with NWBHDF5IO('electrodes_mwe.nwb', 'a') as io:
+            nwbfile_i = io.read()
+            for aa, bb in zip(nwbfile_i.electrodes['group'][:], nwbfile.electrodes['group'][:]):
+                self.assertEqual(aa.name, bb.name)
+
         for i in range(4):
-            nwbfile.add_electrode(np.nan, np.nan, np.nan, np.nan, 'a', 'a', elecgrp, id=i)
+            nwbfile.add_electrode(np.nan, np.nan, np.nan, np.nan, 'a', 'a', elecgrp, id=i + 1)
+
         with NWBHDF5IO('electrodes_mwe.nwb', 'w') as io:
             io.write(nwbfile)
 


### PR DESCRIPTION
…round trip

## Motivation
fix  #739

## How to test the behavior?
```python
nwbfile = NWBFile('a', 'b', datetime.now(tzlocal()))
device = nwbfile.create_device('a')
elecgrp = nwbfile.create_electrode_group('a', 'b', device=device, location='a')
for i in range(4):
    nwbfile.add_electrode(np.nan, np.nan, np.nan, np.nan, 'a', 'a', elecgrp, id=i)
with NWBHDF5IO('electrodes_mwe.nwb', 'w') as io:
    io.write(nwbfile)

with NWBHDF5IO('electrodes_mwe.nwb', 'a') as io:
    nwbfile_i = io.read()
    for aa, bb in zip(nwbfile_i.electrodes['group'][:], nwbfile.electrodes['group'][:]):
        self.assertEqual(aa.name, bb.name)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
