### PR TITLE
fix indexed DynamicTableRegion

### DIFF
--- a/docs/gallery/domain/brain_observatory.py
+++ b/docs/gallery/domain/brain_observatory.py
@@ -40,7 +40,7 @@ metadata = dataset.get_metadata()
 cell_specimen_ids = dataset.get_cell_specimen_ids()
 timestamps, dFF = dataset.get_dff_traces()
 stimulus_list = [s for s in si.SESSION_STIMULUS_MAP[metadata['session_type']]
-                 if s is not 'spontaneous']
+                 if s != 'spontaneous']
 running_data, _ = dataset.get_running_speed()
 trial_table = dataset.get_stimulus_table('master')
 trial_table['start'] = timestamps[trial_table['start'].values]

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1353,6 +1353,9 @@ class DynamicTableRegion(VectorData):
             arg1 = key[0]
             arg2 = key[1]
             return self.table[self.data[arg1], arg2]
+        elif isinstance(key, slice):
+            data = np.arange(*key.indices(len(self.table)))
+            return DynamicTableRegion(name=self.name, data=data, description=self.description, table=self.table)
         else:
             if isinstance(key, int):
                 return self.table[self.data[key]]

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -144,10 +144,10 @@ class NWBBaseType(with_metaclass(ExtenderMeta, Container)):
             raise TypeError("'__nwbfields__' must be of type tuple")
 
         if len(bases) and 'NWBContainer' in globals() and issubclass(bases[-1], NWBContainer) \
-           and bases[-1].__nwbfields__ is not cls.__nwbfields__:
-                new_nwbfields = list(cls.__nwbfields__)
-                new_nwbfields[0:0] = bases[-1].__nwbfields__
-                cls.__nwbfields__ = tuple(new_nwbfields)
+                and bases[-1].__nwbfields__ is not cls.__nwbfields__:
+            new_nwbfields = list(cls.__nwbfields__)
+            new_nwbfields[0:0] = bases[-1].__nwbfields__
+            cls.__nwbfields__ = tuple(new_nwbfields)
         new_nwbfields = list()
         docs = {dv['name']: dv['doc'] for dv in get_docval(cls.__init__)}
         for f in cls.__nwbfields__:

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -912,10 +912,10 @@ class DynamicTable(NWBDataInterface):
             raise TypeError(msg)
 
         if len(bases) and 'DynamicTable' in globals() and issubclass(bases[-1], NWBContainer) \
-           and bases[-1].__columns__ is not cls.__columns__:
-                new_columns = list(cls.__columns__)
-                new_columns[0:0] = bases[-1].__columns__
-                cls.__columns__ = tuple(new_columns)
+                and bases[-1].__columns__ is not cls.__columns__:
+            new_columns = list(cls.__columns__)
+            new_columns[0:0] = bases[-1].__columns__
+            cls.__columns__ = tuple(new_columns)
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this table'},    # noqa: C901
             {'name': 'description', 'type': str, 'doc': 'a description of what is in this table'},

--- a/src/pynwb/form/query.py
+++ b/src/pynwb/form/query.py
@@ -27,10 +27,10 @@ class Query(with_metaclass(ExtenderMeta, object)):
             raise TypeError("'__operations__' must be of type tuple")
         # add any new operations
         if len(bases) and 'Query' in globals() and issubclass(bases[-1], Query) \
-           and bases[-1].__operations__ is not cls.__operations__:
-                new_operations = list(cls.__operations__)
-                new_operations[0:0] = bases[-1].__operations__
-                cls.__operations__ = tuple(new_operations)
+                and bases[-1].__operations__ is not cls.__operations__:
+            new_operations = list(cls.__operations__)
+            new_operations[0:0] = bases[-1].__operations__
+            cls.__operations__ = tuple(new_operations)
         for op in cls.__operations__:
             if not hasattr(cls, op):
                 setattr(cls, op, cls.__build_operation(op))

--- a/src/pynwb/form/query.py
+++ b/src/pynwb/form/query.py
@@ -117,10 +117,10 @@ class FORMDataset(with_metaclass(ExtenderMeta, object)):
             raise TypeError("'__operations__' must be of type tuple")
         # add any new operations
         if len(bases) and 'Query' in globals() and issubclass(bases[-1], Query) \
-           and bases[-1].__operations__ is not cls.__operations__:
-                new_operations = list(cls.__operations__)
-                new_operations[0:0] = bases[-1].__operations__
-                cls.__operations__ = tuple(new_operations)
+                and bases[-1].__operations__ is not cls.__operations__:
+            new_operations = list(cls.__operations__)
+            new_operations[0:0] = bases[-1].__operations__
+            cls.__operations__ = tuple(new_operations)
         for op in cls.__operations__:
             setattr(cls, op, cls.__build_operation(op))
 

--- a/src/pynwb/form/utils.py
+++ b/src/pynwb/form/utils.py
@@ -44,9 +44,9 @@ def __type_okay(value, argtype, allow_none=False):
     if isinstance(argtype, str):
         if argtype in __macros:
             return __type_okay(value, __macros[argtype], allow_none=allow_none)
-        elif argtype is 'int':
+        elif argtype == 'int':
             return __is_int(value)
-        elif argtype is 'float':
+        elif argtype == 'float':
             return __is_float(value)
         return argtype in [cls.__name__ for cls in value.__class__.__mro__]
     elif isinstance(argtype, type):

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -102,8 +102,8 @@ class TestMapNWBContainer(unittest.TestCase):
                         if len(f1) == 0:
                             continue
                         if isinstance(f1[0], float):
-                                for v1, v2 in zip(f1, f2):
-                                    self.assertAlmostEqual(v1, v2, places=6)
+                            for v1, v2 in zip(f1, f2):
+                                self.assertAlmostEqual(v1, v2, places=6)
                         else:
                             self.assertTrue(np.array_equal(f1, f2))
                 elif isinstance(f1, dict) and len(f1) and isinstance(next(iter(f1.values())), NWBContainer):

--- a/tests/integration/ui_write/test_core.py
+++ b/tests/integration/ui_write/test_core.py
@@ -43,7 +43,7 @@ class TestUnits(base.TestMapRoundTrip):
         return nwbfile.units
 
 
-class TestUnitsDf(base.TestMapRoundTrip):
+class TestFromDataframe(base.TestMapRoundTrip):
 
     def setUpContainer(self):
         # this will get ignored

--- a/tests/integration/ui_write/test_misc.py
+++ b/tests/integration/ui_write/test_misc.py
@@ -75,6 +75,37 @@ class TestUnitsIO(base.TestDataInterfaceIO):
         self.assertTrue(np.array_equal(ut['obs_intervals'][:], [[[0, 1], [2, 3]], [[2, 5], [6, 7]]]))
 
 
+class TestUnitElectrodes(base.TestMapRoundTrip):
+
+    def setUpContainer(self):
+        # this will get ignored
+        return Units('placeholder_units')
+
+    def addContainer(self, nwbfile):
+        device = nwbfile.create_device(name='trodes_rig123')
+        electrode_name = 'tetrode1'
+        description = "an example tetrode"
+        location = "somewhere in the hippocampus"
+        electrode_group = nwbfile.create_electrode_group(electrode_name,
+                                                         description=description,
+                                                         location=location,
+                                                         device=device)
+        for idx in [1, 2, 3, 4]:
+            nwbfile.add_electrode(idx,
+                                  x=1.0, y=2.0, z=3.0,
+                                  imp=float(-idx),
+                                  location='CA1', filtering='none',
+                                  group=electrode_group)
+
+        nwbfile.add_unit(id=1, electrodes=[1])
+        nwbfile.add_unit(id=2, electrodes=[1])
+        nwbfile.units.to_dataframe()
+        self.container = nwbfile.units
+
+    def getContainer(self, nwbfile):
+        return nwbfile.units
+
+
 class TestSpectralAnalysis(base.TestDataInterfaceIO):
     def setUpContainer(self):
         self.timeseries = TimeSeries(name='dummy timeseries', description='desc',

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -271,32 +271,3 @@ class TestEpochsRoundtripDf(base.TestMapRoundTrip):
     def getContainer(self, nwbfile):
         return nwbfile.epochs
 
-
-class TestUnitElectrodes(base.TestMapRoundTrip):
-
-    def setUpContainer(self):
-        # this will get ignored
-        return Units('placeholder_units')
-
-    def addContainer(self, nwbfile):
-        device = nwbfile.create_device(name='trodes_rig123')
-        electrode_name = 'tetrode1'
-        description = "an example tetrode"
-        location = "somewhere in the hippocampus"
-        electrode_group = nwbfile.create_electrode_group(electrode_name,
-                                                         description=description,
-                                                         location=location,
-                                                         device=device)
-        for idx in [1, 2, 3, 4]:
-            nwbfile.add_electrode(idx,
-                                  x=1.0, y=2.0, z=3.0,
-                                  imp=float(-idx),
-                                  location='CA1', filtering='none',
-                                  group=electrode_group)
-
-        nwbfile.add_unit(id=1, electrodes=[1])
-        nwbfile.add_unit(id=2, electrodes=[1])
-        self.container = nwbfile.units
-
-    def getContainer(self, nwbfile):
-        return nwbfile.units

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -12,7 +12,6 @@ from pynwb import NWBFile, TimeSeries
 from pynwb.file import Subject
 from pynwb.ecephys import Clustering
 from pynwb.epoch import TimeIntervals
-from pynwb.misc import Units
 
 from . import base
 
@@ -270,4 +269,3 @@ class TestEpochsRoundtripDf(base.TestMapRoundTrip):
 
     def getContainer(self, nwbfile):
         return nwbfile.epochs
-

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -1,11 +1,10 @@
-import unittest2 as unittest
-
-from pynwb.core import DynamicTable, VectorData, ElementIdentifiers, NWBTable, DynamicTableRegion
-from pynwb import NWBFile, TimeSeries, available_namespaces
+from datetime import datetime
 
 import pandas as pd
-from datetime import datetime
+import unittest2 as unittest
 from dateutil.tz import tzlocal
+from pynwb import NWBFile, TimeSeries, available_namespaces
+from pynwb.core import DynamicTable, VectorData, ElementIdentifiers, NWBTable, DynamicTableRegion
 
 
 class TestDynamicTable(unittest.TestCase):
@@ -203,9 +202,9 @@ class TestDynamicTable(unittest.TestCase):
             table.add_row({'bar': 60.0, 'foo': 6, 'baz': 'oryx', 'qax': -1}, None)
 
     def test_indexed_dynamic_table_region(self):
-        table = self.with_spec()
+        table = self.with_columns_and_data()
 
-        dynamic_table_region = DynamicTableRegion('dtr', [0, 1], 'desc', table)
+        dynamic_table_region = DynamicTableRegion('dtr', [0, 1], 'desc', table=table)
         assert dynamic_table_region[slice(0, 1)]
 
 
@@ -219,7 +218,8 @@ class TestNWBTable(unittest.TestCase):
             ]
         self.cls = MyTable
 
-    def basic_data(self):
+    @staticmethod
+    def basic_data():
         return [
             [1, 'a'],
             [2, 'b'],

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -1,6 +1,6 @@
 import unittest2 as unittest
 
-from pynwb.core import DynamicTable, VectorData, ElementIdentifiers, NWBTable
+from pynwb.core import DynamicTable, VectorData, ElementIdentifiers, NWBTable, DynamicTableRegion
 from pynwb import NWBFile, TimeSeries, available_namespaces
 
 import pandas as pd
@@ -14,7 +14,7 @@ class TestDynamicTable(unittest.TestCase):
         self.spec = [
             {'name': 'foo', 'description': 'foo column'},
             {'name': 'bar', 'description': 'bar column'},
-            {'name': 'baz', 'description': 'baz column'}
+            {'name': 'baz', 'description': 'baz column'},
         ]
         self.data = [
             [1, 2, 3, 4, 5],
@@ -201,6 +201,12 @@ class TestDynamicTable(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             table.add_row({'bar': 60.0, 'foo': 6, 'baz': 'oryx', 'qax': -1}, None)
+
+    def test_indexed_dynamic_table_region(self):
+        table = self.with_spec()
+
+        dynamic_table_region = DynamicTableRegion('dtr', [0, 1], 'desc', table)
+        assert dynamic_table_region[slice(0, 1)]
 
 
 class TestNWBTable(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -228,14 +228,14 @@ class NWBFileTest(unittest.TestCase):
                                                     'tetrode description', 'tetrode location', dev1)
         self.nwbfile.add_electrode(1.0, 2.0, 3.0, -1.0, 'CA1',
                                    'none', group=group, id=1)
-        self.assertEqual(self.nwbfile.ec_electrodes[0][0], 1)
-        self.assertEqual(self.nwbfile.ec_electrodes[0][1], 1.0)
-        self.assertEqual(self.nwbfile.ec_electrodes[0][2], 2.0)
-        self.assertEqual(self.nwbfile.ec_electrodes[0][3], 3.0)
-        self.assertEqual(self.nwbfile.ec_electrodes[0][4], -1.0)
-        self.assertEqual(self.nwbfile.ec_electrodes[0][5], 'CA1')
-        self.assertEqual(self.nwbfile.ec_electrodes[0][6], 'none')
-        self.assertEqual(self.nwbfile.ec_electrodes[0][7], group)
+        self.assertEqual(self.nwbfile.electrodes[0][0], 1)
+        self.assertEqual(self.nwbfile.electrodes[0][1], 1.0)
+        self.assertEqual(self.nwbfile.electrodes[0][2], 2.0)
+        self.assertEqual(self.nwbfile.electrodes[0][3], 3.0)
+        self.assertEqual(self.nwbfile.electrodes[0][4], -1.0)
+        self.assertEqual(self.nwbfile.electrodes[0][5], 'CA1')
+        self.assertEqual(self.nwbfile.electrodes[0][6], 'none')
+        self.assertEqual(self.nwbfile.electrodes[0][7], group)
 
     def test_all_children(self):
         ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -180,6 +180,8 @@ class NWBFileTest(unittest.TestCase):
         table.add_row(x=1.0, y=2.0, z=3.0, imp=-4.0, location='CA1', filtering='none', group=group,
                       group_name='tetrode1')
         self.nwbfile.set_electrode_table(table)
+
+        self.assertIs(self.nwbfile.ec_electrodes, self.nwbfile.electrodes)
         self.assertIs(self.nwbfile.electrodes, table)
         self.assertIs(table.parent, self.nwbfile)
 

--- a/tests/unit/pynwb_tests/test_icephys.py
+++ b/tests/unit/pynwb_tests/test_icephys.py
@@ -8,17 +8,17 @@ from pynwb.device import Device
 
 
 def GetElectrode():
-        device = Device(name='device_name')
-        elec = IntracellularElectrode('test_iS',
-                                      device,
-                                      'slice',
-                                      'seal',
-                                      'description',
-                                      'location',
-                                      'resistance',
-                                      'filtering',
-                                      'initial_access_resistance')
-        return elec
+    device = Device(name='device_name')
+    elec = IntracellularElectrode('test_iS',
+                                  device,
+                                  'slice',
+                                  'seal',
+                                  'description',
+                                  'location',
+                                  'resistance',
+                                  'filtering',
+                                  'initial_access_resistance')
+    return elec
 
 
 class IntracellularElectrodeConstructor(unittest.TestCase):


### PR DESCRIPTION
* handle getting slices of DynamicTableRegion
* move ui units w/ electrodes test from core to misc
* add line to test conversion to dataframe

## Motivation

fix #810

## How to test the behavior?
```python
device = nwbfile.create_device(name='trodes_rig123')
electrode_name = 'tetrode1'
description = "an example tetrode"
location = "somewhere in the hippocampus"
electrode_group = nwbfile.create_electrode_group(electrode_name,
                                                 description=description,
                                                 location=location,
                                                 device=device)
for idx in [1, 2, 3, 4]:
    nwbfile.add_electrode(idx,
                          x=1.0, y=2.0, z=3.0,
                          imp=float(-idx),
                          location='CA1', filtering='none',
                          group=electrode_group)

nwbfile.add_unit(id=1, electrodes=[1])
nwbfile.add_unit(id=2, electrodes=[1])
nwbfile.units.to_dataframe()
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
