### PR TITLE
Fix ogen, add RT tests

### DIFF
--- a/src/pynwb/data/nwb.ogen.yaml
+++ b/src/pynwb/data/nwb.ogen.yaml
@@ -31,7 +31,7 @@ groups:
     target_type: OptogeneticStimulusSite
 - neurodata_type_def: OptogeneticStimulusSite
   neurodata_type_inc: NWBContainer
-  doc: 'One of possibly many groups describing an optogenetic stimuluation site. COMMENT:
+  doc: 'One of possibly many groups describing an optogenetic stimulation site. COMMENT:
     Name is arbitrary but should be meaningful. Name is referenced by OptogeneticSeries'
   attributes:
   - name: help
@@ -42,13 +42,14 @@ groups:
   - name: description
     dtype: text
     doc: Description of site
-  - name: device
-    dtype: text
-    doc: Name of device in /general/devices
   - name: excitation_lambda
-    dtype: text
-    doc: Excitation wavelength
+    dtype: float
+    doc: Excitation wavelength in nm
   - name: location
     dtype: text
     doc: Location of stimulation site
   quantity: '*'
+  links:
+  - name: device
+    doc: Device that generated the stimulus
+    target_type: Device

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -32,7 +32,7 @@ class NWBFileMap(ObjectMapper):
         self.map_spec('electrodes', ecephys_spec.get_group('electrodes'))
         self.map_spec('electrode_groups', ecephys_spec.get_neurodata_type('ElectrodeGroup'))
         self.map_spec(
-            'optogenetic_sites',
+            'ogen_sites',
             general_spec.get_group('optogenetics').get_neurodata_type('OptogeneticStimulusSite'))
         self.map_spec(
             'imaging_planes',

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -21,7 +21,7 @@ class OptogeneticStimulusSite(NWBContainer):
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this stimulus site'},
             {'name': 'device', 'type': Device, 'doc': 'the device that was used'},
             {'name': 'description', 'type': str, 'doc': 'Description of site.'},
-            {'name': 'excitation_lambda', 'type': str, 'doc': 'Excitation wavelength.'},
+            {'name': 'excitation_lambda', 'type': float, 'doc': 'Excitation wavelength in nm.'},
             {'name': 'location', 'type': str, 'doc': 'Location of stimulation site.'})
     def __init__(self, **kwargs):
         device, description, excitation_lambda, location = popargs(
@@ -48,12 +48,11 @@ class OptogeneticSeries(TimeSeries):
             {'name': 'data', 'type': ('array_data', 'data', TimeSeries), 'shape': (None, ),
              'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
             {'name': 'unit', 'type': str, 'doc': 'Value is the string "Watt".', 'default': 'Watt'},
-            {'name': 'site', 'type': OptogeneticStimulusSite,
-             'doc': 'Name of site description in general/optogentics.'},
+            {'name': 'site', 'type': OptogeneticStimulusSite, 'doc': 'The site to which this stimulus was applied.'},
             {'name': 'resolution', 'type': float, 'doc': 'The smallest meaningful difference \
             (in specified unit) between values in data', 'default': _default_resolution},
             {'name': 'conversion', 'type': float,
-             'doc': 'Scalar to multiply each element by to conver to volts', 'default': _default_conversion},
+             'doc': 'Scalar to multiply each element by to convert to volts', 'default': _default_conversion},
 
             {'name': 'timestamps', 'type': ('array_data', 'data', TimeSeries), 'shape': (None, ),
              'doc': 'Timestamps for samples stored in data', 'default': None},

--- a/tests/integration/ui_write/test_ogen.py
+++ b/tests/integration/ui_write/test_ogen.py
@@ -1,0 +1,20 @@
+from pynwb.ogen import OptogeneticSeries, OptogeneticStimulusSite
+from pynwb.device import Device
+
+from . import base
+
+
+class TestOptogeneticStimulusSeries(base.TestMapRoundTrip):
+    """
+    A TestCase class for testing OptogeneticStimulusSeries
+    """
+
+    def setUpContainer(self):
+        self.device = Device(name='dev1')
+        self.ogen_stim_site = OptogeneticStimulusSite('stim_site', self.device, 'my stim site', 300., 'in the brain')
+        return OptogeneticSeries('stim_series', [1., 2., 3.], self.ogen_stim_site, rate=100.)
+
+    def addContainer(self, nwbfile):
+        nwbfile.add_device(self.device)
+        nwbfile.add_ogen_site(self.ogen_stim_site)
+        nwbfile.add_acquisition(self.container)

--- a/tests/integration/ui_write/test_ogen.py
+++ b/tests/integration/ui_write/test_ogen.py
@@ -4,6 +4,20 @@ from pynwb.device import Device
 from . import base
 
 
+class TestOptogeneticStimulusSite(base.TestMapRoundTrip):
+
+    def setUpContainer(self):
+        self.device = Device(name='dev1')
+        return OptogeneticStimulusSite('stim_site', self.device, 'my stim site', 300., 'in the brain')
+
+    def addContainer(self, nwbfile):
+        nwbfile.add_device(self.device)
+        nwbfile.add_ogen_site(self.container)
+
+    def getContainer(self, nwbfile):
+        return nwbfile.get_ogen_site(self.container.name)
+
+
 class TestOptogeneticStimulusSeries(base.TestMapRoundTrip):
     """
     A TestCase class for testing OptogeneticStimulusSeries

--- a/tests/unit/pynwb_tests/test_ogen.py
+++ b/tests/unit/pynwb_tests/test_ogen.py
@@ -8,11 +8,11 @@ class OptogeneticSeriesConstructor(unittest.TestCase):
 
     def test_init(self):
         device = Device('name')
-        oS = OptogeneticStimulusSite('site1', device, 'description', 'excitation_lambda', 'location')
+        oS = OptogeneticStimulusSite('site1', device, 'description', 300., 'location')
         self.assertEqual(oS.name, 'site1')
         self.assertEqual(oS.device, device)
         self.assertEqual(oS.description, 'description')
-        self.assertEqual(oS.excitation_lambda, 'excitation_lambda')
+        self.assertEqual(oS.excitation_lambda, 300.)
         self.assertEqual(oS.location, 'location')
 
         iS = OptogeneticSeries('test_iS', list(), oS, timestamps=list())


### PR DESCRIPTION
## Motivation
The ogen module had a few inconsistencies. Some of the types are wrong and/or mismatched between the schema and pynwb, and there were previously no round trip tests. I created one, but it's not passing and I don't know why.

The changes I am suggesting including changing `excitation_wavelength` to be a `float` instead of a `str`, which would make it consistent with the ophys module, but is a breaking change. I think this should be allowed, since the original type was clearly a mistake, but I understand that breaking changes are a big ask at this point so I'd be willing to compromise on that point.

fix #783 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
