### PR TITLE
add methods to TimeSeries of aligning to events

### DIFF
--- a/tests/integration/ui_write/test_base.py
+++ b/tests/integration/ui_write/test_base.py
@@ -1,6 +1,5 @@
 import numpy as np
 import datetime as datetime
-import numpy.testing
 
 from pynwb.form.build import GroupBuilder, DatasetBuilder
 
@@ -53,11 +52,3 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
         tsa = nwbfile.acquisition['a']
         tsb = nwbfile.acquisition['b']
         self.assertIs(tsa.timestamps, tsb.timestamps)
-
-    def test_align_by_trials(self):
-        nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now(), session_description='bar')
-        nwbfile.add_trial(start_time=5., stop_time=10.)
-        nwbfile.add_trial(start_time=15., stop_time=20.)
-        ts = TimeSeries(name='a', data=np.arange(1000), timestamps=np.arange(1000), unit='m')
-        nwbfile.add_acquisition(ts)
-        numpy.testing.assert_equal(ts.align_by_trials(), [[6, 7, 8, 9, 10], [16, 17, 18, 19, 20]])

--- a/tests/integration/ui_write/test_base.py
+++ b/tests/integration/ui_write/test_base.py
@@ -1,5 +1,6 @@
 import numpy as np
 import datetime as datetime
+import numpy.testing
 
 from pynwb.form.build import GroupBuilder, DatasetBuilder
 
@@ -37,7 +38,7 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
         return nwbfile.get_acquisition(self.container.name)
 
     def test_timestamps_linking(self):
-        ''' Test that timestamps get linked to in TimeSeres '''
+        ''' Test that timestamps get linked to in TimeSeries '''
         path = 'test_timestamps_linking.nwb'
         tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000), unit='m')
         tsb = TimeSeries(name='b', data=np.linspace(0, 1, 1000), timestamps=tsa, unit='m')
@@ -52,3 +53,11 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
         tsa = nwbfile.acquisition['a']
         tsb = nwbfile.acquisition['b']
         self.assertIs(tsa.timestamps, tsb.timestamps)
+
+    def test_align_by_trials(self):
+        nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now(), session_description='bar')
+        nwbfile.add_trial(start_time=5., stop_time=10.)
+        nwbfile.add_trial(start_time=15., stop_time=20.)
+        ts = TimeSeries(name='a', data=np.arange(1000), timestamps=np.arange(1000), unit='m')
+        nwbfile.add_acquisition(ts)
+        numpy.testing.assert_equal(ts.align_by_trials(), [[6, 7, 8, 9, 10], [16, 17, 18, 19, 20]])

--- a/tests/unit/pynwb_tests/test_base.py
+++ b/tests/unit/pynwb_tests/test_base.py
@@ -1,9 +1,12 @@
 import unittest2 as unittest
 import numpy as np
+import numpy.testing
+import datetime
 
 from pynwb.base import ProcessingModule, TimeSeries, Images, Image
 from pynwb.form.data_utils import DataChunkIterator
 from pynwb.form.backends.hdf5 import H5DataIO
+from pynwb import NWBFile
 
 
 class TestProcessingModule(unittest.TestCase):
@@ -118,6 +121,14 @@ class TestTimeSeries(unittest.TestCase):
         with self.assertRaises(ValueError):
             TimeSeries('test_ts2', [10, 11, 12, 13, 14, 15], 'grams',
                        starting_time=30., timestamps=[.3, .4, .5, .6, .7, .8])
+
+    def test_align_by_trials(self):
+        nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now(), session_description='bar')
+        nwbfile.add_trial(start_time=5., stop_time=10.)
+        nwbfile.add_trial(start_time=15., stop_time=20.)
+        ts = TimeSeries(name='a', data=np.arange(1000), timestamps=np.arange(1000), unit='m')
+        nwbfile.add_acquisition(ts)
+        numpy.testing.assert_equal(ts.align_by_trials(), [[6, 7, 8, 9, 10], [16, 17, 18, 19, 20]])
 
 
 class TestImage(unittest.TestCase):


### PR DESCRIPTION
## Motivation

Addresses a common need to align `TimeSeries` data to trials

## How to test the behavior?
```python
import numpy.testing
import datetime
from pynwb import TimeSeries, NWBFile

nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now(), session_description='bar')
nwbfile.add_trial(start_time=5., stop_time=10.)
nwbfile.add_trial(start_time=15., stop_time=20.)
ts = TimeSeries(name='a', data=np.arange(1000), timestamps=np.arange(1000), unit='m')
nwbfile.add_acquisition(ts)
numpy.testing.assert_equal(ts.align_by_trials(), [[6, 7, 8, 9, 10], [16, 17, 18, 19, 20]])
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
