### PR TITLE
modular timestamps storage

### DIFF
--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -59,9 +59,15 @@ class TimeSeriesMap(NWBContainerMapper):
         if tstamps_builder is None:
             return None
         if isinstance(tstamps_builder, LinkBuilder):
-            if tstamps_builder.builder.parent is None:
-                return
-            target = tstamps_builder.builder
-            return manager.construct(target.parent)
+            # if the parent of our target is available, return the parent object
+            # Otherwise, return the dataset in the target builder
+            #
+            # NOTE: it is not available when data is externally linked
+            # and we haven't explicitly read that file
+            if tstamps_builder.builder.parent is not None:
+                target = tstamps_builder.builder
+                return manager.construct(target.parent)
+            else:
+                return tstamps_builder.builder.data
         else:
             return tstamps_builder.data

--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -59,6 +59,8 @@ class TimeSeriesMap(NWBContainerMapper):
         if tstamps_builder is None:
             return None
         if isinstance(tstamps_builder, LinkBuilder):
+            if tstamps_builder.builder.parent is None:
+                return
             target = tstamps_builder.builder
             return manager.construct(target.parent)
         else:

--- a/tests/integration/ui_write/test_modular_storage.py
+++ b/tests/integration/ui_write/test_modular_storage.py
@@ -1,0 +1,85 @@
+import os
+from datetime import datetime
+from dateutil.tz import tzutc
+
+import numpy as np
+
+from pynwb.base import TimeSeries
+from pynwb import get_manager, NWBFile
+from hdmf.backends.hdf5 import HDF5IO
+from hdmf.backends.hdf5.h5_utils import H5DataIO
+
+from . import base
+
+
+class TestTimeSeriesModular(base.TestMapRoundTrip):
+
+    _required_tests = ('test_roundtrip',)
+
+    def remove_file(self, path):
+        if os.path.exists(path) and os.getenv("CLEAN_NWB", '1') not in ('0', 'false', 'FALSE', 'False'):
+            os.remove(path)
+
+    def setUp(self):
+        self.__manager = get_manager()
+        self.start_time = datetime(1971, 1, 1, 12, tzinfo=tzutc())
+
+        self.data = np.arange(2000).reshape((2, 1000))
+        self.timestamps = np.linspace(0, 1, 1000)
+
+        self.container = TimeSeries(
+            name='data_ts',
+            unit='V',
+            data=self.data,
+            timestamps=self.timestamps
+        )
+
+        self.data_filename = 'test_time_series_modular_data.nwb'
+        self.link_filename = 'test_time_series_modular_link.nwb'
+
+    def tearDown(self):
+        self.read_container.data.file.close()
+        self.read_container.timestamps.file.close()
+
+        self.remove_file(self.data_filename)
+        self.remove_file(self.link_filename)
+
+    def roundtripContainer(self):
+        data_file = NWBFile(
+            session_description='a test file',
+            identifier='data_file',
+            session_start_time=self.start_time
+        )
+        data_file.add_acquisition(self.container)
+
+        with HDF5IO(self.data_filename, 'w', manager=get_manager()) as self.data_write_io:
+            self.data_write_io.write(data_file)
+
+        with HDF5IO(self.data_filename, 'r', manager=get_manager()) as self.data_read_io:
+            data_file_obt = self.data_read_io.read()
+
+            with HDF5IO(self.link_filename, 'w', manager=get_manager()) as link_write_io:
+                link_file = NWBFile(
+                    session_description='a test file',
+                    identifier='link_file',
+                    session_start_time=self.start_time
+                )
+                link_file.add_acquisition(TimeSeries(
+                    name='test_mod_ts',
+                    unit='V',
+                    data=data_file_obt.get_acquisition('data_ts'),
+                    timestamps=H5DataIO(
+                        data=data_file_obt.get_acquisition('data_ts').timestamps,
+                        link_data=True
+                    )
+                ))
+                link_write_io.write(link_file)
+
+        with HDF5IO(self.link_filename, 'r', manager=get_manager()) as self.link_file_reader:
+            return self.getContainer(self.link_file_reader.read())
+
+    def getContainer(self, nwbfile):
+        return nwbfile.get_acquisition('test_mod_ts')
+
+    def addContainer(self, nwbfile):
+        pass


### PR DESCRIPTION
Fix #901 

Implements a fix for modular (cross-file) storage of timeseries timestamps and a roundtrip test of this functionality.