### PR TITLE
Enh/add links to elec grp

### DIFF
--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -335,6 +335,20 @@ groups:
   - name: location
     dtype: text
     doc: description of location of this electrode group
+  datasets:
+    - name: acquisition
+      neurodata_type_inc: ElectricalSeries
+      doc: 'ElectricalSeries recorded by this ElectrodeGroup'
+      quantity: '?'
+  groups:
+    - neurodata_type_inc: LFP
+      name: lfp
+      doc: 'LFP recorded from this ElectrodeGroup'
+      quantity: '?'
+    - neurodata_type_inc: EventWaveform
+      name: event_waveform
+      doc: 'Spike waveforms recorded from this ElectrodeGroup'
+      quantity: '?'
   links:
   - name: device
     doc: the device that was used to record from this electrode group

--- a/src/pynwb/data/nwb.ecephys.yaml
+++ b/src/pynwb/data/nwb.ecephys.yaml
@@ -335,11 +335,6 @@ groups:
   - name: location
     dtype: text
     doc: description of location of this electrode group
-  datasets:
-    - name: acquisition
-      neurodata_type_inc: ElectricalSeries
-      doc: 'ElectricalSeries recorded by this ElectrodeGroup'
-      quantity: '?'
   groups:
     - neurodata_type_inc: LFP
       name: lfp
@@ -354,3 +349,7 @@ groups:
     doc: the device that was used to record from this electrode group
     quantity: '?'
     target_type: Device
+  - name: acquisition
+    target_type: ElectricalSeries
+    doc: 'ElectricalSeries recorded by this ElectrodeGroup'
+    quantity: '*'

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -19,20 +19,33 @@ class ElectrodeGroup(NWBContainer):
     __nwbfields__ = ('name',
                      'description',
                      'location',
-                     'device')
+                     'device',
+                     {'name': 'lfp', 'doc': 'LFP recorded from this ElectrodeGroup', 'child': False},
+                     {'name': 'event_waveform', 'doc': 'Spike waveforms recorded from this ElectrodeGroup',
+                      'child': False},
+                     {'name': 'acquisition', 'doc': 'ElectricalSeries recorded by this ElectrodeGroup', 'child': False})
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
             {'name': 'description', 'type': str, 'doc': 'description of this electrode group'},
             {'name': 'location', 'type': str, 'doc': 'description of location of this electrode group'},
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record from this electrode group'},
+            {'name': 'lfp', 'type': 'LFP', 'doc': 'LFP recorded from this ElectrodeGroup', 'default': None},
+            {'name': 'event_waveform', 'type': 'EventWaveform',
+             'doc': 'Spike waveforms recorded from this ElectrodeGroup', 'default': None},
+            {'name': 'acquisition', 'type': 'ElectricalSeries',
+             'doc': 'ElectricalSeries recorded by this ElectrodeGroup', 'default': None},
             {'name': 'parent', 'type': 'NWBContainer',
              'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
     def __init__(self, **kwargs):
         call_docval_func(super(ElectrodeGroup, self).__init__, kwargs)
-        description, location, device = popargs("description", "location", "device", kwargs)
+        description, location, device, lfp, event_waveform, acquisition = popargs(
+            "description", "location", "device", "lfp", "event_waveform", "acquisition", kwargs)
         self.description = description
         self.location = location
         self.device = device
+        self.lfp = lfp
+        self.event_waveform = event_waveform
+        self.acquisition = acquisition
 
 
 _et_docval = [

--- a/src/pynwb/form/spec/spec.py
+++ b/src/pynwb/form/spec/spec.py
@@ -945,9 +945,12 @@ class GroupSpec(BaseStorageSpec):
         if isinstance(spec, Spec):
             name = spec.name
             if name is None:
-                name = spec.data_type_def
-            if name is None:
-                name = spec.data_type_inc
+                if isinstance(spec, LinkSpec):
+                    name = spec.target_type
+                else:
+                    name = spec.data_type_def
+                    if name is None:
+                        name = spec.data_type_inc
             if name is None:
                 raise ValueError('received Spec with wildcard name but no data_type_inc or data_type_def')
             spec = name

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -18,28 +18,19 @@ class TestElectrodeGroupIO(base.TestMapRoundTrip):
 
     def setUpContainer(self):
         self.dev1 = Device('dev1')
-        return ElectrodeGroup('elec1', 'a test ElectrodeGroup',
-                                       'a nonexistent place',
-                                       self.dev1)
+        self.event_waveform = EventWaveform()
+        self.lfp = LFP()
 
-    def setUpBuilder(self):
-        device_builder = GroupBuilder('dev1',
-                                      attributes={'neurodata_type': 'Device',
-                                                  'namespace': 'core',
-                                                  'help': 'A recording device e.g. amplifier'})
-        return GroupBuilder('elec1',
-                            attributes={'neurodata_type': 'ElectrodeGroup',
-                                        'namespace': 'core',
-                                        'help': 'A physical grouping of channels',
-                                        'description': 'a test ElectrodeGroup',
-                                        'location': 'a nonexistent place'},
-                            links={
-                                'device': LinkBuilder(device_builder, 'device')
-                            })
+        return ElectrodeGroup('elec1', 'a test ElectrodeGroup', 'a nonexistent place', self.dev1,
+                              event_waveform=self.event_waveform, lfp=self.lfp)
 
     def addContainer(self, nwbfile):
         ''' Should take an NWBFile object and add the container to it '''
         nwbfile.add_device(self.dev1)
+        ecephys_mod = nwbfile.create_processing_module('ecephys', 'description')
+        ecephys_mod.add_data_interface(self.event_waveform)
+        ecephys_mod.add_data_interface(self.lfp)
+
         nwbfile.add_electrode_group(self.container)
 
     def getContainer(self, nwbfile):


### PR DESCRIPTION
## Motivation

Adds links to ElectrodeGroup that facilitates queries between ElectrodeGroups and recorded data
depends on #827 

## How to test the behavior?
```python
ElectrodeGroup('elec1', 'a test ElectrodeGroup', 'a nonexistent place', Device(),
               event_waveform=EventWaveform(), lfp=LFP())
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
