### PR TITLE
ClusterWaveforms deprecation warning

### DIFF
--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -244,8 +244,8 @@ class ClusterWaveforms(NWBDataInterface):
     DEPRECATED. `ClusterWaveforms` was deprecated in Oct 27, 2018 and will be removed in a future release.
     Please use the `Units` table to store waveform mean and standard deviation
     e.g. `NWBFile.units.add_unit(..., waveform_mean=..., waveform_sd=...)`
-    
-    
+
+
     Describe cluster waveforms by mean and standard deviation for at each sample.
     """
 

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -241,6 +241,11 @@ class Clustering(NWBDataInterface):
 @register_class('ClusterWaveforms', CORE_NAMESPACE)
 class ClusterWaveforms(NWBDataInterface):
     """
+    DEPRECATED. `ClusterWaveforms` was deprecated in Oct 27, 2018 and will be removed in a future release.
+    Please use the `Units` table to store waveform mean and standard deviation
+    e.g. `NWBFile.units.add_unit(..., waveform_mean=..., waveform_sd=...)`
+    
+    
     Describe cluster waveforms by mean and standard deviation for at each sample.
     """
 


### PR DESCRIPTION
Add a note about the deprecation of ClusterWaveforms in the class docstring so that this information is available to a users through the docs

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
