### PR TITLE
Shortcut loop in ObjectMapper.__is_reftype to improve perfomance

### DIFF
--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -4,7 +4,7 @@ import warnings
 from collections import OrderedDict
 from copy import copy
 from datetime import datetime
-from six import with_metaclass, raise_from, text_type, binary_type
+from six import with_metaclass, raise_from, text_type, binary_type, integer_types
 
 from ..utils import docval, getargs, ExtenderMeta, get_docval, fmt_docval_args, call_docval_func
 from ..container import Container, Data, DataRegion
@@ -661,6 +661,9 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         while hasattr(tmp, '__len__') and not isinstance(tmp, (Container, text_type, binary_type)):
             tmptmp = None
             for t in tmp:
+                # In case of a numeric array stop the iteration at the first element to avoid long-running loop
+                if isinstance(t, (integer_types, float, complex, bool)):
+                    break
                 if hasattr(t, '__len__') and not isinstance(t, (Container, text_type, binary_type)) and len(t) > 0:
                     tmptmp = tmp[0]
                     break


### PR DESCRIPTION
## Motivation
Fix #728. Write of spike times was slow because ObjectMapper.__is_reftype was iterating over all elements in the spike_times array. This fix shortcuts the corresponding loop if the first element is Python numeric type. 

## How to test the behavior?
See #728 and the script provided by @NileGraddis here https://gist.github.com/NileGraddis/96c70d1827c9b37333dafdcb2835703c

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
