### PR TITLE
fix units table column name type

### DIFF
--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -199,7 +199,7 @@ groups:
     shape:
     - null
     - 2
-  - neurodata_type_inc: DynamicTableRegion
+  - neurodata_type_inc: VectorIndex
     name: electrodes_index
     doc: the index into electrodes
     quantity: '?'


### PR DESCRIPTION
## Motivation
*electrodes_index* is an index into *electrodes*. The schema has it specified as DynamicTableRegion, but it should be a VectorIndex
