### PR TITLE
Add isinstance check in to_dataframe for h5py Dataset

### DIFF
--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1,4 +1,4 @@
-from h5py import RegionReference
+from h5py import RegionReference, Dataset
 import numpy as np
 import pandas as pd
 
@@ -1254,7 +1254,7 @@ class DynamicTable(NWBDataInterface):
         data = {}
         for name in self.colnames:
             col = self.__df_cols[self.__colids[name]]
-            if isinstance(col.data, np.ndarray) and col.data.ndim > 1:
+            if isinstance(col.data, (Dataset, np.ndarray)) and col.data.ndim > 1:
                 data[name] = [x for x in col[:]]
             else:
                 data[name] = col[:]

--- a/tests/integration/ui_write/test_core.py
+++ b/tests/integration/ui_write/test_core.py
@@ -47,18 +47,21 @@ class TestFromDataframe(base.TestMapRoundTrip):
 
     def setUpContainer(self):
         # this will get ignored
-        return DynamicTable('units', 'a placeholder table')
+        return DynamicTable.from_dataframe(pd.DataFrame({
+                'a': [[1, 2, 3],
+                      [1, 2, 3],
+                      [1, 2, 3]],
+                'b': ['4', '5', '6']
+            }), 'test_table')
 
     def addContainer(self, nwbfile):
-        nwbfile.units = DynamicTable.from_dataframe(pd.DataFrame({
-            'a': [1, 2, 3],
-            'b': ['4', '5', '6']
-        }), 'units')
-        # reset the thing
-        self.container = nwbfile.units
+        test_mod = nwbfile.create_processing_module('test', 'desc')
+        test_mod.add_data_interface(self.container)
 
     def getContainer(self, nwbfile):
-        return nwbfile.units
+        dyn_tab = nwbfile.modules['test'].data_interfaces['test_table']
+        dyn_tab.to_dataframe()  # also test 2D column round-trip
+        return dyn_tab
 
 
 class TestElectrodes(base.TestMapRoundTrip):


### PR DESCRIPTION
## Motivation

to_dataframe on a DynamicTable had a corner case when reading from a file, as opposed to an im-memory object.  Isinstance is used to detect if a column consists of data with each row being a numpy array, and removing the outer dimension to build the column.  This PR catches the corner case.

test_pandas_roundtrip should be enhanced with a fixture that uses a file on tempdir, but Ill leave that to be organized with other test fixtures in the test directory

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
