### PR TITLE
Update HDMF pinned requirement to 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 chardet==3.0.4
 h5py==2.9.0
-hdmf==1.0.5
+hdmf==1.1.0
 numpy==1.16.4
 pandas==0.24.2
 python-dateutil==2.8.0


### PR DESCRIPTION
A few PRs rely on new functionality in HDMF 1.1.0. This PR updates the pinned requirement from 1.0.5 to 1.1.0.