### PR TITLE
add `None` default arg for `DecompositionSeries.bands.band_limits`

### DIFF
--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -292,7 +292,7 @@ class DecompositionSeries(TimeSeries):
 
     @docval({'name': 'band_name', 'type': str, 'doc': 'the name of the frequency band',
              'default': None},
-            {'name': 'band_limits', 'type': ('array_data', 'data'),
+            {'name': 'band_limits', 'type': ('array_data', 'data'), 'default': None,
              'doc': 'low and high frequencies of bandpass filter in Hz'},
             {'name': 'band_mean', 'type': float, 'doc': 'the mean of Gaussian filters in Hz',
              'default': None},


### PR DESCRIPTION
## Motivation

For consistency with schema

## Checklist
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
