### PR TITLE
Change roundtrip test and fix docval for list of strings that broke

### DIFF
--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -1,4 +1,3 @@
-import numpy as np
 from collections import Iterable
 
 from hdmf.utils import docval, getargs, popargs, call_docval_func

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -350,7 +350,7 @@ class FeatureExtraction(NWBDataInterface):
 
     @docval({'name': 'electrodes', 'type': DynamicTableRegion,
              'doc': 'the table region corresponding to the electrodes from which this series was recorded'},
-            {'name': 'description', 'type': (list, tuple, np.ndarray, DataChunkIterator),
+            {'name': 'description', 'type': ('array_data', 'data'),
              'doc': 'A description for each feature extracted', 'shape': (None, )},
             {'name': 'times', 'type': ('array_data', 'data'), 'shape': (None, ),
              'doc': 'The times of events that features correspond to'},

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -89,6 +89,8 @@ class TestMapNWBContainer(unittest.TestCase):
             with self.subTest(nwbfield=nwbfield, container_type=type1.__name__):
                 f1 = getattr(container1, nwbfield)
                 f2 = getattr(container2, nwbfield)
+                if isinstance(f1, h5py.Dataset):
+                    f1 = f1[()]
                 if isinstance(f1, (tuple, list, np.ndarray)):
                     if len(f1) > 0:
                         if isinstance(f1[0], NWBContainer):
@@ -124,7 +126,7 @@ class TestMapNWBContainer(unittest.TestCase):
                     elif isinstance(f2, NWBData):
                         self.assertTrue(np.array_equal(f1.data, f2))
                 else:
-                    if isinstance(f1, (float, np.float32, np.float16, h5py.Dataset)):
+                    if isinstance(f1, (float, np.float32, np.float16)):
                         npt.assert_almost_equal(f1, f2)
                     else:
                         self.assertEqual(f1, f2)


### PR DESCRIPTION
Addresses tests that broke after [change in hdmf](https://github.com/hdmf-dev/hdmf/commit/e0d863d0e31ea09f3b465ea2014d8e4d96d2e8fc)  regarding loading of lists of 
strings
