### PR TITLE
fix conversion from ndarrays to dataframes

### DIFF
--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1240,10 +1240,10 @@ class DynamicTable(NWBDataInterface):
         data = {}
         for name in self.colnames:
             col = self.__df_cols[self.__colids[name]]
-            if col.data.ndim == 1:
-                data[name] = col[:]
-            else:
+            if isinstance(col.data, np.ndarray) and col.data.ndim > 1:
                 data[name] = [x for x in col[:]]
+            else:
+                data[name] = col[:]
 
         return pd.DataFrame(data, index=pd.Index(name=self.id.name, data=self.id.data))
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1240,7 +1240,10 @@ class DynamicTable(NWBDataInterface):
         data = {}
         for name in self.colnames:
             col = self.__df_cols[self.__colids[name]]
-            data[name] = col[:]
+            if col.data.ndim == 1:
+                data[name] = col[:]
+            else:
+                data[name] = [x for x in col[:]]
 
         return pd.DataFrame(data, index=pd.Index(name=self.id.name, data=self.id.data))
 

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import numpy as np
 import pandas as pd
 import unittest2 as unittest
 from dateutil.tz import tzlocal
@@ -206,6 +207,10 @@ class TestDynamicTable(unittest.TestCase):
 
         dynamic_table_region = DynamicTableRegion('dtr', [0, 1], 'desc', table=table)
         assert dynamic_table_region[slice(0, 1)]
+
+    def test_nd_array_to_df(self):
+        col = VectorData(name='name', description='desc', data=np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]]))
+        DynamicTable('test', 'desc', np.arange(3, dtype='int'), (col, )).to_dataframe()
 
 
 class TestNWBTable(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -2,6 +2,7 @@ from datetime import datetime
 
 import numpy as np
 import pandas as pd
+from pandas.util.testing import assert_frame_equal
 import unittest2 as unittest
 from dateutil.tz import tzlocal
 from pynwb import NWBFile, TimeSeries, available_namespaces
@@ -209,8 +210,12 @@ class TestDynamicTable(unittest.TestCase):
         assert dynamic_table_region[slice(0, 1)]
 
     def test_nd_array_to_df(self):
-        col = VectorData(name='name', description='desc', data=np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]]))
-        DynamicTable('test', 'desc', np.arange(3, dtype='int'), (col, )).to_dataframe()
+        data = np.array([[1, 1, 1], [2, 2, 2], [3, 3, 3]])
+        col = VectorData(name='name', description='desc', data=data)
+        df = DynamicTable('test', 'desc', np.arange(3, dtype='int'), (col, )).to_dataframe()
+        df2 = pd.DataFrame({'name': [x for x in data]},
+                           index=pd.Index(name='id', data=[0, 1, 2]))
+        assert_frame_equal(df, df2)
 
 
 class TestNWBTable(unittest.TestCase):


### PR DESCRIPTION
*convert nd arrays to list of arrays when converting to df
*add test

## Motivation

fix #810 

## How to test the behavior?
```python
from pynwb.core import DynamicTable, VectorData
import numpy as np 
import pandas as pd

col = VectorData(name='name', description='desc', data=np.array([[1,1,1],[2,2,2],[3,3,3]])) 
DynamicTable('test', 'desc', np.arange(3, dtype='int'), (col, )).to_dataframe()
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
