### PR TITLE
link to timestamps when TimeSeries pase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ flake:
 	$(FLAKE) --ignore E402,W504 docs/gallery
 
 checkpdb:
-	find {src,tests} -name "*.py" -exec grep -Hn pdb {} \;
+	find {src,tests} -name "*.py" -exec grep -Hn -e pdb -e breakpoint {} \;
 
 devtest:
 	$(PYTHON) -W ignore:::pynwb.form.build.map: test.py -fpi

--- a/docs/gallery/general/file.py
+++ b/docs/gallery/general/file.py
@@ -45,7 +45,7 @@ test_ts = TimeSeries('test_timeseries', data, 'SIunit', timestamps=timestamps)
 # Alternatively, if your recordings are sampled at a uniform rate, you can supply *starting_time*
 # and *rate*.
 
-test_ts = TimeSeries('test_timeseries', data, 'SIunit', starting_time=0.0, rate=1.0)
+rate_ts = TimeSeries('test_timeseries', data, 'SIunit', starting_time=0.0, rate=1.0)
 
 ####################
 # Using this scheme says that this :py:class:`~pynwb.base.TimeSeries` started recording 0 seconds after
@@ -59,6 +59,26 @@ test_ts = TimeSeries('test_timeseries', data, 'SIunit', starting_time=0.0, rate=
 # :py:func:`~pynwb.file.NWBFile.add_stimulus_template` to store stimulus templates [#]_.
 
 nwbfile.add_acquisition(test_ts)
+
+####################
+# .. _reuse_timestamps:
+#
+# Reusing timestamps
+# ~~~~~~~~~~~~~~~~~~
+#
+# When working with multimodal data, it can be convenient and efficient to store timestamps once and associate multiple
+# data with the single timestamps instance. PyNWB enables this by letting you reuse timestamps across
+# :class:`~pynwb.base.TimeSeries` objects. To reuse a :class:`~pynwb.base.TimeSeries` timestamps in a new
+# :class:`~pynwb.base.TimeSeries`, pass the exising :class:`~pynwb.base.TimeSeries` as the new
+# :class:`~pynwb.base.TimeSeries` timestamps:
+
+data = list(range(101, 201, 10))
+reuse_ts = TimeSeries('reusing_timeseries', data, 'SIunit', timestamps=test_ts)
+
+####################
+# And then add it to the NWBFile.
+
+nwbfile.add_acquisition(reuse_ts)
 
 ####################
 # .. _basic_data_interfaces:

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -30,6 +30,14 @@ class Builder(with_metaclass(ABCMeta, dict)):
             self.__source = None
         self.__written = False
 
+    def get_path(self):
+        s = list()
+        c = self
+        while c is not None:
+            s.append(c.name)
+            c = c.parent
+        return "/".join(s[::-1])
+
     @property
     def written(self):
         ''' The source of this Builder '''

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -30,7 +30,11 @@ class Builder(with_metaclass(ABCMeta, dict)):
             self.__source = None
         self.__written = False
 
-    def get_path(self):
+    @property
+    def path(self):
+        """
+        Get the path of this Builder
+        """
         s = list()
         c = self
         while c is not None:

--- a/src/pynwb/form/build/builders.py
+++ b/src/pynwb/form/build/builders.py
@@ -202,6 +202,21 @@ class GroupBuilder(BaseBuilder):
         super(GroupBuilder, self).set_attribute(name, value)
         self.obj_type[name] = GroupBuilder.__attribute
 
+    @docval({'name': 'builder', 'type': 'Builder', 'doc': 'the Builder to add to this GroupBuilder'})
+    def set_builder(self, **kwargs):
+        '''
+        Add an existing builder to this this GroupBuilder
+        '''
+        builder = getargs('builder', kwargs)
+        if isinstance(builder, LinkBuilder):
+            self.__set_builder(builder, GroupBuilder.__link)
+        elif isinstance(builder, GroupBuilder):
+            self.__set_builder(builder, GroupBuilder.__dataset)
+        elif isinstance(builder, DatasetBuilder):
+            self.__set_builder(builder, GroupBuilder.__dataset)
+        else:
+            raise ValueError("Got unexpected builder type: %s" % type(builder))
+
     def __set_builder(self, builder, obj_type):
         name = builder.name
         if name in self.obj_type:

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -1411,10 +1411,10 @@ class TypeMap(object):
         builder = getargs('builder', kwargs)
         data_type = self.get_builder_dt(builder)
         if data_type is None:
-            raise ValueError("No data_type found for builder %s" % builder.get_path())
+            raise ValueError("No data_type found for builder %s" % builder.path)
         namespace = self.get_builder_ns(builder)
         if namespace is None:
-            raise ValueError("No namespace found for builder %s" % builder.get_path())
+            raise ValueError("No namespace found for builder %s" % builder.path)
         return self.get_container_cls(namespace, data_type)
 
     @docval({'name': 'spec', 'type': (DatasetSpec, GroupSpec), 'doc': 'the parent spec to search'},

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -1391,9 +1391,6 @@ class TypeMap(object):
         '''
         builder = getargs('builder', kwargs)
         ret = builder.attributes.get(self.__ns_catalog.group_spec_cls.type_key())
-        if ret is None:
-            msg = "builder '%s' does not have a data_type" % builder.name
-            raise ValueError(msg)
 
         if isinstance(ret, bytes):
             ret = ret.decode('UTF-8')
@@ -1410,9 +1407,6 @@ class TypeMap(object):
         if isinstance(builder, LinkBuilder):
             builder = builder.builder
         ret = builder.attributes.get('namespace')
-        if ret is None:
-            msg = "builder '%s' does not have a namespace" % builder.name
-            raise ValueError(msg)
         return ret
 
     @docval({'name': 'builder', 'type': Builder,

--- a/src/pynwb/form/build/map.py
+++ b/src/pynwb/form/build/map.py
@@ -914,7 +914,9 @@ class ObjectMapper(with_metaclass(ExtenderMeta, object)):
                                   % (spec.name, builder.name, self.spec.data_type_def)
                     warnings.warn(msg, MissingRequiredWarning)
                 continue
-            if spec.data_type_def is None and spec.data_type_inc is None:
+            if isinstance(attr_value, Builder):
+                builder.set_builder(attr_value)
+            elif spec.data_type_def is None and spec.data_type_inc is None:
                 if spec.name in builder.datasets:
                     sub_builder = builder.datasets[spec.name]
                 else:

--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -47,7 +47,7 @@ class TimeSeriesMap(NWBContainerMapper):
             curr = owner.fields.get('timestamps')
             while isinstance(curr, TimeSeries):
                 owner = curr
-                curr = parent.fields.get('timestamps')
+                curr = owner.fields.get('timestamps')
             ts_builder = manager.build(owner)
             tstamps_builder = ts_builder['timestamps']
             ret = LinkBuilder(tstamps_builder, 'timestamps')

--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -54,10 +54,12 @@ class TimeSeriesMap(NWBContainerMapper):
         return ret
 
     @NWBContainerMapper.constructor_arg("timestamps")
-    def timestamps_attr(self, builder, manager):
-        tstamps_builder = builder
-        if isinstance(builder, LinkBuilder):
-            target = builder.target
+    def timestamps_carg(self, builder, manager):
+        tstamps_builder = builder.get('timestamps')
+        if tstamps_builder is None:
+            return None
+        if isinstance(tstamps_builder, LinkBuilder):
+            target = tstamps_builder.builder
             return manager.construct(target.parent)
         else:
-            return builder.data
+            return tstamps_builder.data

--- a/tests/integration/ui_write/test_base.py
+++ b/tests/integration/ui_write/test_base.py
@@ -1,6 +1,9 @@
+import numpy as np
+import datetime as datetime
+
 from pynwb.form.build import GroupBuilder, DatasetBuilder
 
-from pynwb import TimeSeries
+from pynwb import TimeSeries, NWBFile, NWBHDF5IO
 
 from . import base
 
@@ -32,3 +35,20 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
     def getContainer(self, nwbfile):
         ''' Should take an NWBFile object and return the Container'''
         return nwbfile.get_acquisition(self.container.name)
+
+    def test_timestamps_linking(self):
+        ''' Test that timestamps get linked to in TimeSeres '''
+        path = 'test_timestamps_linking.nwb'
+        tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000), unit='m')
+        tsb = TimeSeries(name='b', data=np.linspace(0, 1, 1000), timestamps=tsa, unit='m')
+        nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now(), session_description='bar')
+        nwbfile.add_acquisition(tsa)
+        nwbfile.add_acquisition(tsb)
+        io = NWBHDF5IO(path, 'w')
+        io.write(nwbfile)
+        io.close()
+        io = NWBHDF5IO(path, 'r')
+        nwbfile = io.read()
+        tsa = nwbfile.acquisition['a']
+        tsb = nwbfile.acquisition['b']
+        self.assertIs(tsa.timestamps, tsb.timestamps)

--- a/tests/unit/form_tests/build_tests/test_io_build_builders.py
+++ b/tests/unit/form_tests/build_tests/test_io_build_builders.py
@@ -81,6 +81,13 @@ class GroupBuilderGetterTests(unittest.TestCase):
     def tearDown(self):
         pass
 
+    def test_path(self):
+        self.assertEquals(self.subgroup1.path, 'gb/group1/subgroup1')
+        self.assertEquals(self.dataset1.path, 'gb/dataset1')
+        self.assertEquals(self.soft_link1.path, 'gb/soft_link1')
+        self.assertEquals(self.group1.path, 'gb/group1')
+        self.assertEquals(self.gb.path, 'gb')
+
     def test_get_item_group(self):
         """Test __get_item__ for groups"""
         self.assertIs(self.gb['group1'], self.group1)

--- a/tests/unit/form_tests/build_tests/test_io_manager.py
+++ b/tests/unit/form_tests/build_tests/test_io_manager.py
@@ -292,6 +292,23 @@ class TestNestedContainersSubgroupSubgroup(TestNestedBase):
                                      groups=[tmp_spec])
 
 
+class TestTypeMap(TestBase):
+
+    def test_get_ns_dt_missing(self):
+        bldr = GroupBuilder('my_foo', attributes={'attr1': 'value1'})
+        dt = self.type_map.get_builder_dt(bldr)
+        ns = self.type_map.get_builder_ns(bldr)
+        self.assertIsNone(dt)
+        self.assertIsNone(ns)
+
+    def test_get_ns_dt(self):
+        bldr = GroupBuilder('my_foo', attributes={'attr1': 'value1', 'namespace': 'CORE', 'data_type': 'Foo'})
+        dt = self.type_map.get_builder_dt(bldr)
+        ns = self.type_map.get_builder_ns(bldr)
+        self.assertEqual(dt, 'Foo')
+        self.assertEqual(ns, 'CORE')
+
+
 # TODO:
 class TestWildCardNamedSpecs(unittest.TestCase):
     pass


### PR DESCRIPTION
## Motivation

Timestamps were not linking when passing in TimeSeries as the timestamps argument.

## How to test the behavior?
See added unit test.

```
$ python -m unittest tests.integration.ui_write.test_base.TestTimeSeriesIO.test_timestamps_linking
```

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?