### PR TITLE
add optional parameter Subject.date_of_birth of type isodatetime

### DIFF
--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -277,6 +277,10 @@ groups:
         dtype: text
         doc: Age of subject
         quantity: '?'
+      - name: date_of_birth
+        dtype: isodatetime
+        doc: can be supplied instead of age
+        quantity: '?'
       - name: description
         dtype: text
         doc: Description of subject and where subject came from (e.g., breeder, if

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -45,6 +45,7 @@ class Subject(NWBContainer):
         'species',
         'subject_id',
         'weight',
+        'date_of_birth'
     )
 
     @docval({'name': 'age', 'type': str, 'doc': 'the age of the subject', 'default': None},
@@ -53,7 +54,9 @@ class Subject(NWBContainer):
             {'name': 'sex', 'type': str, 'doc': 'the sex of the subject', 'default': None},
             {'name': 'species', 'type': str, 'doc': 'the species of the subject', 'default': None},
             {'name': 'subject_id', 'type': str, 'doc': 'a unique identifier for the subject', 'default': None},
-            {'name': 'weight', 'type': str, 'doc': 'the weight of the subject', 'default': None})
+            {'name': 'weight', 'type': str, 'doc': 'the weight of the subject', 'default': None},
+            {'name': 'date_of_birth', 'type': datetime, 'default': None,
+             'doc': 'datetime of date of birth. May be supplied instead of age.'})
     def __init__(self, **kwargs):
         kwargs['name'] = 'subject'
         pargs, pkwargs = fmt_docval_args(super(Subject, self).__init__, kwargs)
@@ -65,6 +68,11 @@ class Subject(NWBContainer):
         self.species = getargs('species', kwargs)
         self.subject_id = getargs('subject_id', kwargs)
         self.weight = getargs('weight', kwargs)
+        date_of_birth = getargs('date_of_birth', kwargs)
+        if date_of_birth and date_of_birth.tzinfo is None:
+            self.date_of_birth = _add_missing_timezone(date_of_birth)
+        else:
+            self.date_of_birth = date_of_birth
 
 
 @register_class('NWBFile', CORE_NAMESPACE)

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -271,7 +271,8 @@ class SubjectTest(unittest.TestCase):
                                sex='M',
                                species='Rattus norvegicus',
                                subject_id='RAT123',
-                               weight='2 lbs')
+                               weight='2 lbs',
+                               date_of_birth=datetime(2017, 5, 1, 12, tzinfo=tzlocal()))
         self.start = datetime(2017, 5, 1, 12, tzinfo=tzlocal())
         self.path = 'nwbfile_test.h5'
         self.nwbfile = NWBFile('a test session description for a test NWBFile',


### PR DESCRIPTION
## Motivation

fix https://github.com/NeurodataWithoutBorders/nwb-schema/issues/145


## How to test the behavior?
```python
Subject(age='12 mo', description='An unfortunate rat', genotype='WT', sex='M', 
        species='Rattus norvegicus', subject_id='RAT123', weight='2 lbs',
        date_of_birth=datetime(2017, 5, 1, 12, tzinfo=tzlocal())
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
