### PR TITLE
Fix/dtype4dataio

### DIFF
--- a/src/pynwb/form/backends/hdf5/h5tools.py
+++ b/src/pynwb/form/backends/hdf5/h5tools.py
@@ -862,7 +862,8 @@ class HDF5IO(FORMIO):
         try:
             dset = parent.create_dataset(name, shape=data_shape, dtype=dtype, **io_settings)
         except Exception as exc:
-            msg = "Could not create dataset %s in %s. %s" % (name, parent.name, str(exc))
+            msg = "Could not create dataset %s in %s with shape %s, dtype %s, and iosettings %s. %s" % \
+                  (name, parent.name, str(data_shape), str(dtype), str(**io_settings), str(exc))
             raise_from(Exception(msg), exc)
         # Write the data
         if len(data) > dset.shape[0]:

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -392,12 +392,18 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
         Convert values to the specified dtype. For example, if a literal int
         is passed in to a field that is specified as a unsigned integer, this function
         will convert the Python int to a numpy unsigned int.
+
+        :return: The function returns a tuple consisting of 1) the value, and 2) the data type.
+                 The value is returned as the function may convert the input value to comply
+                 with the dtype specified in the schema.
         """
         if value is None:
             dt = spec.dtype
             if isinstance(dt, RefSpec):
                 dt = dt.reftype
             return None, dt
+        if isinstance(value, DataIO):
+            return value, cls.convert_dtype(spec, value.data)[1]
         if spec.dtype is None:
             return value, None
         if spec.dtype == 'numeric':


### PR DESCRIPTION
## Motivation

The data type was not determined correctly in ObjectMapper.convert_dtype if a dataset wrapped with DataIO was given. Fix #789

## How to test the behavior?
```
from pynwb import NWBHDF5IO, NWBFile, TimeSeries
from pynwb.form.backends.hdf5.h5_utils import H5DataIO
from datetime import datetime
import numpy as np

nwbfile = NWBFile('a', 'b', datetime.now())
print("\n\n")

ts = TimeSeries('ts_name', [1, 2, 3], 'A', timestamps=H5DataIO(np.array([1., 2., 3.]), compression='gzip'))

nwbfile.add_acquisition(ts)

with NWBHDF5IO('test_out.nwb', 'w') as io: 
    io.write(nwbfile)

import h5py
f = h5py.File('test_out.nwb' , 'r')
d = f['/acquisition/ts_name/timestamps']
print(d)
print("Compression ? " , d.compression)

```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
