### PR TITLE
Add Builder tests for icephys

### DIFF
--- a/tests/integration/ui_write/test_icephys.py
+++ b/tests/integration/ui_write/test_icephys.py
@@ -1,3 +1,5 @@
+from pynwb.form.build import GroupBuilder, LinkBuilder, DatasetBuilder
+
 from pynwb.icephys import (IntracellularElectrode, PatchClampSeries, CurrentClampStimulusSeries,
                            VoltageClampStimulusSeries, CurrentClampSeries,
                            VoltageClampSeries, IZeroClampSeries)
@@ -21,6 +23,31 @@ class TestIntracellularElectrode(base.TestMapRoundTrip):
                                            initial_access_resistance='I guess this changes',
                                            device=self.device)
         return self.elec
+
+    def setUpBuilder(self):
+        device = GroupBuilder('device_name',
+                              attributes={'help': 'A recording device e.g. amplifier',
+                                          'namespace': 'core',
+                                          'neurodata_type': 'Device'})
+        datasets = [
+            DatasetBuilder('slice', data=u'tissue slice'),
+            DatasetBuilder('resistance', data=u'something measured in ohms'),
+            DatasetBuilder('seal', data=u'sealing method'),
+            DatasetBuilder('description', data=u'a fake electrode object'),
+            DatasetBuilder('location', data=u'Springfield Elementary School'),
+            DatasetBuilder('filtering', data=u'a meaningless free-form text field'),
+            DatasetBuilder('initial_access_resistance', data=u'I guess this changes'),
+        ]
+        elec = GroupBuilder('elec0',
+                            attributes={'help': 'Metadata about an intracellular electrode',
+                                        'namespace': 'core',
+                                        'neurodata_type': 'IntracellularElectrode',
+                                        },
+                            datasets={d.name: d for d in datasets},
+                            links={
+                                'device': LinkBuilder(device, 'device')
+                            })
+        return elec
 
     def addContainer(self, nwbfile):
         ''' Should take an NWBFile object and add the container to it '''

--- a/tests/integration/ui_write/test_icephys.py
+++ b/tests/integration/ui_write/test_icephys.py
@@ -1,6 +1,7 @@
-from pynwb.form.build import GroupBuilder, LinkBuilder, DatasetBuilder
-
+from pynwb.form.build import GroupBuilder, LinkBuilder, ReferenceBuilder, DatasetBuilder
+from pynwb import NWBFile
 from pynwb.icephys import (IntracellularElectrode, PatchClampSeries, CurrentClampStimulusSeries,
+                           SweepTable,
                            VoltageClampStimulusSeries, CurrentClampSeries,
                            VoltageClampSeries, IZeroClampSeries)
 from pynwb.device import Device
@@ -133,34 +134,148 @@ class TestIZeroClampSeries(TestPatchClampSeries):
 
 class TestSweepTableRoundTripEasy(base.TestMapRoundTrip):
 
-    def setUpContainer(self):
+    _required_tests = ('test_container', 'test_build', 'test_construct', 'test_roundtrip')
 
-        # will be overwritten in addContainer
-        return None
+    def setUpContainer(self):
+        self.setUpSweepTable()
+        return self.sweep_table
+
+    def setUpSweepTable(self):
+        self.device = Device(name='device_name')
+        self.elec = IntracellularElectrode(name="elec0", slice='tissue slice',
+                                           resistance='something measured in ohms',
+                                           seal='sealing method', description='a fake electrode object',
+                                           location='Springfield Elementary School',
+                                           filtering='a meaningless free-form text field',
+                                           initial_access_resistance='I guess this changes',
+                                           device=self.device)
+        self.pcs = PatchClampSeries(name="pcs", data=[1, 2, 3, 4, 5], unit='A',
+                                    starting_time=123.6, rate=10e3, electrode=self.elec, gain=0.126,
+                                    stimulus_description="gotcha ya!", sweep_number=4711)
+        self.sweep_table = SweepTable(name='sweep_table')
+        self.sweep_table.add_entry(self.pcs)
 
     def addContainer(self, nwbfile):
-        device = Device(name='device_name')
-        nwbfile.add_device(device)
-        elec = IntracellularElectrode(name="elec0", slice='tissue slice',
-                                      resistance='something measured in ohms',
-                                      seal='sealing method', description='a fake electrode object',
-                                      location='Springfield Elementary School',
-                                      filtering='a meaningless free-form text field',
-                                      initial_access_resistance='I guess this changes',
-                                      device=device)
-        nwbfile.add_ic_electrode(elec)
-        pcs = PatchClampSeries(name="pcs", data=[1, 2, 3, 4, 5], unit='A',
-                               starting_time=123.6, rate=10e3, electrode=elec, gain=0.126,
-                               stimulus_description="gotcha ya!", sweep_number=4711)
-        nwbfile.add_acquisition(pcs)
-        self.container = nwbfile.sweep_table
+        nwbfile.add_device(self.device)
+        nwbfile.add_ic_electrode(self.elec)
+        nwbfile.add_acquisition(self.pcs)
 
-        self.assertEqual(len(self.container['series'].data), 1)
-        self.assertEqual(self.container.id[0], 0)
-        self.assertEqual(self.container['sweep_number'].data[0], 4711)
+    def test_container(self):
+        description = 'a file to test writing and reading a %s' % self.container_type
+        identifier = 'TEST_%s' % self.container_type
+        nwbfile = NWBFile(description, identifier, self.start_time, file_create_date=self.create_date)
+        self.addContainer(nwbfile)
+
+        sweep_table = self.getContainer(nwbfile)
+        self.assertEqual(len(sweep_table['series'].data), 1)
+        self.assertEqual(sweep_table.id[0], 0)
+        self.assertEqual(sweep_table['sweep_number'].data[0], 4711)
 
     def getContainer(self, nwbfile):
+        ''' Should take an NWBFile object and return the Container'''
         return nwbfile.sweep_table
+
+    def setUpBuilder(self):
+        device = GroupBuilder('device_name',
+                              attributes={'neurodata_type': 'Device',
+                                          'help': 'A recording device e.g. amplifier',
+                                          'namespace': 'core',
+                                          })
+        datasets = [
+            DatasetBuilder('slice', data=u'tissue slice'),
+            DatasetBuilder('resistance', data=u'something measured in ohms'),
+            DatasetBuilder('seal', data=u'sealing method'),
+            DatasetBuilder('description', data=u'a fake electrode object'),
+            DatasetBuilder('location', data=u'Springfield Elementary School'),
+            DatasetBuilder('filtering', data=u'a meaningless free-form text field'),
+            DatasetBuilder('initial_access_resistance', data=u'I guess this changes'),
+        ]
+        elec = GroupBuilder('elec0',
+                            attributes={'help': 'Metadata about an intracellular electrode',
+                                        'namespace': 'core',
+                                        'neurodata_type': 'IntracellularElectrode',
+                                        },
+                            datasets={d.name: d for d in datasets},
+                            links={
+                                'device': LinkBuilder(device, 'device')
+                            })
+        datasets = [
+            DatasetBuilder('gain',
+                           data=0.126,
+                           attributes={},
+                           ),
+            DatasetBuilder('data',
+                           data=[1, 2, 3, 4, 5],
+                           attributes={'conversion': 1.0,
+                                       'resolution': 0.0,
+                                       'unit': u'A',
+                                       }
+                           ),
+            DatasetBuilder('starting_time',
+                           data=123.6,
+                           attributes={'rate': 10000.0,
+                                       'unit': 'Seconds',
+                                       }
+                           ),
+                ]
+        pcs = GroupBuilder('pcs',
+                           attributes={'neurodata_type': 'PatchClampSeries',
+                                       'namespace': 'core',
+                                       'comments': u'no comments',
+                                       'help': 'Superclass definition for patch-clamp data',
+                                       'description': u'no description',
+                                       'stimulus_description': u'gotcha ya!',
+                                       'sweep_number': 4711
+                                       },
+                           links={'electrode': LinkBuilder(elec, 'electrode')},
+                           datasets={d.name: d for d in datasets},
+                           )
+
+        column_id = DatasetBuilder('id', [0],
+                                   attributes={'neurodata_type': 'ElementIdentifiers',
+                                               'namespace': 'core',
+                                               'help': 'unique identifiers for a list of elements',
+                                               }
+                                   )
+
+        column_series = DatasetBuilder('series',
+                                       attributes={'neurodata_type': 'VectorData',
+                                                   'namespace': 'core',
+                                                   'help': 'Values for a list of elements',
+                                                   'description': u'PatchClampSeries with the same sweep number',
+                                                   },
+                                       data=[LinkBuilder(pcs)]
+                                       )
+
+        column_index = DatasetBuilder('series_index', [1],
+                                      attributes={'neurodata_type': 'VectorIndex',
+                                                  'namespace': 'core',
+                                                  'help': 'indexes into a list of values for a list of elements',
+                                                  'target': ReferenceBuilder(column_series),
+                                                  },
+                                      )
+
+        column_sweep_number = DatasetBuilder('sweep_number', data=[4711],
+                                             attributes={'neurodata_type': 'VectorData',
+                                                         'namespace': 'core',
+                                                         'help': 'Values for a list of elements',
+                                                         'description': u'Sweep number of the entries in that row',
+                                                         }
+                                             )
+
+        columns = [column_id, column_series, column_index, column_sweep_number]
+        sweep_table = GroupBuilder('sweep_table', datasets={c.name: c for c in columns},
+                                   attributes={'neurodata_type': 'SweepTable',
+                                               'namespace': 'core',
+                                               'colnames': ('series',
+                                                            'sweep_number'),
+                                               'help': 'The table which groups different PatchClampSeries together',
+                                               'description':
+                                               u'A sweep table groups different PatchClampSeries together.',
+                                               },
+                                   )
+
+        return sweep_table
 
 
 class TestSweepTableRoundTripComplicated(base.TestMapRoundTrip):

--- a/tests/integration/ui_write/test_icephys.py
+++ b/tests/integration/ui_write/test_icephys.py
@@ -280,52 +280,66 @@ class TestSweepTableRoundTripEasy(base.TestMapRoundTrip):
 
 class TestSweepTableRoundTripComplicated(base.TestMapRoundTrip):
 
+    _required_tests = ('test_container', 'test_build', 'test_construct', 'test_roundtrip')
+
     def setUpContainer(self):
-        # will be overwritten in addContainer
-        return None
+        self.setUpSweepTable()
+        return self.sweep_table
+
+    def setUpSweepTable(self):
+        self.device = Device(name='device_name')
+        self.elec = IntracellularElectrode(name="elec0", slice='tissue slice',
+                                           resistance='something measured in ohms',
+                                           seal='sealing method', description='a fake electrode object',
+                                           location='Springfield Elementary School',
+                                           filtering='a meaningless free-form text field',
+                                           initial_access_resistance='I guess this changes',
+                                           device=self.device)
+        self.pcs1 = PatchClampSeries(name="pcs1", data=[1, 2, 3, 4, 5], unit='A',
+                                     starting_time=123.6, rate=10e3, electrode=self.elec, gain=0.126,
+                                     stimulus_description="gotcha ya!", sweep_number=4711)
+        self.pcs2a = PatchClampSeries(name="pcs2a", data=[1, 2, 3, 4, 5], unit='A',
+                                      starting_time=123.6, rate=10e3, electrode=self.elec, gain=0.126,
+                                      stimulus_description="gotcha ya!", sweep_number=4712)
+        self.pcs2b = PatchClampSeries(name="pcs2b", data=[1, 2, 3, 4, 5], unit='A',
+                                      starting_time=123.6, rate=10e3, electrode=self.elec, gain=0.126,
+                                      stimulus_description="gotcha ya!", sweep_number=4712)
+
+        self.sweep_table = SweepTable(name='sweep_table')
+        self.sweep_table.add_entry(self.pcs1)
+        self.sweep_table.add_entry(self.pcs2a)
+        self.sweep_table.add_entry(self.pcs2b)
 
     def addContainer(self, nwbfile):
-        device = Device(name='device_name')
-        nwbfile.add_device(device)
-        elec = IntracellularElectrode(name="elec0", slice='tissue slice',
-                                      resistance='something measured in ohms',
-                                      seal='sealing method', description='a fake electrode object',
-                                      location='Springfield Elementary School',
-                                      filtering='a meaningless free-form text field',
-                                      initial_access_resistance='I guess this changes',
-                                      device=device)
-        nwbfile.add_ic_electrode(elec)
+        ''' Should take an NWBFile object and add the SweepTable container to it '''
+        nwbfile.add_device(self.device)
+        nwbfile.add_ic_electrode(self.elec)
 
-        self.pcs1 = PatchClampSeries(name="pcs1", data=[1, 2, 3, 4, 5], unit='A',
-                                     starting_time=123.6, rate=10e3, electrode=elec, gain=0.126,
-                                     stimulus_description="gotcha ya!", sweep_number=4711)
         nwbfile.add_acquisition(self.pcs1)
-
-        self.pcs2a = PatchClampSeries(name="pcs2a", data=[1, 2, 3, 4, 5], unit='A',
-                                      starting_time=123.6, rate=10e3, electrode=elec, gain=0.126,
-                                      stimulus_description="gotcha ya!", sweep_number=4712)
         nwbfile.add_stimulus_template(self.pcs2a)
-
-        self.pcs2b = PatchClampSeries(name="pcs2b", data=[1, 2, 3, 4, 5], unit='A',
-                                      starting_time=123.6, rate=10e3, electrode=elec, gain=0.126,
-                                      stimulus_description="gotcha ya!", sweep_number=4712)
         nwbfile.add_stimulus(self.pcs2b)
 
-        self.container = nwbfile.sweep_table
+    def test_container(self):
+        description = 'a file to test writing and reading a %s' % self.container_type
+        identifier = 'TEST_%s' % self.container_type
+        nwbfile = NWBFile(description, identifier, self.start_time, file_create_date=self.create_date)
+        self.addContainer(nwbfile)
 
-        self.assertEqual(len(self.container['series'].data), 3)
-        self.assertEqual(self.container['sweep_number'].data[0], 4711)
-        self.assertEqual(self.container['sweep_number'].data[1], 4712)
-        self.assertEqual(self.container['sweep_number'].data[2], 4712)
+        sweep_table = self.getContainer(nwbfile)
 
-        series = self.container.get_series(4711)
+        self.assertEqual(len(sweep_table['series'].data), 3)
+        self.assertEqual(sweep_table['sweep_number'].data[0], 4711)
+        self.assertEqual(sweep_table['sweep_number'].data[1], 4712)
+        self.assertEqual(sweep_table['sweep_number'].data[2], 4712)
+
+        series = sweep_table.get_series(4711)
         self.assertEqual(len(series), 1)
         names = [elem.name for elem in series]
         self.assertEqual(names, ["pcs1"])
         sweep_numbers = [elem.sweep_number for elem in series]
         self.assertEqual(sweep_numbers, [4711])
 
-        series = self.container.get_series(4712)
+        series = sweep_table.get_series(4712)
         self.assertEqual(len(series), 2)
         names = [elem.name for elem in series]
         self.assertEqual(names, ["pcs2a", "pcs2b"])
@@ -334,3 +348,119 @@ class TestSweepTableRoundTripComplicated(base.TestMapRoundTrip):
 
     def getContainer(self, nwbfile):
         return nwbfile.sweep_table
+
+    def setUpBuilder(self):
+        device = GroupBuilder('device_name',
+                              attributes={'neurodata_type': 'Device',
+                                          'help': 'A recording device e.g. amplifier',
+                                          'namespace': 'core',
+                                          })
+
+        datasets = [
+            DatasetBuilder('slice', data=u'tissue slice'),
+            DatasetBuilder('resistance', data=u'something measured in ohms'),
+            DatasetBuilder('seal', data=u'sealing method'),
+            DatasetBuilder('description', data=u'a fake electrode object'),
+            DatasetBuilder('location', data=u'Springfield Elementary School'),
+            DatasetBuilder('filtering', data=u'a meaningless free-form text field'),
+            DatasetBuilder('initial_access_resistance', data=u'I guess this changes'),
+        ]
+        elec = GroupBuilder('elec0',
+                            attributes={'help': 'Metadata about an intracellular electrode',
+                                        'namespace': 'core',
+                                        'neurodata_type': 'IntracellularElectrode',
+                                        },
+                            datasets={d.name: d for d in datasets},
+                            links={
+                                'device': LinkBuilder(device, 'device')
+                            })
+
+        datasets = [
+            DatasetBuilder('gain',
+                           data=0.126,
+                           attributes={},
+                           ),
+            DatasetBuilder('data',
+                           data=[1, 2, 3, 4, 5],
+                           attributes={'conversion': 1.0,
+                                       'resolution': 0.0,
+                                       'unit': u'A',
+                                       }
+                           ),
+            DatasetBuilder('starting_time',
+                           data=123.6,
+                           attributes={'rate': 10000.0,
+                                       'unit': 'Seconds',
+                                       }
+                           ),
+                ]
+        attributes = {'neurodata_type': 'PatchClampSeries',
+                      'namespace': 'core',
+                      'comments': u'no comments',
+                      'help': 'Superclass definition for patch-clamp data',
+                      'description': u'no description',
+                      'stimulus_description': u'gotcha ya!',
+                      }
+        attributes['sweep_number'] = 4711
+        pcs1 = GroupBuilder('pcs1',
+                            attributes=attributes,
+                            links={'electrode': LinkBuilder(elec, 'electrode')},
+                            datasets={d.name: d for d in datasets},
+                            )
+        attributes['sweep_number'] = 4712
+        pcs2a = GroupBuilder('pcs2a',
+                             attributes=attributes,
+                             links={'electrode': LinkBuilder(elec, 'electrode')},
+                             datasets={d.name: d for d in datasets},
+                             )
+        pcs2b = GroupBuilder('pcs2b',
+                             attributes=attributes,
+                             links={'electrode': LinkBuilder(elec, 'electrode')},
+                             datasets={d.name: d for d in datasets},
+                             )
+
+        column_id = DatasetBuilder('id', [0, 1, 2],
+                                   attributes={'neurodata_type': 'ElementIdentifiers',
+                                               'namespace': 'core',
+                                               'help': 'unique identifiers for a list of elements',
+                                               }
+                                   )
+
+        column_series = DatasetBuilder('series',
+                                       attributes={'neurodata_type': 'VectorData',
+                                                   'namespace': 'core',
+                                                   'help': 'Values for a list of elements',
+                                                   'description': u'PatchClampSeries with the same sweep number',
+                                                   },
+                                       data=[LinkBuilder(pcs) for pcs in (pcs1, pcs2a, pcs2b)]
+                                       )
+
+        column_index = DatasetBuilder('series_index', [1, 2, 3],
+                                      attributes={'neurodata_type': 'VectorIndex',
+                                                  'namespace': 'core',
+                                                  'help': 'indexes into a list of values for a list of elements',
+                                                  'target': ReferenceBuilder(column_series),
+                                                  },
+                                      )
+
+        column_sweep_number = DatasetBuilder('sweep_number', data=[4711, 4712, 4712],
+                                             attributes={'neurodata_type': 'VectorData',
+                                                         'namespace': 'core',
+                                                         'help': 'Values for a list of elements',
+                                                         'description': u'Sweep number of the entries in that row',
+                                                         }
+                                             )
+
+        columns = [column_id, column_series, column_index, column_sweep_number]
+        sweep_table = GroupBuilder('sweep_table', datasets={c.name: c for c in columns},
+                                   attributes={'neurodata_type': 'SweepTable',
+                                               'namespace': 'core',
+                                               'colnames': ('series',
+                                                            'sweep_number'),
+                                               'help': 'The table which groups different PatchClampSeries together',
+                                               'description':
+                                               u'A sweep table groups different PatchClampSeries together.',
+                                               },
+                                   )
+
+        return sweep_table


### PR DESCRIPTION
## Motivation
fix #708 #unittest

Add builder unit tests for SweepTable

add a manual builder object to secure the automatic creation of the
builder object from a given container object via build manager and the
construction of a container from the manual builder in the associated
test cases `test_build` and `test_construct`.

```console
(Container --> Build Manager --> Builder) == manual Builder
                    ^.build                ^test_build()

(manual Builder --> Build Manager --> Container) == Container
                         ^construct               ^test_construct()
```
move unit test for checking the container creation to its separate test case
instead of keeping them in the addContainer function.

```console
(NWBfile --> Main Container --> SweepTable) is as defined
        ^add_classes                        ^test_container
```

## How to test the behavior?
```
pip install pytest
py.test -s tests/integration/ui_write/test_icephys.py
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
