### PR TITLE
FORM tests: Don't use deprecated unit test assertions

### DIFF
--- a/tests/unit/form_tests/utils_test/test_core_DataChunkIterator.py
+++ b/tests/unit/form_tests/utils_test/test_core_DataChunkIterator.py
@@ -41,7 +41,7 @@ class DataChunkIteratorTests(unittest.TestCase):
         a = np.arange(10)
         dci = DataChunkIterator(data=a, buffer_size=3)
         self.assertTupleEqual(dci.maxshape, a.shape)
-        self.assertEquals(dci.dtype, a.dtype)
+        self.assertEqual(dci.dtype, a.dtype)
         count = 0
         for chunk in dci:
             if count < 3:
@@ -68,7 +68,7 @@ class DataChunkIteratorTests(unittest.TestCase):
 
     def test_standard_iterator_unmatched_buffersized(self):
         dci = DataChunkIterator(data=range(10), buffer_size=3)
-        self.assertEquals(dci.dtype, np.dtype(int))
+        self.assertEqual(dci.dtype, np.dtype(int))
         self.assertTupleEqual(dci.maxshape, (10,))
         self.assertIsNone(dci.recommended_chunk_shape())
         self.assertTupleEqual(dci.recommended_data_shape(), (10,))  # Test before and after iteration
@@ -91,7 +91,7 @@ class DataChunkIteratorTests(unittest.TestCase):
         for chunk in dci:
             self.assertTupleEqual(chunk.data.shape, (1, 2, 3))
             count += 1
-        self.assertEquals(count, 5)
+        self.assertEqual(count, 5)
         self.assertTupleEqual(dci.recommended_data_shape(), (5, 2, 3))
         self.assertIsNone(dci.recommended_chunk_shape())
 

--- a/tests/unit/form_tests/utils_test/test_core_ShapeValidator.py
+++ b/tests/unit/form_tests/utils_test/test_core_ShapeValidator.py
@@ -46,7 +46,7 @@ class ShapeValidatorTests(unittest.TestCase):
         d2 = np.arange(20).reshape(5, 2, 2)
         res = assertEqualShape(d1, d2)
         self.assertFalse(res.result)
-        self.assertEquals(res.error, 'NUM_AXES_ERROR')
+        self.assertEqual(res.error, 'NUM_AXES_ERROR')
         self.assertTupleEqual(res.ignored, ())
         self.assertTupleEqual(res.unmatched, ())
         self.assertTupleEqual(res.shape1, (2, 5))
@@ -88,7 +88,7 @@ class ShapeValidatorTests(unittest.TestCase):
         d2 = np.arange(20).reshape(5, 2, 2)
         res = assertEqualShape(d1, d2, [0, 1], 1)
         self.assertFalse(res.result)
-        self.assertEquals(res.error, "NUM_AXES_ERROR")
+        self.assertEqual(res.error, "NUM_AXES_ERROR")
         self.assertTupleEqual(res.ignored, ())
         self.assertTupleEqual(res.unmatched, ())
         self.assertTupleEqual(res.shape1, (2, 5))
@@ -102,7 +102,7 @@ class ShapeValidatorTests(unittest.TestCase):
         d2 = np.arange(20).reshape(5, 2, 2)
         res = assertEqualShape(d1, d2, 4, 1)
         self.assertFalse(res.result)
-        self.assertEquals(res.error, 'AXIS_OUT_OF_BOUNDS')
+        self.assertEqual(res.error, 'AXIS_OUT_OF_BOUNDS')
         self.assertTupleEqual(res.ignored, ())
         self.assertTupleEqual(res.unmatched, ())
         self.assertTupleEqual(res.shape1, (2, 5))
@@ -116,7 +116,7 @@ class ShapeValidatorTests(unittest.TestCase):
         d2 = np.arange(20).reshape(5, 2, 2)
         res = assertEqualShape(d1, d2, [0, 1], [5, 0])
         self.assertFalse(res.result)
-        self.assertEquals(res.error, 'AXIS_OUT_OF_BOUNDS')
+        self.assertEqual(res.error, 'AXIS_OUT_OF_BOUNDS')
         self.assertTupleEqual(res.ignored, ())
         self.assertTupleEqual(res.unmatched, ())
         self.assertTupleEqual(res.shape1, (2, 5))
@@ -158,7 +158,7 @@ class ShapeValidatorTests(unittest.TestCase):
         d2 = DataChunkIterator(data=np.arange(10).reshape(2, 5))
         res = assertEqualShape(d1, d2, ignore_undetermined=False)
         self.assertFalse(res.result)
-        self.assertEquals(res.error, 'AXIS_LEN_ERROR')
+        self.assertEqual(res.error, 'AXIS_LEN_ERROR')
         self.assertTupleEqual(res.ignored, ())
         self.assertTupleEqual(res.unmatched, ((0, 0),))
         self.assertTupleEqual(res.shape1, (None, 5))
@@ -178,7 +178,7 @@ class ShapeValidatorResultTests(unittest.TestCase):
     def test_default_message(self):
         temp = ShapeValidatorResult()
         temp.error = 'AXIS_LEN_ERROR'
-        self.assertEquals(temp.default_message, ShapeValidatorResult.SHAPE_ERROR[temp.error])
+        self.assertEqual(temp.default_message, ShapeValidatorResult.SHAPE_ERROR[temp.error])
 
     def test_set_error_to_illegal_type(self):
         temp = ShapeValidatorResult()


### PR DESCRIPTION
assertEquals is deprecated in favour of assertEqual.