### PR TITLE
fix #941: clean up API

### DIFF
--- a/docs/gallery/domain/brain_observatory.py
+++ b/docs/gallery/domain/brain_observatory.py
@@ -156,7 +156,7 @@ ophys_module = nwbfile.create_processing_module(
 image_segmentation_interface = ImageSegmentation(
     name='image_segmentation')
 
-ophys_module.add_data_interface(image_segmentation_interface)
+ophys_module.add(image_segmentation_interface)
 
 plane_segmentation = image_segmentation_interface.create_plane_segmentation(
     name='plane_segmentation',
@@ -173,7 +173,7 @@ for cell_specimen_id in cell_specimen_ids:
 # each ROI.
 
 dff_interface = DfOverF(name='dff_interface')
-ophys_module.add_data_interface(dff_interface)
+ophys_module.add(dff_interface)
 
 rt_region = plane_segmentation.create_roi_table_region(
     description='segmented cells with cell_specimen_ids',

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -87,7 +87,7 @@ nwbfile.add_acquisition(image_series)
 
 mod = nwbfile.create_processing_module('ophys', 'contains optical physiology processed data')
 img_seg = ImageSegmentation()
-mod.add_data_interface(img_seg)
+mod.add(img_seg)
 ps = img_seg.create_plane_segmentation('output from segmenting my favorite imaging plane',
                                        imaging_plane, 'my_planeseg', image_series)
 
@@ -128,7 +128,7 @@ ps.add_roi(pixel_mask=pix_mask2, image_mask=img_mask2)
 
 
 fl = Fluorescence()
-mod.add_data_interface(fl)
+mod.add(fl)
 
 
 ####################
@@ -181,11 +181,11 @@ nwbfile = io.read()
 #
 # After you read the NWB file, you can access individual components of your data file.
 # To get the :py:class:`~pynwb.base.ProcessingModule` back, you can index into the
-# :py:func:`~pynwb.file.NWBFile.modules` attribute with the name of the
+# :py:func:`~pynwb.file.NWBFile.processing` attribute with the name of the
 # :py:class:`~pynwb.base.ProcessingModule`.
 
 
-mod = nwbfile.modules['ophys']
+mod = nwbfile.processing['ophys']
 
 ####################
 # Now you can retrieve the :py:class:`~pynwb.ophys.ImageSegmentation` object by indexing into the

--- a/docs/gallery/general/file.py
+++ b/docs/gallery/general/file.py
@@ -273,7 +273,7 @@ nwbfile.add_processing_module(ecephys_module)
 # These are: 'behavior', 'ecephys', 'icephys', 'ophys', 'ogen', 'retinotopy', and 'misc'. You may also create
 # a processing module with a custom name. Once these processing modules are added, access them with
 
-nwbfile.modules
+nwbfile.processing
 
 ####################
 # which returns a `dict`:
@@ -291,7 +291,7 @@ nwbfile.modules
 #
 # :py:class:`~pynwb.core.NWBDataInterface` objects can be added to the behavior :ref:`ProcessingModule <basic_procmod>`.
 
-nwbfile.modules['behavior'].add_data_interface(position)
+nwbfile.processing['behavior'].add(position)
 
 ####################
 # .. _basic_epochs:
@@ -419,7 +419,7 @@ with NWBHDF5IO('example_file_path.nwb', 'w') as io:
 
 io = NWBHDF5IO('example_file_path.nwb', mode='a')
 nwbfile = io.read()
-position = nwbfile.modules['behavior'].data_interfaces['Position']
+position = nwbfile.processings['behavior'].data_interfaces['Position']
 
 ####################
 # Next, add a new :py:class:`~pynwb.behavior.SpatialSeries`.

--- a/docs/gallery/general/file.py
+++ b/docs/gallery/general/file.py
@@ -419,7 +419,7 @@ with NWBHDF5IO('example_file_path.nwb', 'w') as io:
 
 io = NWBHDF5IO('example_file_path.nwb', mode='a')
 nwbfile = io.read()
-position = nwbfile.processings['behavior'].data_interfaces['Position']
+position = nwbfile.processing['behavior'].data_interfaces['Position']
 
 ####################
 # Next, add a new :py:class:`~pynwb.behavior.SpatialSeries`.

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -65,6 +65,19 @@ class ProcessingModule(MultiContainerInterface):
         warn(PendingDeprecationWarning('get_container will be replaced by get_data_interface'))
         return self.get(container_name)
 
+    @docval({'name': 'NWBDataInterface', 'type': NWBDataInterface, 'doc': 'the NWBDataInterface to add to this Module'})
+    def add_data_interface(self, **kwargs):
+        NWBDataInterface = getargs('NWBDataInterface', kwargs)
+        warn(PendingDeprecationWarning('add_data_interface will be replaced by add'))
+        self.add(NWBDataInterface)
+
+    @docval({'name': 'data_interface_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})
+    def get_data_interface(self, **kwargs):
+        data_interface_name = getargs('data_interface_name', kwargs)
+        warn(PendingDeprecationWarning('get_data_interface will be replaced by get'))
+        return self.get(data_interface_name)
+
+
 
 @register_class('TimeSeries', CORE_NAMESPACE)
 class TimeSeries(NWBDataInterface):

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -78,7 +78,6 @@ class ProcessingModule(MultiContainerInterface):
         return self.get(data_interface_name)
 
 
-
 @register_class('TimeSeries', CORE_NAMESPACE)
 class TimeSeries(NWBDataInterface):
     """A generic base class for time series data"""

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -24,9 +24,9 @@ class ProcessingModule(MultiContainerInterface):
 
     __clsconf__ = {
             'attr': 'data_interfaces',
-            'add': 'add_data_interface',
+            'add': 'add',
             'type': NWBDataInterface,
-            'get': 'get_data_interface'
+            'get': 'get'
     }
 
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this processing module'},
@@ -45,7 +45,7 @@ class ProcessingModule(MultiContainerInterface):
         return self.data_interfaces
 
     def __getitem__(self, arg):
-        return self.get_data_interface(arg)
+        return self.get(arg)
 
     @docval({'name': 'container', 'type': NWBDataInterface, 'doc': 'the NWBDataInterface to add to this Module'})
     def add_container(self, **kwargs):
@@ -54,7 +54,7 @@ class ProcessingModule(MultiContainerInterface):
         '''
         container = getargs('container', kwargs)
         warn(PendingDeprecationWarning('add_container will be replaced by add_data_interface'))
-        self.add_data_interface(container)
+        self.add(container)
 
     @docval({'name': 'container_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})
     def get_container(self, **kwargs):
@@ -63,7 +63,7 @@ class ProcessingModule(MultiContainerInterface):
         '''
         container_name = getargs('container_name', kwargs)
         warn(PendingDeprecationWarning('get_container will be replaced by get_data_interface'))
-        return self.get_data_interface(container_name)
+        return self.get(container_name)
 
 
 @register_class('TimeSeries', CORE_NAMESPACE)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -53,7 +53,7 @@ class ProcessingModule(MultiContainerInterface):
         Add an NWBContainer to this ProcessingModule
         '''
         container = getargs('container', kwargs)
-        warn(PendingDeprecationWarning('add_container will be replaced by add_data_interface'))
+        warn(PendingDeprecationWarning('add_container will be replaced by add'))
         self.add(container)
 
     @docval({'name': 'container_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -374,6 +374,11 @@ class NWBFile(MultiContainerInterface):
         return ret
 
     @property
+    def modules(self):
+        warn("replaced by NWBFile.processing", DeprecationWarning)
+        return self.processing
+
+    @property
     def ec_electrode_groups(self):
         warn("replaced by NWBFile.electrode_groups", DeprecationWarning)
         return self.electrode_groups

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -109,7 +109,7 @@ class NWBFile(MultiContainerInterface):
             'get': 'get_stimulus_template'
         },
         {
-            'attr': 'modules',
+            'attr': 'processing',
             'add': 'add_processing_module',
             'type': ProcessingModule,
             'create': 'create_processing_module',
@@ -259,7 +259,7 @@ class NWBFile(MultiContainerInterface):
              'doc': 'any TimeIntervals tables storing time intervals', 'default': None},
             {'name': 'units', 'type': Units,
              'doc': 'A table containing unit metadata', 'default': None},
-            {'name': 'modules', 'type': (list, tuple),
+            {'name': 'processing', 'type': (list, tuple),
              'doc': 'ProcessingModule objects belonging to this NWBFile', 'default': None},
             {'name': 'lab_meta_data', 'type': (list, tuple), 'default': None,
              'doc': 'an extension that contains lab-specific meta-data'},
@@ -309,7 +309,7 @@ class NWBFile(MultiContainerInterface):
         self.stimulus_template = getargs('stimulus_template', kwargs)
         self.keywords = getargs('keywords', kwargs)
 
-        self.modules = getargs('modules', kwargs)
+        self.processing = getargs('processing', kwargs)
         epochs = getargs('epochs', kwargs)
         if epochs is not None:
             if epochs.name != 'epochs':

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -40,7 +40,7 @@ class NWBFileMap(ObjectMapper):
             general_spec.get_group('optophysiology').get_neurodata_type('ImagingPlane'))
 
         self.map_spec(
-            'modules',
+            'processing',
             self.spec.get_group('processing').get_neurodata_type('ProcessingModule'))
         # self.unmap(general_spec.get_dataset('stimulus'))
         self.map_spec('stimulus_notes', general_spec.get_dataset('stimulus'))

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -245,7 +245,7 @@ class TestAppend(unittest.TestCase):
                                                                                              tzinfo=tzutc()))
         proc_mod = nwb.create_processing_module(name='test_proc_mod', description='')
         proc_inter = LFP(name='test_proc_dset')
-        proc_mod.add_data_interface(proc_inter)
+        proc_mod.add(proc_inter)
         device = nwb.create_device(name='test_device')
         e_group = nwb.create_electrode_group(
             name='test_electrode_group',
@@ -268,7 +268,7 @@ class TestAppend(unittest.TestCase):
 
         with NWBHDF5IO(FILENAME, mode='a') as io:
             nwb = io.read()
-            elec = nwb.modules['test_proc_mod']['LFP'].electrical_series['test_device'].electrodes
+            elec = nwb.processing['test_proc_mod']['LFP'].electrical_series['test_device'].electrodes
             ts2 = ElectricalSeries(name='timeseries2', data=[4., 5., 6.], rate=1.0, electrodes=elec)
             nwb.add_acquisition(ts2)
             io.write(nwb)

--- a/tests/integration/ui_write/test_core.py
+++ b/tests/integration/ui_write/test_core.py
@@ -58,10 +58,10 @@ class TestFromDataframe(base.TestMapRoundTrip):
 
     def addContainer(self, nwbfile):
         test_mod = nwbfile.create_processing_module('test', 'desc')
-        test_mod.add_data_interface(self.container)
+        test_mod.add(self.container)
 
     def getContainer(self, nwbfile):
-        dyn_tab = nwbfile.modules['test'].data_interfaces['test_table']
+        dyn_tab = nwbfile.processing['test'].data_interfaces['test_table']
         dyn_tab.to_dataframe()  # also test 2D column round-trip
         return dyn_tab
 

--- a/tests/integration/ui_write/test_misc.py
+++ b/tests/integration/ui_write/test_misc.py
@@ -128,8 +128,8 @@ class TestSpectralAnalysis(base.TestDataInterfaceIO):
     def addContainer(self, nwbfile):
         nwbfile.add_acquisition(self.timeseries)
         prcs_mod = nwbfile.create_processing_module('test_mod', 'test_mod')
-        prcs_mod.add_data_interface(self.container)
+        prcs_mod.add(self.container)
 
     def getContainer(self, nwbfile):
 
-        return nwbfile.modules['test_mod']['LFPSpectralAnalysis']
+        return nwbfile.processing['test_mod']['LFPSpectralAnalysis']

--- a/tests/integration/ui_write/test_nwbfile.py
+++ b/tests/integration/ui_write/test_nwbfile.py
@@ -140,7 +140,7 @@ class TestNWBFileIO(base.TestMapNWBContainer):
                                                       'a test module')
         self.clustering = Clustering("A fake Clustering interface", [0, 1, 2, 0, 1, 2], [100., 101., 102.],
                                      list(range(10, 61, 10)))
-        self.mod.add_data_interface(self.clustering)
+        self.mod.add(self.clustering)
         return container
 
     def test_children(self):

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -313,11 +313,11 @@ class TestPlaneSegmentation(base.TestMapRoundTrip):
         img_seg.add_plane_segmentation(self.container)
         mod = nwbfile.create_processing_module('plane_seg_test_module',
                                                'a plain module for testing')
-        mod.add_data_interface(img_seg)
+        mod.add(img_seg)
 
     def getContainer(self, nwbfile):
         mod = nwbfile.get_processing_module('plane_seg_test_module')
-        img_seg = mod.get_data_interface('ImageSegmentation')
+        img_seg = mod.get('ImageSegmentation')
         return img_seg.get_plane_segmentation('test_plane_seg_name')
 
 
@@ -413,5 +413,5 @@ class TestRoiResponseSeriesIO(base.TestDataInterfaceIO):
         img_seg.add_plane_segmentation(self.plane_segmentation)
         mod = nwbfile.create_processing_module('plane_seg_test_module',
                                                'a plain module for testing')
-        mod.add_data_interface(img_seg)
+        mod.add(img_seg)
         super(TestRoiResponseSeriesIO, self).addContainer(nwbfile)

--- a/tests/unit/pynwb_tests/test_base.py
+++ b/tests/unit/pynwb_tests/test_base.py
@@ -29,18 +29,33 @@ class TestProcessingModule(unittest.TestCase):
         self.assertIn(ts.name, self.pm.containers)
         self.assertIs(ts, self.pm.containers[ts.name])
 
+    def test_deprecated_add_container(self):
+        ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
+                        'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        self.pm.add_container(ts)
+        self.assertIn(ts.name, self.pm.containers)
+        self.assertIs(ts, self.pm.containers[ts.name])
+
     def test_get_data_interface(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
         self.pm.add(ts)
         tmp = self.pm.get('test_ts')
         self.assertIs(tmp, ts)
+        self.assertIs(self.pm['test_ts'], self.pm.get('test_ts'))
 
     def test_deprecated_get_data_interface(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
         self.pm.add(ts)
         tmp = self.pm.get_data_interface('test_ts')
+        self.assertIs(tmp, ts)
+
+    def test_deprecated_get_container(self):
+        ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
+                        'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        self.pm.add(ts)
+        tmp = self.pm.get_container('test_ts')
         self.assertIs(tmp, ts)
 
     def test_getitem(self):

--- a/tests/unit/pynwb_tests/test_base.py
+++ b/tests/unit/pynwb_tests/test_base.py
@@ -18,21 +18,21 @@ class TestProcessingModule(unittest.TestCase):
     def test_add_data_interface(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
-        self.pm.add_data_interface(ts)
+        self.pm.add(ts)
         self.assertIn(ts.name, self.pm.containers)
         self.assertIs(ts, self.pm.containers[ts.name])
 
     def test_get_data_interface(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
-        self.pm.add_data_interface(ts)
-        tmp = self.pm.get_data_interface('test_ts')
+        self.pm.add(ts)
+        tmp = self.pm.get('test_ts')
         self.assertIs(tmp, ts)
 
     def test_getitem(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
-        self.pm.add_data_interface(ts)
+        self.pm.add(ts)
         tmp = self.pm['test_ts']
         self.assertIs(tmp, ts)
 

--- a/tests/unit/pynwb_tests/test_base.py
+++ b/tests/unit/pynwb_tests/test_base.py
@@ -22,11 +22,25 @@ class TestProcessingModule(unittest.TestCase):
         self.assertIn(ts.name, self.pm.containers)
         self.assertIs(ts, self.pm.containers[ts.name])
 
+    def test_deprecated_add_data_interface(self):
+        ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
+                        'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        self.pm.add_data_interface(ts)
+        self.assertIn(ts.name, self.pm.containers)
+        self.assertIs(ts, self.pm.containers[ts.name])
+
     def test_get_data_interface(self):
         ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
         self.pm.add(ts)
         tmp = self.pm.get('test_ts')
+        self.assertIs(tmp, ts)
+
+    def test_deprecated_get_data_interface(self):
+        ts = TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
+                        'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
+        self.pm.add(ts)
+        tmp = self.pm.get_data_interface('test_ts')
         self.assertIs(tmp, ts)
 
     def test_getitem(self):

--- a/tests/unit/pynwb_tests/test_core.py
+++ b/tests/unit/pynwb_tests/test_core.py
@@ -158,7 +158,7 @@ class TestDynamicTable(unittest.TestCase):
 
         module_behavior = nwbfile.create_processing_module('a', 'b')
 
-        module_behavior.add_data_interface(table)
+        module_behavior.add(table)
 
     def test_pandas_roundtrip(self):
         df = pd.DataFrame({
@@ -341,8 +341,8 @@ Fields:
   imaging_planes: { }
   intervals: { }
   lab_meta_data: { }
-  modules: { }
   ogen_sites: { }
+  processing: { }
   stimulus: { }
   stimulus_template: { }
 """)

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -125,7 +125,7 @@ class NWBFileTest(unittest.TestCase):
     def test_access_processing(self):
         self.nwbfile.create_processing_module('test_mod', 'test_desciprion')
         # test deprecate .modules
-        self.assertEqual(self.nwbfile.processing, self.nwbfile.modules)
+        self.assertIs(self.nwbfile.processing['test_mod'], self.nwbfile.modules['test_mod'])
 
     def test_epoch_tags(self):
         tags1 = ['t1', 't2']

--- a/tests/unit/pynwb_tests/test_file.py
+++ b/tests/unit/pynwb_tests/test_file.py
@@ -122,6 +122,11 @@ class NWBFileTest(unittest.TestCase):
 
         os.remove("electrodes_mwe.nwb")
 
+    def test_access_processing(self):
+        self.nwbfile.create_processing_module('test_mod', 'test_desciprion')
+        # test deprecate .modules
+        self.assertEqual(self.nwbfile.processing, self.nwbfile.modules)
+
     def test_epoch_tags(self):
         tags1 = ['t1', 't2']
         tags2 = ['t3', 't4']

--- a/tests/unit/pynwb_tests/test_ophys.py
+++ b/tests/unit/pynwb_tests/test_ophys.py
@@ -90,7 +90,7 @@ class CorrectedImageStackConstructor(unittest.TestCase):
         tstamps = np.arange(1.0, 100.0, 0.1, dtype=np.float)
         ts = TimeSeries("test_ts", list(range(len(tstamps))), 'unit', timestamps=tstamps)
         cis = CorrectedImageStack(is1, is2, ts)
-        ProcessingModule('name', 'description').add_data_interface(cis)
+        ProcessingModule('name', 'description').add(cis)
         self.assertEqual(cis.corrected, is1)
         self.assertEqual(cis.original, is2)
         self.assertEqual(cis.xy_translation, ts)


### PR DESCRIPTION
* change ProcessingModule.add_data_interface() to .add()
* change ProcessingModule.get_data_interface() to .get()
* change nwbfile.modules to nwbfile.processing

## Motivation

syntax is now: `nwbfile.processing['my_module_name'].add(my_elec_series)`

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
