### PR TITLE
add UnitSeries

### DIFF
--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -257,3 +257,32 @@ groups:
     - null
     quantity: '?'
   default_name: Units
+- neurodata_type_def: UnitSeries
+  neurodata_type_inc: TimeSeries
+  doc: Unit spike times a stream of IDs of spiking units
+  attributes:
+  - name: help
+    dtype: text
+    doc: Value is 'Unit spike times a stream of IDs of spiking units'
+    value: Unit spike times a stream of IDs of spiking units
+  datasets:
+  - name: data
+    dtype: int
+    doc: the index of the spike unit in the DynamicTableRegion "units"
+    attributes:
+    - name: resolution
+      dtype: float
+      doc: Value is -1.0. Indices do not have resolution
+      value: -1.0
+    - name: unit
+      dtype: text
+      doc: Value is 'index'
+      value: index
+    dims:
+    - num_times
+    shape:
+    - null
+  links:
+   - name: units
+     doc: The units table that is being indexed
+     target_type: Units

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -329,6 +329,7 @@ class DecompositionSeries(TimeSeries):
         self.bands.add_row({k: v for k, v in kwargs.items() if v is not None})
 
 
+@register_class('UnitSeries', CORE_NAMESPACE)
 class UnitSeries(TimeSeries):
 
     __nwbfields__ = ({'name': 'units', 'child': False, 'doc': 'link to Units table'},)

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -327,3 +327,29 @@ class DecompositionSeries(TimeSeries):
             self.__check_column('band_stdev', 'the standard deviation of Gaussian filters in Hz')
 
         self.bands.add_row({k: v for k, v in kwargs.items() if v is not None})
+
+
+class UnitSeries(TimeSeries):
+
+    __nwbfields__ = ({'name': 'units', 'child': False, 'doc': 'link to Units table'},)
+
+    @docval({'name': 'name', 'type': str, 'doc': 'The name of this UnitSeries dataset'},
+            {'name': 'data', 'type': ('array_data', 'data', TimeSeries), 'shape': (None,),
+             'doc': 'Indices of Units table (0-indexed)'},
+            {'name': 'timestamps', 'type': ('array_data', 'data', TimeSeries), 'shape': (None,),
+             'doc': 'Timestamps for samples stored in data', 'default': None},
+            {'name': 'units', 'type': Units, 'doc': 'Units table', 'default': None},
+            {'name': 'description', 'type': str,
+             'doc': 'Description of this TimeSeries dataset', 'default': 'no description'},
+            {'name': 'control', 'type': Iterable,
+             'doc': 'Numerical labels that apply to each element in data', 'default': None},
+            {'name': 'control_description', 'type': Iterable,
+             'doc': 'Description of each control value', 'default': None},
+            {'name': 'parent', 'type': NWBContainer,
+             'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
+    def __init__(self, **kwargs):
+        kwargs.update(conversion=np.nan, resolution=np.nan)
+
+        name, data, units = popargs('name', 'data', 'units', kwargs)
+        super(UnitSeries, self).__init__(name, data, **kwargs)
+        self.units = units

--- a/tests/integration/ui_write/test_misc.py
+++ b/tests/integration/ui_write/test_misc.py
@@ -5,7 +5,7 @@ from pynwb.form.build import GroupBuilder, DatasetBuilder, ReferenceBuilder
 from pynwb import TimeSeries
 from pynwb.core import DynamicTable, VectorData
 
-from pynwb.misc import Units, DecompositionSeries
+from pynwb.misc import Units, DecompositionSeries, UnitSeries
 
 
 class TestUnitsIO(base.TestDataInterfaceIO):
@@ -106,7 +106,7 @@ class TestUnitElectrodes(base.TestMapRoundTrip):
         return nwbfile.units
 
 
-class TestSpectralAnalysis(base.TestDataInterfaceIO):
+class TestDecompositionSeries(base.TestDataInterfaceIO):
     def setUpContainer(self):
         self.timeseries = TimeSeries(name='dummy timeseries', description='desc',
                                      data=np.ones((3, 3)), unit='flibs',
@@ -133,3 +133,21 @@ class TestSpectralAnalysis(base.TestDataInterfaceIO):
     def getContainer(self, nwbfile):
 
         return nwbfile.modules['test_mod']['LFPSpectralAnalysis']
+
+
+class TestUnitSeries(base.TestDataInterfaceIO):
+    def setUpContainer(self):
+        self.units = Units(name='units', description='a simple table for testing Units')
+        self.units.add_unit(spike_times=[0, 1, 2], obs_intervals=[[0, 1], [2, 3]])
+
+        us = UnitSeries('test_unit_series', np.array([0, 0, 1, 1], dtype=int),
+                        timestamps=[.1, .2, .3, .4], units=self.units, description='description')
+        return us
+
+    def addContainer(self, nwbfile):
+        nwbfile.units = self.units
+        ecephys_mod = nwbfile.create_processing_module('ecephys', 'test_mod')
+        ecephys_mod.add_data_interface(self.container)
+
+    def getContainer(self, nwbfile):
+        return nwbfile.modules['ecephys']['test_unit_series']

--- a/tests/unit/pynwb_tests/test_misc.py
+++ b/tests/unit/pynwb_tests/test_misc.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 
 from pynwb.misc import AnnotationSeries, AbstractFeatureSeries, IntervalSeries, Units, \
-    DecompositionSeries
+    DecompositionSeries, UnitSeries
 from pynwb.file import TimeSeries, DynamicTable
 from pynwb.core import VectorData
 
@@ -148,6 +148,15 @@ class UnitsTests(unittest.TestCase):
         self.assertTrue(all(ut['spike_times'][1] == np.array([3, 4, 5])))
         self.assertTrue(np.all(ut['obs_intervals'][0] == np.array([[0, 2]])))
         self.assertTrue(np.all(ut['obs_intervals'][1] == np.array([[2, 3], [4, 5]])))
+
+
+class UnitSeriesConstructor(unittest.TestCase):
+    def test_init(self):
+        units = Units()
+        us = UnitSeries('test_unit_series', np.array([0, 0, 1, 1], dtype=int),
+                        timestamps=[.1, .2, .3, .4], units=units, description='description')
+        self.assertTrue(all(us.data == np.array([0, 0, 1, 1], dtype=int)))
+        self.assertEqual(units, us.units)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Motivation

Part of plan to make spike waveforms accessible from Units table. See https://github.com/NeurodataWithoutBorders/nwb-schema/issues/248

## How to test the behavior?
```
from pynwb.misc import Units, UnitSeries

units = Units()
us = UnitSeries('test_unit_series', np.array([0, 0, 1, 1], dtype=int), timestamps=[.1, .2, .3, .4], units=units, description='description')
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
