### PR TITLE
Add `pip check` to tox to catch dependency conflicts 

### DIFF
--- a/docs/source/update_requirements.rst
+++ b/docs/source/update_requirements.rst
@@ -27,6 +27,7 @@ the following script:
 
    cd pynwb
    pip install .
+   pip check # check for package conflicts
    pip freeze > requirements.txt
 
    deactivate
@@ -54,6 +55,9 @@ the following scripts:
    # If relevant, you could pip install new requirements now
    # pip install -U <name-of-new-requirement>
 
+   # Check for any conflicts in installed packages
+   pip check
+   
    # Update list of pinned requirements
    pip freeze > $target_requirements
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     -rrequirements.txt
 
 commands =
+    pip check # check for conflicting packages
     python test.py -v
 
 # Env to create coverage report locally


### PR DESCRIPTION
Per discussion at #921.

It is currently possible for our pinned requirements list to specify a set of packages that are in conflict with each other. (This is because pip install does not fail in this case https://github.com/pypa/pip/issues/775 https://github.com/pypa/pip/issues/988 )

Indeed, right now we have such a conflict (until #923 is merged). So adding this test should cause CI to fail if it is done before 923.

The `pip check` command checks for this condition, and fails if there are conflicts. This PR adds `pip check` to the tox testenv, and also recommends running it when initially writing the requirements files.

I am not sure if I put the command in the right place within tox, but I did test that it detects the conflict.