### PR TITLE
Fix spurious warning from icephys tutorial

### DIFF
--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -80,20 +80,20 @@ class NWBBaseType(with_metaclass(ExtenderMeta, Container)):
         call_docval_func(super(NWBBaseType, self).__init__, kwargs)
         self.__fields = dict()
 
-    def get_parent_neurodata_type(self, neurodata_type='NWBFile'):
+    @docval({'name': 'neurodata_type', 'type': str, 'doc': 'the neurodata_type to search for', 'default': None})
+    def get_ancestor(self, **kwargs):
         """
-        Traverse parent hierarchy and return first instance of the
-        specified neurodata_type
-
-        Args:
-            neurodata_type (str)    : the neurodata_type to search for. Search for *NWBFile* by default
+        Traverse parent hierarchy and return first instance of the specified neurodata_type
         """
+        neurodata_type = getargs('neurodata_type', kwargs)
+        if neurodata_type is None:
+            return self.parent
         p = self.parent
         while p is not None:
             if p.neurodata_type == neurodata_type:
                 return p
             p = p.parent
-        return p
+        return None
 
     @property
     def fields(self):

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -102,6 +102,10 @@ class BuildManager(object):
     def namespace_catalog(self):
         return self.__type_map.namespace_catalog
 
+    @property
+    def type_map(self):
+        return self.__type_map
+
     @docval({"name": "object", "type": (BaseBuilder, Container), "doc": "the container or builder to get a proxy for"},
             {"name": "source", "type": str,
              "doc": "the source of container being built i.e. file path", 'default': None})
@@ -854,7 +858,11 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
 
             if isinstance(spec.dtype, RefSpec):
                 if not self.__is_reftype(attr_value):
-                    msg = "invalid type for reference '%s' (%s) - must be Container" % (spec.name, type(attr_value))
+                    if attr_value is None:
+                        msg = "object of data_type %s not found on %s '%s'" % \
+                              (spec.dtype.target_type, type(container).__name__, container.name)
+                    else:
+                        msg = "invalid type for reference '%s' (%s) - must be Container" % (spec.name, type(attr_value))
                     raise ValueError(msg)
                 target_builder = build_manager.build(attr_value, source=source)
                 attr_value = ReferenceBuilder(target_builder)

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -8,8 +8,7 @@ from pynwb.file import NWBFile
 from pynwb.core import NWBData, DynamicTable, NWBContainer, VectorIndex
 
 
-@register_map(NWBContainer)
-class NWBContainerMapper(ObjectMapper):
+class NWBBaseTypeMapper(ObjectMapper):
 
     @staticmethod
     def get_nwb_file(container):
@@ -18,6 +17,12 @@ class NWBContainerMapper(ObjectMapper):
             if isinstance(curr, NWBFile):
                 return curr
             curr = container.parent
+
+
+@register_map(NWBContainer)
+class NWBContainerMapper(NWBBaseTypeMapper):
+
+    pass
 
 
 @register_map(DynamicTable)
@@ -55,11 +60,13 @@ class DynamicTableMap(NWBContainerMapper):
                     msg = "empty or missing table for DynamicTableRegion '%s' in DynamicTable '%s'" %\
                           (attr_value.name, container.name)
                     raise ValueError(msg)
+            elif spec.neurodata_type_inc == 'VectorIndex':
+                attr_value = container[spec.name]
         return attr_value
 
 
 @register_map(NWBData)
-class NWBDataMap(ObjectMapper):
+class NWBDataMap(NWBBaseTypeMapper):
 
     @ObjectMapper.constructor_arg('name')
     def carg_name(self, builder, manager):

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -223,6 +223,11 @@ class Units(DynamicTable):
         Add a unit to this table
         """
         super(Units, self).add_row(**kwargs)
+        if 'electrodes' in self:
+            elec_col = self['electrodes'].target
+            if elec_col.table is None:
+                nwbfile = self.get_parent_neurodata_type()
+                elec_col.table = nwbfile.electrodes
 
     @docval({'name': 'index', 'type': int,
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'})

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -262,6 +262,18 @@ class NWBFileTest(unittest.TestCase):
                     source_script=None,
                     source_script_file_name='nofilename')
 
+    def test_get_neurodata_type(self):
+        ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],
+                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        ts2 = TimeSeries('test_ts2', [0, 1, 2, 3, 4, 5],
+                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        self.nwbfile.add_acquisition(ts1)
+        self.nwbfile.add_acquisition(ts2)
+        p1 = ts1.get_ancestor(neurodata_type='NWBFile')
+        self.assertIs(p1, self.nwbfile)
+        p2 = ts2.get_ancestor(neurodata_type='NWBFile')
+        self.assertIs(p2, self.nwbfile)
+
 
 class SubjectTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
- track VectorIndex objects in DynamicTable
- set Units.electrodes.table before hitting ObjectMapper
  - the ObjectMapper was attemping to retrieve this
    before it was set, creating another bug

## Motivation

fix #714 


## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
