### PR TITLE
fix CorrectedImageStack inheritance

### DIFF
--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -6,7 +6,8 @@ from .form.utils import docval, getargs, popargs, fmt_docval_args, call_docval_f
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .image import ImageSeries
-from .core import NWBContainer, MultiContainerInterface, DynamicTable, DynamicTableRegion, ElementIdentifiers
+from .core import NWBContainer, MultiContainerInterface, DynamicTable, DynamicTableRegion, ElementIdentifiers,\
+    NWBDataInterface
 from .device import Device
 
 
@@ -159,7 +160,7 @@ class TwoPhotonSeries(ImageSeries):
 
 
 @register_class('CorrectedImageStack', CORE_NAMESPACE)
-class CorrectedImageStack(NWBContainer):
+class CorrectedImageStack(NWBDataInterface):
     """
     An image stack where all frames are shifted (registered) to a common coordinate system, to
     account for movement and drift between frames. Note: each frame at each point in time is

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -5,6 +5,7 @@ from pynwb.ophys import TwoPhotonSeries, RoiResponseSeries, DfOverF, Fluorescenc
 from pynwb.image import ImageSeries
 from pynwb.base import TimeSeries
 from pynwb.device import Device
+from pynwb.base import ProcessingModule
 
 import numpy as np
 
@@ -89,6 +90,7 @@ class CorrectedImageStackConstructor(unittest.TestCase):
         tstamps = np.arange(1.0, 100.0, 0.1, dtype=np.float)
         ts = TimeSeries("test_ts", list(range(len(tstamps))), 'unit', timestamps=tstamps)
         cis = CorrectedImageStack(is1, is2, ts)
+        ProcessingModule('name', 'description').add_container(cis)
         self.assertEqual(cis.corrected, is1)
         self.assertEqual(cis.original, is2)
         self.assertEqual(cis.xy_translation, ts)


### PR DESCRIPTION
Fix that it could not be added to a processing module.
* Make CorrectedImageStack inherit from NWBDataInterface
* Add test for adding object to processing module

## Motivation

fix #757 

## How to test the behavior?
```python
is1 = ImageSeries(name='is1', data=np.ones((2, 2, 2)), unit='unit',
                  external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=[1., 2.])
is2 = ImageSeries(name='is2', data=np.ones((2, 2, 2)), unit='unit',
                  external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=[1., 2.])
tstamps = np.arange(1.0, 100.0, 0.1, dtype=np.float)
ts = TimeSeries("test_ts", list(range(len(tstamps))), 'unit', timestamps=tstamps)
cis = CorrectedImageStack(is1, is2, ts)
ProcessingModule('name', 'description').add_container(cis)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
