### PR TITLE
pin allensdk

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,5 +3,5 @@ matplotlib
 pillow
 sphinx_rtd_theme
 sphinx-gallery
-allensdk
+allensdk==0.16.0
 -r requirements.txt


### PR DESCRIPTION
## Motivation

pip is not able to install the current version of the allensdk. Because of this, documentation on Read the Docs has not been building for a month.

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
