### PR TITLE
import Device from device.py, not ecephys.py

### DIFF
--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -9,8 +9,9 @@ from hdmf import Container
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, ProcessingModule
+from .device import Device
 from .epoch import TimeIntervals
-from .ecephys import ElectrodeGroup, Device
+from .ecephys import ElectrodeGroup
 from .icephys import IntracellularElectrode, SweepTable, PatchClampSeries
 from .ophys import ImagingPlane
 from .ogen import OptogeneticStimulusSite

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -5,7 +5,7 @@ from hdmf.utils import docval, popargs, fmt_docval_args
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, _default_resolution, _default_conversion
 from .core import NWBContainer
-from .ecephys import Device
+from .device import Device
 
 
 @register_class('OptogeneticStimulusSite', CORE_NAMESPACE)


### PR DESCRIPTION
this technically was not broken because ecephys.py imports Device properly from device.py, so any file that imports Device from ecephys.py still gets the Device class. but this fixes the inconsistency

## Motivation

This pull request is more for me to better understand and practice how to make changes to the repo, test them, and do pull requests. If this was a bug of substance, I would also open an issue and note the issue # here, but I didn't think this one was worth it. Let me know if I should do anything differently.
