### PR TITLE
NWBHDF5IO/HDF5IO: Use none as default opening mode

### DIFF
--- a/docs/gallery/general/advanced_hdf5_io.py
+++ b/docs/gallery/general/advanced_hdf5_io.py
@@ -174,7 +174,7 @@ io.close()
 #
 # Again, nothing has changed for read. All of the above advanced I/O features are handled transparently.
 
-io = NWBHDF5IO('advanced_io_example.nwb')
+io = NWBHDF5IO('advanced_io_example.nwb', 'r')
 nwbfile = io.read()
 
 ####################

--- a/docs/gallery/general/file.py
+++ b/docs/gallery/general/file.py
@@ -236,7 +236,7 @@ with NWBHDF5IO('basic_example.nwb', 'w') as io:
 # and use the :py:func:`~pynwb.form.backends.io.FORMIO.read` method to retrieve an
 # :py:class:`~pynwb.file.NWBFile` object.
 
-io = NWBHDF5IO('basic_example.nwb')
+io = NWBHDF5IO('basic_example.nwb', 'r')
 nwbfile = io.read()
 
 ####################
@@ -298,6 +298,11 @@ mod_ts = added_mod.get_data_interface('ts_for_mod')
 # the name of the object we want back.
 
 mod_ts = added_mod['ts_for_mod']
+
+####################
+# Close the file when we are done with it.
+
+io.close()
 
 ####################
 # .. _basic_appending:

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -449,7 +449,7 @@ print("   Reduction     :  %.2f x" % (expected_size / file_size_largechunks_comp
 #
 #   .. code-block:: python
 #
-#       io = NWBHDF5IO('basic_sparse_iterwrite_example.nwb')
+#       io = NWBHDF5IO('basic_sparse_iterwrite_example.nwb', 'r')
 #       nwbfile = io.read()
 #       data = nwbfile.get_acquisition('synthetic_timeseries').data  # <-- PyNWB does lazy load; no problem
 #       subset = data[10:100, 10:100]                                # <-- Loading a subset is fine too
@@ -541,7 +541,7 @@ write_test_file(filename='basic_sparse_iterwrite_largearray.nwb',
 # Read the NWB file
 from pynwb import NWBHDF5IO    # noqa
 
-io = NWBHDF5IO('basic_sparse_iterwrite_largearray.nwb')
+io = NWBHDF5IO('basic_sparse_iterwrite_largearray.nwb', 'r')
 nwbfile = io.read()
 data = nwbfile.get_acquisition('synthetic_timeseries').data
 # Compare all the data values of our two arrays

--- a/docs/gallery/general/linking_data.py
+++ b/docs/gallery/general/linking_data.py
@@ -128,7 +128,7 @@ nwbfile4 = NWBFile(session_description='demonstrate external files',
 #
 
 # Get the first timeseries
-io1 = NWBHDF5IO(filename1)
+io1 = NWBHDF5IO(filename1, 'r')
 nwbfile1 = io1.read()
 timeseries_1 = nwbfile1.get_acquisition('test_timeseries1')
 timeseries_1_data = timeseries_1.data
@@ -208,12 +208,12 @@ manager = get_manager()
 #
 
 # Get the first timeseries
-io1 = NWBHDF5IO(filename1, manager=manager)
+io1 = NWBHDF5IO(filename1, 'r', manager=manager)
 nwbfile1 = io1.read()
 timeseries_1 = nwbfile1.get_acquisition('test_timeseries1')
 
 # Get the second timeseries
-io2 = NWBHDF5IO(filename2, manager=manager)
+io2 = NWBHDF5IO(filename2, 'r', manager=manager)
 nwbfile2 = io2.read()
 timeseries_2 = nwbfile2.get_acquisition('test_timeseries2')
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -190,7 +190,7 @@ class NWBHDF5IO(HDF5IO):
 
     @docval({'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
             {'name': 'mode', 'type': str,
-             'doc': 'the mode to open the HDF5 file with, one of ("w", "r", "r+", "a", "w-")', 'default': 'a'},
+             'doc': 'the mode to open the HDF5 file with, one of ("w", "r", "r+", "a", "w-")'},
             {'name': 'load_namespaces', 'type': bool,
              'doc': 'whether or not to load cached namespaces from given path', 'default': False},
             {'name': 'manager', 'type': BuildManager, 'doc': 'the BuildManager to use for I/O', 'default': None},
@@ -226,7 +226,7 @@ class NWBHDF5IO(HDF5IO):
                 manager = get_manager(extensions=extensions)
             elif manager is None:
                 manager = get_manager()
-        super(NWBHDF5IO, self).__init__(path, manager, mode=mode, file=file_obj)
+        super(NWBHDF5IO, self).__init__(path, manager=manager, mode=mode, file=file_obj)
 
 
 from . import io as __io  # noqa: F401,E402

--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -32,7 +32,7 @@ class HDF5IO(FORMIO):
     @docval({'name': 'path', 'type': str, 'doc': 'the path to the HDF5 file'},
             {'name': 'manager', 'type': BuildManager, 'doc': 'the BuildManager to use for I/O', 'default': None},
             {'name': 'mode', 'type': str,
-             'doc': 'the mode to open the HDF5 file with, one of ("w", "r", "r+", "a", "w-")', 'default': 'a'},
+             'doc': 'the mode to open the HDF5 file with, one of ("w", "r", "r+", "a", "w-")'},
             {'name': 'comm', 'type': 'Intracom',
              'doc': 'the MPI communicator to use for parallel I/O', 'default': None},
             {'name': 'file', 'type': File, 'doc': 'a pre-existing h5py.File object', 'default': None})

--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -36,7 +36,7 @@ def main():
         print('%s not found' % args.path, file=sys.stderr)
         sys.exit(1)
 
-    io = HDF5IO(args.path, get_manager())
+    io = HDF5IO(args.path, get_manager(), mode='r')
 
     if args.nspath is not None:
         namespaces = load_namespaces(args.nspath)

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -62,7 +62,7 @@ class TestHDF5Writer(unittest.TestCase):
         os.remove(self.path)
 
     def test_nwbio(self):
-        io = HDF5IO(self.path, self.manager)
+        io = HDF5IO(self.path, manager=self.manager, mode='a')
         io.write(self.container)
         io.close()
         f = File(self.path)
@@ -78,7 +78,7 @@ class TestHDF5Writer(unittest.TestCase):
         self.assertIn('test_timeseries', acq)
 
     def test_write_clobber(self):
-        io = HDF5IO(self.path, self.manager)
+        io = HDF5IO(self.path, manager=self.manager, mode='a')
         io.write(self.container)
         io.close()
         f = File(self.path)  # noqa: F841
@@ -89,7 +89,7 @@ class TestHDF5Writer(unittest.TestCase):
             assert_file_exists = OSError
 
         with self.assertRaises(assert_file_exists):
-            io = HDF5IO(self.path, self.manager, mode='w-')
+            io = HDF5IO(self.path, manager=self.manager, mode='w-')
             io.write(self.container)
             io.close()
 
@@ -97,7 +97,7 @@ class TestHDF5Writer(unittest.TestCase):
         '''
         Round-trip test for writing spec and reading it back in
         '''
-        io = HDF5IO(self.path, self.manager)
+        io = HDF5IO(self.path, manager=self.manager, mode="a")
         io.write(self.container, cache_spec=True)
         io.close()
         f = File(self.path)
@@ -170,7 +170,7 @@ class TestHDF5WriterWithInjectedFile(unittest.TestCase):
 
     def test_nwbio(self):
         fil = File(self.path)
-        io = HDF5IO(self.path, self.manager, file=fil)
+        io = HDF5IO(self.path, manager=self.manager, file=fil, mode="a")
         io.write(self.container)
         io.close()
         f = File(self.path)
@@ -187,7 +187,7 @@ class TestHDF5WriterWithInjectedFile(unittest.TestCase):
 
     def test_write_clobber(self):
         fil = File(self.path)
-        io = HDF5IO(self.path, self.manager, file=fil)
+        io = HDF5IO(self.path, manager=self.manager, file=fil, mode="a")
         io.write(self.container)
         io.close()
         f = File(self.path)  # noqa: F841
@@ -198,7 +198,7 @@ class TestHDF5WriterWithInjectedFile(unittest.TestCase):
             assert_file_exists = OSError
 
         with self.assertRaises(assert_file_exists):
-            io = HDF5IO(self.path, self.manager, mode='w-')
+            io = HDF5IO(self.path, manager=self.manager, mode='w-')
             io.write(self.container)
             io.close()
 
@@ -208,7 +208,7 @@ class TestHDF5WriterWithInjectedFile(unittest.TestCase):
         '''
 
         fil = File(self.path)
-        io = HDF5IO(self.path, self.manager, file=fil)
+        io = HDF5IO(self.path, manager=self.manager, file=fil, mode='a')
         io.write(self.container, cache_spec=True)
         io.close()
         f = File(self.path)

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -151,10 +151,10 @@ class TestMapRoundTrip(TestMapNWBContainer):
         nwbfile = NWBFile(description, identifier, self.start_time, file_create_date=self.create_date)
         self.addContainer(nwbfile)
 
-        self.writer = HDF5IO(self.filename, get_manager(), mode='w')
+        self.writer = HDF5IO(self.filename, manager=get_manager(), mode='w')
         self.writer.write(nwbfile)
         self.writer.close()
-        self.reader = HDF5IO(self.filename, get_manager(), mode='r')
+        self.reader = HDF5IO(self.filename, manager=get_manager(), mode='r')
         read_nwbfile = self.reader.read()
 
         try:

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -151,16 +151,16 @@ class TestNWBFileIO(base.TestMapNWBContainer):
             os.remove(self.path)
 
     def test_write(self):
-        hdf5io = HDF5IO(self.path, self.manager)
+        hdf5io = HDF5IO(self.path, manager=self.manager, mode='a')
         hdf5io.write(self.container)
         hdf5io.close()
         # TODO add some asserts
 
     def test_read(self):
-        hdf5io = HDF5IO(self.path, self.manager)
+        hdf5io = HDF5IO(self.path, manager=self.manager, mode='a')
         hdf5io.write(self.container)
         hdf5io.close()
-        hdf5io = HDF5IO(self.path, self.manager)
+        hdf5io = HDF5IO(self.path, manager=self.manager, mode='a')
         container = hdf5io.read()
         self.assertIsInstance(container, NWBFile)
         raw_ts = container.acquisition

--- a/tests/unit/form_tests/test_io_hdf5.py
+++ b/tests/unit/form_tests/test_io_hdf5.py
@@ -228,13 +228,13 @@ class TestHDF5Writer(GroupBuilderTestCase):
         return f
 
     def test_write_builder(self):
-        writer = HDF5IO(self.path, self.manager)
+        writer = HDF5IO(self.path, manager=self.manager, mode='a')
         writer.write_builder(self.builder)
         writer.close()
         self.check_fields()
 
     def test_write_attribute_reference_container(self):
-        writer = HDF5IO(self.path, self.manager)
+        writer = HDF5IO(self.path, manager=self.manager, mode='a')
         self.builder.set_attribute('ref_attribute', self.ts)
         writer.write_builder(self.builder)
         writer.close()
@@ -243,7 +243,7 @@ class TestHDF5Writer(GroupBuilderTestCase):
         self.assertEqual(f['acquisition/timeseries/test_timeseries'], f[f.attrs['ref_attribute']])
 
     def test_write_attribute_reference_builder(self):
-        writer = HDF5IO(self.path, self.manager)
+        writer = HDF5IO(self.path, manager=self.manager, mode='a')
         self.builder.set_attribute('ref_attribute', self.ts_builder)
         writer.write_builder(self.builder)
         writer.close()
@@ -252,13 +252,13 @@ class TestHDF5Writer(GroupBuilderTestCase):
         self.assertEqual(f['acquisition/timeseries/test_timeseries'], f[f.attrs['ref_attribute']])
 
     def test_write_context_manager(self):
-        with HDF5IO(self.path, self.manager) as writer:
+        with HDF5IO(self.path, manager=self.manager, mode='a') as writer:
             writer.write_builder(self.builder)
         self.check_fields()
 
     def test_read_builder(self):
         self.maxDiff = None
-        io = HDF5IO(self.path, self.manager)
+        io = HDF5IO(self.path, manager=self.manager, mode='a')
         io.write_builder(self.builder)
         builder = io.read_builder()
         self.assertBuilderEqual(builder, self.builder)
@@ -266,7 +266,7 @@ class TestHDF5Writer(GroupBuilderTestCase):
 
     def test_overwrite_written(self):
         self.maxDiff = None
-        io = HDF5IO(self.path, self.manager)
+        io = HDF5IO(self.path, manager=self.manager, mode='a')
         io.write_builder(self.builder)
         builder = io.read_builder()
         with self.assertRaisesRegex(ValueError, "cannot change written to not written"):

--- a/tests/unit/form_tests/test_io_hdf5_h5tools.py
+++ b/tests/unit/form_tests/test_io_hdf5_h5tools.py
@@ -32,7 +32,7 @@ class H5IOTest(unittest.TestCase):
         # The temp file will be closed before h5py truncates it
         # and will be removed during the tearDown step.
         self.test_temp_file.close()
-        self.io = HDF5IO(self.test_temp_file.name)
+        self.io = HDF5IO(self.test_temp_file.name, mode='a')
         self.f = self.io._file
 
     def tearDown(self):
@@ -363,7 +363,7 @@ class TestCacheSpec(unittest.TestCase):
         # The temp file will be closed before h5py truncates it
         # and will be removed during the tearDown step.
         self.test_temp_file.close()
-        self.io = NWBHDF5IO(self.test_temp_file.name)
+        self.io = NWBHDF5IO(self.test_temp_file.name, mode='a')
         # Setup all the data we need
         start_time = datetime(2017, 4, 3, 11, tzinfo=tzlocal())
         create_date = datetime(2017, 4, 15, 12, tzinfo=tzlocal())
@@ -449,7 +449,7 @@ class NWBHDF5IOMultiFileTest(unittest.TestCase):
         # and will be removed during the tearDown step.
         for i in self.test_temp_files:
             i.close()
-        self.io = [NWBHDF5IO(i.name) for i in self.test_temp_files]
+        self.io = [NWBHDF5IO(i.name, mode='a') for i in self.test_temp_files]
         self.f = [i._file for i in self.io]
 
     def tearDown(self):


### PR DESCRIPTION
The default opening mode for HDF5 files is, in accordance with h5py, "a"
which means "Read/write if exists, create otherwise (default)".

This is for numerous reasons a suboptimal choice:
- On windows this locks files which are maybe supposed to be opened read
  only. Thus other programs can not read these files.
- It opens the potential for data corruption if a file is meant to be
  read only and h5py and its C core crashes.
- It results in rather uninspiring error messages when
  trying to open a non-existing file for reading using

  with NWBHDF5IO("I_DONT_EXIST.nwb") as io:
          io.read()

  -> 5 pages of backtraces following

So let's use no mode as default and force the user to choose if she likes
to read or write.
