### PR TITLE
change 'electrode_group' col of Units to be ElectrodeGroup type

### DIFF
--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -212,7 +212,7 @@ class Units(DynamicTable):
              'default': None, 'shape': (None, 2)},
             {'name': 'electrodes', 'type': 'array_data', 'doc': 'the electrodes that each unit came from',
              'default': None},
-            {'name': 'electrode_group', 'type': 'array_data', 'default': None,
+            {'name': 'electrode_group', 'type': 'ElectrodeGroup', 'default': None,
              'doc': 'the electrode group that each unit came from'},
             {'name': 'waveform_mean', 'type': 'array_data', 'doc': 'the spike waveform mean for each unit',
              'default': None},

--- a/tests/integration/ui_write/test_misc.py
+++ b/tests/integration/ui_write/test_misc.py
@@ -97,8 +97,8 @@ class TestUnitElectrodes(base.TestMapRoundTrip):
                                   location='CA1', filtering='none',
                                   group=electrode_group)
 
-        nwbfile.add_unit(id=1, electrodes=[1])
-        nwbfile.add_unit(id=2, electrodes=[1])
+        nwbfile.add_unit(id=1, electrodes=[1], electrode_group=electrode_group)
+        nwbfile.add_unit(id=2, electrodes=[1], electrode_group=electrode_group)
         nwbfile.units.to_dataframe()
         self.container = nwbfile.units
 

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -154,7 +154,7 @@ class UnitsTests(unittest.TestCase):
     def test_electrode_group(self):
         ut = Units()
         device = Device('test_device')
-        electrode_group = ElectrodeGroup('test_electrode_group', 'location', device)
+        electrode_group = ElectrodeGroup('test_electrode_group', 'description', 'location', device)
         ut.add_unit(electrode_group=electrode_group)
         self.assertEqual(ut['electrode_group'][0], electrode_group)
 

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -6,6 +6,8 @@ from pynwb.misc import AnnotationSeries, AbstractFeatureSeries, IntervalSeries, 
     DecompositionSeries
 from pynwb.file import TimeSeries, DynamicTable
 from pynwb.core import VectorData
+from pynwb.device import Device
+from pynwb.ecephys import ElectrodeGroup
 
 
 class AnnotationSeriesConstructor(unittest.TestCase):
@@ -148,6 +150,13 @@ class UnitsTests(unittest.TestCase):
         self.assertTrue(all(ut['spike_times'][1] == np.array([3, 4, 5])))
         self.assertTrue(np.all(ut['obs_intervals'][0] == np.array([[0, 2]])))
         self.assertTrue(np.all(ut['obs_intervals'][1] == np.array([[2, 3], [4, 5]])))
+
+    def test_electrode_group(self):
+        ut = Units()
+        device = Device('test_device')
+        electrode_group = ElectrodeGroup('test_electrode_group', 'location', device)
+        ut.add_unit(electrode_group=electrode_group)
+        self.assertEqual(ut['electrode_group'][0], electrode_group)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

fix #834

Now electrode groups can be added to the Units table

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
