### PR TITLE
Free the types!

### DIFF
--- a/src/pynwb/data/nwb.behavior.yaml
+++ b/src/pynwb/data/nwb.behavior.yaml
@@ -19,7 +19,7 @@ groups:
       spatial dimensions]
   datasets:
   - name: data
-    dtype: float
+    dtype: numeric
     doc: 2-D array storing position or direction relative to some reference frame.
     attributes:
     - name: unit

--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -18,7 +18,7 @@ groups:
       is impractical
   datasets:
   - name: data
-    dtype: float32
+    dtype: numeric
     doc: Values of each feature at each time.
     attributes:
     - name: unit
@@ -116,7 +116,7 @@ groups:
   doc: Holds spectral analysis of a timeseries. For instance of LFP or a speech signal
   datasets:
   - name: data
-    dtype: float
+    dtype: numeric
     doc: The data goes here
     shape:
     - null

--- a/src/pynwb/data/nwb.ogen.yaml
+++ b/src/pynwb/data/nwb.ogen.yaml
@@ -9,7 +9,7 @@ groups:
     value: Optogenetic stimulus
   datasets:
   - name: data
-    dtype: float32
+    dtype: numeric
     doc: Applied power for optogenetic stimulus.
     attributes:
     - name: unit

--- a/src/pynwb/data/nwb.ophys.yaml
+++ b/src/pynwb/data/nwb.ophys.yaml
@@ -46,7 +46,7 @@ groups:
       of data[] should correspond to the signal from one ROI
   datasets:
   - name: data
-    dtype: float32
+    dtype: numeric
     doc: Signals from ROIs
     dims:
     - - num_times


### PR DESCRIPTION
change all measurement neurodata_types to allow any `numeric` datatype

## Motivation

Where appropriate, I have changed the type to `numeric`, allowing the user to decide what datatypes to use for any measurement data fields. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
