### PR TITLE
added mising comman in source of extensions.rst

### DIFF
--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -170,14 +170,14 @@ Create a new namespace with extensions
 
     # create extensions
     ext1 = NWBGroupSpec('A custom SpikeEventSeries interface',
-                        attributes=[...]
+                        attributes=[...],
                         datasets=[...],
                         groups=[...],
                         neurodata_type_inc='SpikeEventSeries',
                         neurodata_type_def='MyExtendedSpikeEventSeries')
 
     ext2 = NWBGroupSpec('A custom EventDetection interface',
-                        attributes=[...]
+                        attributes=[...],
                         datasets=[...],
                         groups=[...],
                         neurodata_type_inc='EventDetection',


### PR DESCRIPTION
## Motivation

Syntax error in extensions docs. There were some missing commas in the source for saving a namespace. 

## Checklist

- [X ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
