### PR TITLE
CurrentClampSeries: Remove duplicated timestamps parameter

### DIFF
--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -155,8 +155,6 @@ class CurrentClampSeries(PatchClampSeries):
 
             {'name': 'timestamps', 'type': ('array_data', 'data', TimeSeries),
              'doc': 'Timestamps for samples stored in data', 'default': None},
-            {'name': 'timestamps', 'type': ('array_data', 'data', TimeSeries),
-             'doc': 'Timestamps for samples stored in data', 'default': None},
             {'name': 'starting_time', 'type': float, 'doc': 'The timestamp of the first sample', 'default': None},
             {'name': 'rate', 'type': float, 'doc': 'Sampling rate in Hz', 'default': None},
 


### PR DESCRIPTION
Introduced in 0d5878e7 (added macros to pynwb container classes,
2017-10-25) and found by accident when reading the documentation.

Is there any use in duplicated arguments? If not maybe teaching `@docval` to complain can prevent that in the future.