### PR TITLE
Updated AllenSDK requirement to fix gallery error

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,5 +3,5 @@ matplotlib
 pillow
 sphinx_rtd_theme
 sphinx-gallery
-allensdk==0.16.0
+allensdk==0.16.3
 -r requirements.txt


### PR DESCRIPTION
Fix gallery error due to  due to failing scipy imresize import. Fix #969

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
