### PR TITLE
Fix broken tests to work with latest hdmf

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ configparser==3.5.0
 coverage==4.5.1
 flake8==3.5.0
 h5py==2.9.0
-hdmf==1.0.3
+hdmf==1.0.4
 idna==2.6
 linecache2==1.0.0
 mccabe==0.6.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,7 @@ configparser==3.5.0
 coverage==4.5.1
 flake8==3.5.0
 h5py==2.9.0
-hdmf==1.0.4
+hdmf==1.0.5
 idna==2.6
 linecache2==1.0.0
 mccabe==0.6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2019.3.9
 chardet==3.0.4
 h5py==2.9.0
-hdmf==1.0.3
+hdmf==1.0.4
 idna==2.6
 numpy==1.14.6
 pandas==0.23.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 certifi==2019.3.9
 chardet==3.0.4
 h5py==2.9.0
-hdmf==1.0.4
+hdmf==1.0.5
 idna==2.6
 numpy==1.14.6
 pandas==0.23.4

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -269,10 +269,14 @@ class TestAppend(unittest.TestCase):
             ts2 = ElectricalSeries(name='timeseries2', data=[4., 5., 6.], rate=1.0, electrodes=link_electrodes)
             nwb.add_acquisition(ts2)
             io.write(nwb)
+            self.assertIs(nwb.processing['test_proc_mod']['LFP'].electrical_series['test_es'].electrodes,
+                          nwb.acquisition['timeseries2'].electrodes)
 
         with NWBHDF5IO(self.path, mode='r') as io:
             nwb = io.read()
             np.testing.assert_equal(nwb.acquisition['timeseries2'].data[:], ts2.data)
+            self.assertIs(nwb.processing['test_proc_mod']['LFP'].electrical_series['test_es'].electrodes,
+                          nwb.acquisition['timeseries2'].electrodes)
             errors = validate(io)
             for e in errors:
                 print('ERROR', e)

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -265,8 +265,8 @@ class TestAppend(unittest.TestCase):
 
         with NWBHDF5IO(self.path, mode='a') as io:
             nwb = io.read()
-            electrodes = nwb.create_electrode_table_region(region=[0], description='')
-            ts2 = ElectricalSeries(name='timeseries2', data=[4., 5., 6.], rate=1.0, electrodes=electrodes)
+            link_electrodes = nwb.processing['test_proc_mod']['LFP'].electrical_series['test_es'].electrodes
+            ts2 = ElectricalSeries(name='timeseries2', data=[4., 5., 6.], rate=1.0, electrodes=link_electrodes)
             nwb.add_acquisition(ts2)
             io.write(nwb)
 


### PR DESCRIPTION
IO tests broke after the latest updates to HDMF where:
- an UnsupportedOperation is thrown if an IO object is opened in w- mode and the file already exists
- you cannot change the parent of a Container after it has been set, so an electrode table region cannot be re-used. 