### PR TITLE
change dims for Units waveform

### DIFF
--- a/src/pynwb/data/nwb.misc.yaml
+++ b/src/pynwb/data/nwb.misc.yaml
@@ -253,21 +253,33 @@ groups:
     neurodata_type_inc: VectorData
     dtype: float
     dims:
-    - num_units
-    - num_samples
+    - - num_units
+      - num_samples
+    - - num_units
+      - num_samples
+      - num_electrodes
     shape:
-    - null
-    - null
+    - - null
+      - null
+    - - null
+      - null
+      - null
     doc: the spike waveform mean for each spike unit
     quantity: '?'
   - name: waveform_sd
     neurodata_type_inc: VectorData
     dtype: float
     dims:
-    - num_units
-    - num_samples
+    - - num_units
+      - num_samples
+    - - num_units
+      - num_samples
+      - num_electrodes
     shape:
-    - null
-    - null
+    - - null
+      - null
+    - - null
+      - null
+      - null
     doc: the spike waveform standard deviation for each spike unit
     quantity: '?'

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -218,10 +218,11 @@ class Units(DynamicTable):
              'default': None},
             {'name': 'electrode_group', 'type': 'ElectrodeGroup', 'default': None,
              'doc': 'the electrode group that each unit came from'},
-            {'name': 'waveform_mean', 'type': 'array_data', 'doc': 'the spike waveform mean for each unit',
+            {'name': 'waveform_mean', 'type': 'array_data',
+             'doc': 'the spike waveform mean for each unit. Shape is (time,) or (time, electrodes)',
              'default': None},
             {'name': 'waveform_sd', 'type': 'array_data', 'default': None,
-             'doc': 'the spike waveform standard deviation for each unit'},
+             'doc': 'the spike waveform standard deviation for each unit. Shape is (time,) or (time, electrodes)'},
             {'name': 'id', 'type': int, 'default': None,
              'help': 'the id for each unit'},
             allow_extra=True)


### PR DESCRIPTION
add an optional 3D shape for waveform_mean and waveform_sd including a third dimension for electrodes

## Motivation

You can easily put multi-electrode waveforms in the waveform_mean and waveform_sd columns, but it previously was not clear what the order of those dimensions was. This adds an optional 3D shape to waveform_mean and waveform_sd that puts electrodes in the last dimension

## How to test the behavior?
```
Show here how to reproduce the new behavior (can be a bug fix or a new feature)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style ? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number ?
