### PR TITLE
Clean up tests to remove errors and warnings

### DIFF
--- a/tests/integration/ui_write/__init__.py
+++ b/tests/integration/ui_write/__init__.py
@@ -1,6 +1,0 @@
-# flake8: noqa: F401
-from . import base
-
-from . import test_base
-from . import test_ecephys
-from . import test_nwbfile

--- a/tests/integration/ui_write/test_base.py
+++ b/tests/integration/ui_write/test_base.py
@@ -1,5 +1,6 @@
 import numpy as np
 import datetime as datetime
+from dateutil.tz import tzlocal
 
 from hdmf.build import GroupBuilder, DatasetBuilder
 
@@ -41,7 +42,9 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
         path = 'test_timestamps_linking.nwb'
         tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000), unit='m')
         tsb = TimeSeries(name='b', data=np.linspace(0, 1, 1000), timestamps=tsa, unit='m')
-        nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now().astimezone(), session_description='bar')
+        nwbfile = NWBFile(identifier='foo', 
+                          session_start_time=datetime.datetime.now().astimezone(tz=tzlocal()), 
+                          session_description='bar')
         nwbfile.add_acquisition(tsa)
         nwbfile.add_acquisition(tsb)
         io = NWBHDF5IO(path, 'w')

--- a/tests/integration/ui_write/test_base.py
+++ b/tests/integration/ui_write/test_base.py
@@ -41,7 +41,7 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
         path = 'test_timestamps_linking.nwb'
         tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000), unit='m')
         tsb = TimeSeries(name='b', data=np.linspace(0, 1, 1000), timestamps=tsa, unit='m')
-        nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now(), session_description='bar')
+        nwbfile = NWBFile(identifier='foo', session_start_time=datetime.datetime.now().astimezone(), session_description='bar')
         nwbfile.add_acquisition(tsa)
         nwbfile.add_acquisition(tsb)
         io = NWBHDF5IO(path, 'w')

--- a/tests/integration/ui_write/test_base.py
+++ b/tests/integration/ui_write/test_base.py
@@ -42,8 +42,8 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
         path = 'test_timestamps_linking.nwb'
         tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000), unit='m')
         tsb = TimeSeries(name='b', data=np.linspace(0, 1, 1000), timestamps=tsa, unit='m')
-        nwbfile = NWBFile(identifier='foo', 
-                          session_start_time=datetime(2017, 5, 1, 12, 0, 0, tzinfo=tzlocal()), 
+        nwbfile = NWBFile(identifier='foo',
+                          session_start_time=datetime(2017, 5, 1, 12, 0, 0, tzinfo=tzlocal()),
                           session_description='bar')
         nwbfile.add_acquisition(tsa)
         nwbfile.add_acquisition(tsb)

--- a/tests/integration/ui_write/test_base.py
+++ b/tests/integration/ui_write/test_base.py
@@ -1,5 +1,5 @@
 import numpy as np
-import datetime as datetime
+from datetime import datetime
 from dateutil.tz import tzlocal
 
 from hdmf.build import GroupBuilder, DatasetBuilder
@@ -43,7 +43,7 @@ class TestTimeSeriesIO(base.TestDataInterfaceIO):
         tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000), unit='m')
         tsb = TimeSeries(name='b', data=np.linspace(0, 1, 1000), timestamps=tsa, unit='m')
         nwbfile = NWBFile(identifier='foo', 
-                          session_start_time=datetime.datetime.now().astimezone(tz=tzlocal()), 
+                          session_start_time=datetime(2017, 5, 1, 12, 0, 0, tzinfo=tzlocal()), 
                           session_description='bar')
         nwbfile.add_acquisition(tsa)
         nwbfile.add_acquisition(tsb)

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -140,7 +140,7 @@ class TestNWBFileIO(base.TestMapNWBContainer):
                                                       'a test module')
         self.clustering = Clustering("A fake Clustering interface", [0, 1, 2, 0, 1, 2], [100., 101., 102.],
                                      list(range(10, 61, 10)))
-        self.mod.add_container(self.clustering)
+        self.mod.add_data_interface(self.clustering)
         return container
 
     def test_children(self):

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -1,3 +1,2 @@
 # flake8: noqa: F401
-from . import form_tests
 from . import pynwb_tests

--- a/tests/unit/pynwb_tests/test_base.py
+++ b/tests/unit/pynwb_tests/test_base.py
@@ -15,14 +15,14 @@ class TestProcessingModule(unittest.TestCase):
         self.assertEqual(self.pm.name, 'test_procmod')
         self.assertEqual(self.pm.description, 'a fake processing module')
 
-    def test_add_container(self):
+    def test_add_data_interface(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
         self.pm.add_data_interface(ts)
         self.assertIn(ts.name, self.pm.containers)
         self.assertIs(ts, self.pm.containers[ts.name])
 
-    def test_get_container(self):
+    def test_get_data_interface(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
         self.pm.add_data_interface(ts)

--- a/tests/unit/pynwb_tests/test_base.py
+++ b/tests/unit/pynwb_tests/test_base.py
@@ -18,21 +18,21 @@ class TestProcessingModule(unittest.TestCase):
     def test_add_container(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
-        self.pm.add_container(ts)
+        self.pm.add_data_interface(ts)
         self.assertIn(ts.name, self.pm.containers)
         self.assertIs(ts, self.pm.containers[ts.name])
 
     def test_get_container(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
-        self.pm.add_container(ts)
-        tmp = self.pm.get_container('test_ts')
+        self.pm.add_data_interface(ts)
+        tmp = self.pm.get_data_interface('test_ts')
         self.assertIs(tmp, ts)
 
     def test_getitem(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
-        self.pm.add_container(ts)
+        self.pm.add_data_interface(ts)
         tmp = self.pm['test_ts']
         self.assertIs(tmp, ts)
 

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -158,7 +158,7 @@ class TestDynamicTable(unittest.TestCase):
 
         module_behavior = nwbfile.create_processing_module('a', 'b')
 
-        module_behavior.add_container(table)
+        module_behavior.add_data_interface(table)
 
     def test_pandas_roundtrip(self):
         df = pd.DataFrame({

--- a/tests/unit/pynwb_tests/test_extension.py
+++ b/tests/unit/pynwb_tests/test_extension.py
@@ -150,8 +150,6 @@ class TestExtension(unittest.TestCase):
 
         MyTestMetaData = get_class('MyTestMetaData', self.prefix)
 
-        nwbfile = NWBFile("a file with header data", "NB123A", datetime(2017, 5, 1, 12, 0, 0, tzinfo=tzlocal()))
-
         with self.assertRaisesRegexp(TypeError, r"unrecognized argument: 'name'"):
             meta = MyTestMetaData(name='test_name', test_attr=5.)
 

--- a/tests/unit/pynwb_tests/test_extension.py
+++ b/tests/unit/pynwb_tests/test_extension.py
@@ -132,30 +132,6 @@ class TestExtension(unittest.TestCase):
 
         nwbfile.add_lab_meta_data(MyTestMetaData(name='test_name', test_attr=5.))
 
-    def test_fixed_name(self):
-        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', self.prefix)
-        fixed_name = 'a fixed name for all instances'
-        test_meta_ext = NWBGroupSpec(
-            neurodata_type_def='MyTestMetaData',
-            neurodata_type_inc='LabMetaData',
-            doc='my test meta data',
-            name=fixed_name,
-            attributes=[
-                NWBAttributeSpec(name='test_attr', dtype='float', doc='test_dtype')])
-        ns_builder.add_spec(self.ext_source, test_meta_ext)
-        ns_builder.export(self.ns_path, outdir=self.tempdir)
-        ns_abs_path = os.path.join(self.tempdir, self.ns_path)
-
-        load_namespaces(ns_abs_path)
-
-        MyTestMetaData = get_class('MyTestMetaData', self.prefix)
-
-        with self.assertRaisesRegexp(TypeError, r"unrecognized argument: 'name'"):
-            meta = MyTestMetaData(name='test_name', test_attr=5.)
-
-        meta = MyTestMetaData(test_attr=5.)
-        self.assertEqual(meta.name, fixed_name)
-
 
 class TestCatchDupNS(unittest.TestCase):
 

--- a/tests/unit/pynwb_tests/test_extension.py
+++ b/tests/unit/pynwb_tests/test_extension.py
@@ -132,6 +132,32 @@ class TestExtension(unittest.TestCase):
 
         nwbfile.add_lab_meta_data(MyTestMetaData(name='test_name', test_attr=5.))
 
+    def test_fixed_name(self):
+        ns_builder = NWBNamespaceBuilder('Extension for use in my Lab', self.prefix)
+        fixed_name = 'a fixed name for all instances'
+        test_meta_ext = NWBGroupSpec(
+            neurodata_type_def='MyTestMetaData',
+            neurodata_type_inc='LabMetaData',
+            doc='my test meta data',
+            name=fixed_name,
+            attributes=[
+                NWBAttributeSpec(name='test_attr', dtype='float', doc='test_dtype')])
+        ns_builder.add_spec(self.ext_source, test_meta_ext)
+        ns_builder.export(self.ns_path, outdir=self.tempdir)
+        ns_abs_path = os.path.join(self.tempdir, self.ns_path)
+
+        load_namespaces(ns_abs_path)
+
+        MyTestMetaData = get_class('MyTestMetaData', self.prefix)
+
+        nwbfile = NWBFile("a file with header data", "NB123A", datetime(2017, 5, 1, 12, 0, 0, tzinfo=tzlocal()))
+
+        with self.assertRaisesRegexp(TypeError, r"unrecognized argument: 'name'"):
+            meta = MyTestMetaData(name='test_name', test_attr=5.)
+
+        meta = MyTestMetaData(test_attr=5.)
+        self.assertEqual(meta.name, fixed_name)
+
 
 class TestCatchDupNS(unittest.TestCase):
 

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -186,7 +186,6 @@ class NWBFileTest(unittest.TestCase):
                       group_name='tetrode1')
         self.nwbfile.set_electrode_table(table)
 
-        self.assertIs(self.nwbfile.ec_electrodes, self.nwbfile.electrodes)
         self.assertIs(self.nwbfile.electrodes, table)
         self.assertIs(table.parent, self.nwbfile)
 
@@ -353,8 +352,10 @@ class TestCacheSpec(unittest.TestCase):
                           lab='Chang Lab')
         with NWBHDF5IO(self.path, 'w') as io:
             io.write(nwbfile, cache_spec=True)
-        reader = NWBHDF5IO(self.path, 'r', load_namespaces=True)
+        with self.assertWarnsRegex(UserWarning, r"ignoring namespace '\S+' because it already exists"):
+            reader = NWBHDF5IO(self.path, 'r', load_namespaces=True)
         nwbfile = reader.read()
+        reader.close()
 
 
 class TestTimestampsRefDefault(unittest.TestCase):

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -90,7 +90,7 @@ class CorrectedImageStackConstructor(unittest.TestCase):
         tstamps = np.arange(1.0, 100.0, 0.1, dtype=np.float)
         ts = TimeSeries("test_ts", list(range(len(tstamps))), 'unit', timestamps=tstamps)
         cis = CorrectedImageStack(is1, is2, ts)
-        ProcessingModule('name', 'description').add_container(cis)
+        ProcessingModule('name', 'description').add_data_interface(cis)
         self.assertEqual(cis.corrected, is1)
         self.assertEqual(cis.original, is2)
         self.assertEqual(cis.xy_translation, ts)


### PR DESCRIPTION
Just cleaning up while I modify other tests. A few deprecated warnings still remain.