### PR TITLE
epoch start and stop time precision in spec: float to double

### DIFF
--- a/src/pynwb/data/nwb.epoch.yaml
+++ b/src/pynwb/data/nwb.epoch.yaml
@@ -11,7 +11,7 @@ groups:
   datasets:
   - neurodata_type_inc: VectorData
     name: start_time
-    dtype: float
+    dtype: double
     doc: Start time of epoch, in seconds
     attributes:
     - name: description
@@ -20,7 +20,7 @@ groups:
       value: start time of the epoch, in seconds
   - neurodata_type_inc: VectorData
     name: stop_time
-    dtype: float
+    dtype: double
     doc: Stop time of epoch, in seconds
     attributes:
     - name: description


### PR DESCRIPTION
## Motivation

Epoch start and stop time precision is defined in docval as float, which is double precision in python (see https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Include/floatobject.h#L5).  This commit modifies the spec to conform.  Note: current behavior is that user-provided precision will be silently coerced to the precision defined in the spec, presumably by hdmf.



- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
