### PR TITLE
Prevent tox from writing `__pycache__`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,6 @@ jobs:
       - run:
           name: Publish wheel and source distribution as a GitHub pre-release
           command: |
-            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install -U scikit-ci-addons
@@ -258,7 +257,6 @@ jobs:
           name: Deploy release
           command: |
             echo "Deploy release"
-            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install twine
@@ -267,7 +265,6 @@ jobs:
       - run:
           name: Publish wheel and source distribution as a GitHub release
           command: |
-            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install githubrelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -257,6 +257,7 @@ jobs:
           name: Deploy release
           command: |
             echo "Deploy release"
+            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install twine
@@ -265,6 +266,7 @@ jobs:
       - run:
           name: Publish wheel and source distribution as a GitHub release
           command: |
+            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install githubrelease

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,7 @@ jobs:
       - run:
           name: Publish wheel and source distribution as a GitHub pre-release
           command: |
+            find . -regex '^.*\(__pycache__\|\.py[co]\)$' -delete
             python -m venv ../venv
             . ../venv/bin/activate
             pip install -U scikit-ci-addons

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ envlist = py27, py35, py36, py37
 
 [testenv]
 usedevelop = True
+setenv = PYTHONDONTWRITEBYTECODE = 1
 install_command =
     pip install -U {opts} {packages}
 


### PR DESCRIPTION
After tox runs tests, `__pycache__` directories are created in `tests/`. This change prevents those directories from being written to fix #1021.