### PR TITLE
fix printing for neurodata types

### DIFF
--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -176,6 +176,8 @@ class NWBBaseType(with_metaclass(ExtenderMeta, Container)):
 
         If v is a dictionary, print the name and type of each element
 
+        If v is a set, print it sorted
+
         If v is a neurodata_type, print the name of type
 
         Otherwise, use the built-in str()
@@ -201,6 +203,8 @@ class NWBBaseType(with_metaclass(ExtenderMeta, Container)):
             if keys:
                 template += " {} {}".format(keys[-1], type(v[keys[-1]]))
             return template + ' }'
+        elif isinstance(v, set):
+            return str(list(sorted(list(v))))
         elif isinstance(v, NWBBaseType):
             return "{} {}".format(getattr(v, 'name'), type(v))
         else:

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -202,7 +202,7 @@ class NWBBaseType(with_metaclass(ExtenderMeta, Container)):
                 template += " {} {}".format(keys[-1], type(v[keys[-1]]))
             return template + ' }'
         elif isinstance(v, NWBBaseType):
-            "{} {}".format(getattr(v, 'name'), type(v))
+            return "{} {}".format(getattr(v, 'name'), type(v))
         else:
             return str(v)
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -204,7 +204,8 @@ class NWBBaseType(with_metaclass(ExtenderMeta, Container)):
                 template += " {} {}".format(keys[-1], type(v[keys[-1]]))
             return template + ' }'
         elif isinstance(v, set):
-            return str(list(sorted(list(v))))
+            out = str(list(sorted(list(v))))
+            return '{' + out[1:-1] + '}'
         elif isinstance(v, NWBBaseType):
             return "{} {}".format(getattr(v, 'name'), type(v))
         else:

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -322,7 +322,7 @@ Fields:
   analysis: { }
   devices: { }
   electrode_groups: { }
-  epoch_tags: ['tag1', 'tag2']
+  epoch_tags: {'tag1', 'tag2'}
   epochs: epochs <class 'pynwb.epoch.TimeIntervals'>
   ic_electrodes: { }
   imaging_planes: { }

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -322,7 +322,7 @@ Fields:
   analysis: { }
   devices: { }
   electrode_groups: { }
-  epoch_tags: {'tag1', 'tag2'}
+  epoch_tags: ['tag1', 'tag2']
   epochs: epochs <class 'pynwb.epoch.TimeIntervals'>
   ic_electrodes: { }
   imaging_planes: { }

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -313,7 +313,7 @@ Fields:
                          )
         nwbfile.add_acquisition(ts)
         nwbfile.add_acquisition(ts2)
-        empty_set_str = str(set())  # changes between py2 and py3
+        nwbfile.add_epoch(start_time=1.0, stop_time=10.0, tags=['tag1', 'tag2'])
         self.assertEqual(str(nwbfile),
                          """
 root <class 'pynwb.file.NWBFile'>
@@ -322,7 +322,8 @@ Fields:
   analysis: { }
   devices: { }
   electrode_groups: { }
-  epoch_tags: """ + empty_set_str + """
+  epoch_tags: {'tag1', 'tag2'}
+  epochs: epochs <class 'pynwb.epoch.TimeIntervals'>
   ic_electrodes: { }
   imaging_planes: { }
   lab_meta_data: { }


### PR DESCRIPTION
## Motivation

fix #817 

## How to test the behavior?
```python
import pynwb
from datetime import datetime
from dateutil import tz

dataset_zero_time = datetime(2006, 1, 2, 12, 0, 0, tzinfo=tz.gettz('US/Pacific'))
file_create_date = datetime.now(tz.tzlocal())
data_dir = 'path/to/nwb/files'
nwb_filename = 'test.nwb'
nwbf = pynwb.NWBFile(session_description='no session description',
                     identifier='no identifier',
                     session_start_time=dataset_zero_time)
nwbf.add_epoch(start_time=1.0,
               stop_time=10.0,
               tags=['tag1', 'tag2'])

print(nwbf)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
