### PR TITLE
Document observation intervals (fix #761)

### DIFF
--- a/docs/gallery/general/file.py
+++ b/docs/gallery/general/file.py
@@ -176,21 +176,31 @@ nwbfile.add_trial(start_time=6.0, stop_time=8.0, stim='desert')
 # and :py:func:`~pynwb.file.NWBFile.add_unit_column`. These methods work like the methods for adding
 # trials described :ref:`above <basic_trials>`
 #
-# By default, NWBFile only requires a unique identifier for each unit. Optional values for each unit
-# are: `spike_times`, `electrodes`, `electrode_group`, `waveform_mean`, and `waveform_sd`.
-# Additional columns can be added using :py:func:`~pynwb.file.NWBFile.add_unit_column`. Like
+# A unit is only required to contain a unique integer identifier in the 'id' column
+# (this will be automatically assigned if not provided). Additional optional values for each unit
+# include: `spike_times`, `electrodes`, `electrode_group`, `obs_intervals`, `waveform_mean`, and `waveform_sd`.
+# Additional user-defined columns can be added using :py:func:`~pynwb.file.NWBFile.add_unit_column`. Like
 # :py:func:`~pynwb.file.NWBFile.add_trial_column`, this method also takes a name
 # for the column, a description of what the column stores and does not need a data type.
 # Once all columns have been added, unit data can be populated using :py:func:`~pynwb.file.NWBFile.add_unit`.
 #
-# Lets specify some unit metadata and then add some units
+# When providing `spike_times`, you may also wish to specify the time intervals during which the unit was
+# being observed, so that it is possible to distinguish times when the unit was silent from times when the
+# unit was not being recorded (and thus correctly compute firing rates, for example). This information
+# should be provided as a list of [start, end] time pairs in the `obs_intervals` field. If `obs_intervals` is
+# provided, then all entries in `spike_times` should occur within one of the listed intervals. In the example
+# below, all 3 units are observed during the time period from 1 to 10 s and fired spikes during that period.
+# Units 2 and 3 were also observed during the time period from 20-30s; but only unit 2 fired spikes in that
+# period.
+# 
+# Lets specify some unit metadata and then add some units:
 
 nwbfile.add_unit_column('location', 'the anatomical location of this unit')
 nwbfile.add_unit_column('quality', 'the quality for the inference of this unit')
 
-nwbfile.add_unit(id=1, spike_times=[2.2, 3.0, 4.5], location='CA1', quality=0.95)
-nwbfile.add_unit(id=2, spike_times=[2.2, 3.0], location='CA3', quality=0.85)
-nwbfile.add_unit(id=3, spike_times=[1.2, 2.3, 3.3, 4.5], location='CA1', quality=0.90)
+nwbfile.add_unit(id=1, spike_times=[2.2, 3.0, 4.5], obs_intervals=[[1, 10]], location='CA1', quality=0.95)
+nwbfile.add_unit(id=2, spike_times=[2.2, 3.0, 25.0, 26.0], obs_intervals=[[1, 10], [20, 30]], location='CA3', quality=0.85)
+nwbfile.add_unit(id=3, spike_times=[1.2, 2.3, 3.3, 4.5], obs_intervals=[[1, 10], [20, 30]], location='CA1', quality=0.90)
 
 ####################
 # .. _units_fields_ref:

--- a/docs/gallery/general/file.py
+++ b/docs/gallery/general/file.py
@@ -192,7 +192,7 @@ nwbfile.add_trial(start_time=6.0, stop_time=8.0, stim='desert')
 # below, all 3 units are observed during the time period from 1 to 10 s and fired spikes during that period.
 # Units 2 and 3 were also observed during the time period from 20-30s; but only unit 2 fired spikes in that
 # period.
-# 
+#
 # Lets specify some unit metadata and then add some units:
 
 nwbfile.add_unit_column('location', 'the anatomical location of this unit')


### PR DESCRIPTION
## Motivation
Document new 'observation intervals' field for units table. See #761

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
