### PR TITLE
fix nwbfile.analysis access

### DIFF
--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -239,6 +239,8 @@ class NWBFile(MultiContainerInterface):
             {'name': 'lab', 'type': str, 'doc': 'lab where experiment was performed', 'default': None},
             {'name': 'acquisition', 'type': (list, tuple),
              'doc': 'Raw TimeSeries objects belonging to this NWBFile', 'default': None},
+            {'name': 'analysis', 'type': (list, tuple),
+             'doc': 'result of analysis', 'default': None},
             {'name': 'stimulus', 'type': (list, tuple),
              'doc': 'Stimulus TimeSeries objects belonging to this NWBFile', 'default': None},
             {'name': 'stimulus_template', 'type': (list, tuple),
@@ -298,6 +300,7 @@ class NWBFile(MultiContainerInterface):
         self.__file_create_date = list(map(_add_missing_timezone, self.__file_create_date))
 
         self.acquisition = getargs('acquisition', kwargs)
+        self.analysis = getargs('analysis', kwargs)
         self.stimulus = getargs('stimulus', kwargs)
         self.stimulus_template = getargs('stimulus_template', kwargs)
         self.keywords = getargs('keywords', kwargs)

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -11,6 +11,7 @@ class NWBFileMap(ObjectMapper):
         super(NWBFileMap, self).__init__(spec)
         raw_ts_spec = self.spec.get_group('acquisition').get_neurodata_type('NWBDataInterface')
         self.map_spec('acquisition', raw_ts_spec)
+        self.map_spec('analysis', self.spec.get_group('analysis').get_neurodata_type('NWBContainer'))
 
         stimulus_spec = self.spec.get_group('stimulus')
         self.unmap(stimulus_spec)

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -133,6 +133,9 @@ class TestNWBFileIO(base.TestMapNWBContainer):
         self.ts = TimeSeries('test_timeseries', list(range(100, 200, 10)),
                              'SIunit', timestamps=list(range(10)), resolution=0.1)
         container.add_acquisition(self.ts)
+        self.ts2 = TimeSeries('test_timeseries2', list(range(200, 300, 10)),
+                              'SIunit', timestamps=list(range(10)), resolution=0.1)
+        container.add_analysis(self.ts2)
         self.mod = container.create_processing_module('test_module',
                                                       'a test module')
         self.clustering = Clustering("A fake Clustering interface", [0, 1, 2, 0, 1, 2], [100., 101., 102.],
@@ -164,6 +167,7 @@ class TestNWBFileIO(base.TestMapNWBContainer):
         self.assertIsInstance(container, NWBFile)
         raw_ts = container.acquisition
         self.assertEqual(len(raw_ts), 1)
+        self.assertEqual(len(container.analysis), 1)
         for v in raw_ts.values():
             self.assertIsInstance(v, TimeSeries)
         hdf5io.close()

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -139,6 +139,11 @@ class NWBFileTest(unittest.TestCase):
                                                       'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
         self.assertEqual(len(self.nwbfile.stimulus_template), 1)
 
+    def test_add_analysis(self):
+        self.nwbfile.add_analysis(TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
+                                             'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))
+        self.assertEqual(len(self.nwbfile.analysis), 1)
+
     def test_add_acquisition_check_dups(self):
         self.nwbfile.add_acquisition(TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                                                 'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))


### PR DESCRIPTION
## Motivation

fix #845 

## How to test the behavior?
```python
from pynwb import NWBFile, NWBHDF5IO, TimeSeries
from pynwb.behavior import BehavioralTimeSeries
import numpy as np
import datetime

filename = "./debug.nwb"

nwbfile_out = NWBFile(
    session_description='test foraging2',
    identifier='behavior_session_uuid',
    session_start_time=datetime.datetime.now(),
    file_create_date=datetime.datetime.now(),
)

ts1 = TimeSeries(
    name='1',
    data=np.random.rand(5),
    timestamps=np.random.rand(5), 
    unit='s'
)

ts2 = TimeSeries(
    name='2',
    data=np.random.rand(5),
    timestamps=np.random.rand(5), 
    unit='s'
)

running_bts = BehavioralTimeSeries(name='running')
running_bts.add_timeseries(ts1)
nwbfile_out.add_analysis(running_bts)


nwbfile_out.add_acquisition(ts2)

with NWBHDF5IO(filename, mode='w') as io:
    io.write(nwbfile_out)

nwbfile_in = NWBHDF5IO(filename, mode='r').read()
assert len(nwbfile_in.acquisition) == 1 # WORKS
assert len(nwbfile_in.analysis) == 1 # FIXED
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
