### PR TITLE
add spike_event_series link to ElectrodeGroup

### DIFF
--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -334,3 +334,7 @@ groups:
     doc: the device that was used to record from this electrode group
     quantity: '?'
     target_type: Device
+  - name: spike_event_series
+    doc: the SpikeEventSeries that holds the recorded spike snippets for this electrode group
+    quantity: '?'
+    target_type: SpikeEventSeries

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -340,7 +340,6 @@ groups:
     doc: the device that was used to record from this electrode group
     quantity: '?'
     target_type: Device
-  - name: spike_event_series
-    doc: the SpikeEventSeries that holds the recorded spike snippets for this electrode group
-    quantity: '?'
-    target_type: SpikeEventSeries
+  - doc: the SpikeEventSeries that holds the recorded spike snippets for this electrode group
+    quantity: '*'
+    target_type: ElectricalSeries

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -20,24 +20,24 @@ class ElectrodeGroup(NWBContainer):
                      'description',
                      'location',
                      'device',
-                     {'name': 'spike_event_series', 'doc': 'doc', 'child': False})
+                     {'name': 'electrical_series', 'doc': 'doc', 'child': False})
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
             {'name': 'description', 'type': str, 'doc': 'description of this electrode group'},
             {'name': 'location', 'type': str, 'doc': 'description of location of this electrode group'},
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record from this electrode group'},
-            {'name': 'spike_event_series', 'type': 'SpikeEventSeries',
+            {'name': 'electrical_series', 'type': 'SpikeEventSeries',
              'doc': 'SpikeEventSeries recorded from this group', 'default': None},
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
     def __init__(self, **kwargs):
         call_docval_func(super(ElectrodeGroup, self).__init__, kwargs)
-        description, location, device, spike_event_series = popargs("description", "location", "device",
-                                                                    "spike_event_series", kwargs)
+        description, location, device, electrical_series = popargs("description", "location", "device",
+                                                                   "electrical_series", kwargs)
         self.description = description
         self.location = location
         self.device = device
-        self.spike_event_series = spike_event_series
+        self.electrical_series = electrical_series
 
 
 _et_docval = [

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -20,7 +20,10 @@ class ElectrodeGroup(NWBContainer):
                      'description',
                      'location',
                      'device',
-                     {'name': 'spike_event_series', 'doc': 'doc', 'child': False})
+                     {'name': 'spike_event_series',
+                      'doc': 'the SpikeEventSeries that holds the recorded spike snippets for this electrode group',
+                      'child': False,
+                      'type': 'SpikeEventSeries'})
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
             {'name': 'description', 'type': str, 'doc': 'description of this electrode group'},

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -20,7 +20,7 @@ class ElectrodeGroup(NWBContainer):
                      'description',
                      'location',
                      'device',
-                     {'name': 'spike_event_series',
+                     {'name': 'electrical_series',
                       'doc': 'the ElectricalSeries that holds the recorded spike snippets for this electrode group',
                       'child': False,
                       'type': 'ElectricalSeries'})

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -19,20 +19,25 @@ class ElectrodeGroup(NWBContainer):
     __nwbfields__ = ('name',
                      'description',
                      'location',
-                     'device')
+                     'device',
+                     {'name': 'spike_event_series', 'doc': 'doc', 'child': False})
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
             {'name': 'description', 'type': str, 'doc': 'description of this electrode group'},
             {'name': 'location', 'type': str, 'doc': 'description of location of this electrode group'},
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record from this electrode group'},
+            {'name': 'spike_event_series', 'type': 'SpikeEventSeries',
+             'doc': 'SpikeEventSeries recorded from this group', 'default': None},
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
     def __init__(self, **kwargs):
         call_docval_func(super(ElectrodeGroup, self).__init__, kwargs)
-        description, location, device = popargs("description", "location", "device", kwargs)
+        description, location, device, spike_event_series = popargs("description", "location", "device",
+                                                                    "spike_event_series", kwargs)
         self.description = description
         self.location = location
         self.device = device
+        self.spike_event_series = spike_event_series
 
 
 _et_docval = [

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -22,8 +22,7 @@ class ElectrodeGroup(NWBContainer):
                      'device',
                      {'name': 'electrical_series',
                       'doc': 'the ElectricalSeries that holds the recorded spike snippets for this electrode group',
-                      'child': False,
-                      'type': 'ElectricalSeries'})
+                      'child': False})
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
             {'name': 'description', 'type': str, 'doc': 'description of this electrode group'},

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -945,9 +945,12 @@ class GroupSpec(BaseStorageSpec):
         if isinstance(spec, Spec):
             name = spec.name
             if name is None:
-                name = spec.data_type_def
-            if name is None:
-                name = spec.data_type_inc
+                if isinstance(spec, LinkSpec):
+                    name = spec.target_type
+                else:
+                    name = spec.data_type_def
+                    if name is None:
+                        name = spec.data_type_inc
             if name is None:
                 raise ValueError('received Spec with wildcard name but no data_type_inc or data_type_def')
             spec = name


### PR DESCRIPTION
## Motivation

Part of plan to make spike waveforms accessible from Units table. See https://github.com/NeurodataWithoutBorders/nwb-schema/issues/248

This is not working and I can't figure out why. Help @ajtritt?