### PR TITLE
change interval type

### DIFF
--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -210,7 +210,7 @@ groups:
       and all timestamps are relative to experiment start time.'
     attributes:
     - name: interval
-      dtype: int32
+      dtype: float32
       doc: Value is '1'
       value: 1
     - name: unit


### PR DESCRIPTION
change type of `TimeSeries.timestamps.interval` to make consistent with schema

## Motivation

fix #801 