### PR TITLE
fix ElectricalSeries_unit

### DIFF
--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -90,10 +90,11 @@ class ElectricalSeries(TimeSeries):
             {'name': 'control_description', 'type': Iterable,
              'doc': 'Description of each control value', 'default': None},
             {'name': 'parent', 'type': 'NWBContainer',
-             'doc': 'The parent NWBContainer for this NWBContainer', 'default': None})
+             'doc': 'The parent NWBContainer for this NWBContainer', 'default': None},
+            {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)', 'default': 'volt'})
     def __init__(self, **kwargs):
-        name, electrodes, data = popargs('name', 'electrodes', 'data', kwargs)
-        super(ElectricalSeries, self).__init__(name, data, 'volt', **kwargs)
+        name, electrodes, data, unit = popargs('name', 'electrodes', 'data', 'unit', kwargs)
+        super(ElectricalSeries, self).__init__(name, data, unit, **kwargs)
         self.electrodes = electrodes
 
 


### PR DESCRIPTION


## Motivation

fix #1005. Now you can supply your own units value to ElectricalSeries

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
