### PR TITLE
Minor schema changes and change version number to 2.1.0

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -103,7 +103,7 @@ class TimeSeries(NWBDataInterface):
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)', 'default': None},
             {'name': 'resolution', 'type': (str, float),
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
-             'default': 0.0},
+             'default': -1.0},
             {'name': 'conversion', 'type': (str, float),
              'doc': 'Scalar to multiply each element in data to convert it to the specified unit',
              'default': 1.0},

--- a/src/pynwb/data/nwb.base.yaml
+++ b/src/pynwb/data/nwb.base.yaml
@@ -159,7 +159,7 @@ groups:
       required: false
     - name: resolution
       dtype: float32
-      default_value: 0.0
+      default_value: -1.0
       doc: Smallest meaningful difference between values in data, stored in the specified
         by unit, e.g., the change in value of the least significant bit, or a larger
         number if signal noise is known to be present. If unknown, use -1.0.

--- a/src/pynwb/data/nwb.file.yaml
+++ b/src/pynwb/data/nwb.file.yaml
@@ -89,10 +89,6 @@ groups:
       doc: Any one-off datasets
       quantity: '*'
       attributes:
-      - name: help
-        doc: Value is 'a scratch dataset'
-        dtype: text
-        value: a scratch dataset
       - name: notes
         doc: 'Any notes the user has about the dataset being stored'
         dtype: text

--- a/src/pynwb/data/nwb.icephys.yaml
+++ b/src/pynwb/data/nwb.icephys.yaml
@@ -70,15 +70,6 @@ groups:
     There is no CurrentClampStimulusSeries associated with an IZero series because
     the amplifier is disconnected and no stimulus can reach the cell.
   datasets:
-  - name: data
-    doc: Recorded voltage.
-    attributes:
-    - name: unit
-      dtype: text
-      value: volts
-      doc: Base unit of measurement for working with the data. which is fixed to 'volts'.
-        Actual stored values are not necessarily stored in these units. To access the data in these units,
-        multiply 'data' by 'conversion'.
   - name: bias_current
     dtype: float32
     value: 0.0

--- a/src/pynwb/data/nwb.namespace.yaml
+++ b/src/pynwb/data/nwb.namespace.yaml
@@ -53,4 +53,4 @@ namespaces:
   - doc: This source module contains neurodata_type for retinotopy data.
     source: nwb.retinotopy.yaml
     title: Retinotopy
-  version: 2.0.2
+  version: 2.1.0

--- a/src/pynwb/data/nwb.retinotopy.yaml
+++ b/src/pynwb/data/nwb.retinotopy.yaml
@@ -128,9 +128,9 @@ groups:
   - name: axis_descriptions
     dtype: text
     dims:
-    - '2'
+    - names
     shape:
-    - null
+    - 2
     doc: Two-element array describing the contents of the two response axis fields.
       Description should be something like ['altitude', 'azimuth'] or '['radius',
       'theta'].

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -92,7 +92,7 @@ class TestTimeSeries(unittest.TestCase):
         ts = TimeSeries('test_ts', dat, 'volts', timestamps=[0.1, 0.2, 0.3, 0.4])
         self.assertIs(ts.data, dat)
         self.assertEqual(ts.conversion, 1.0)
-        self.assertEqual(ts.resolution, 0.0)
+        self.assertEqual(ts.resolution, -1.0)
         self.assertEqual(ts.unit, 'volts')
 
     def test_init_timestamps(self):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -319,7 +319,7 @@ Fields:
   data: [1. 2. 3. ... 1. 2. 3.]
   description: no description
   interval: 1
-  resolution: 0.0
+  resolution: -1.0
   timestamps: [1 2 3]
   timestamps_unit: seconds
 """


### PR DESCRIPTION
1. Update schema version number 2.0.2 -> 2.1.0
2. Make TimeSeries.data.resolution default to -1.0 as the comment says
3. Clean up retinotopy.ImagingRetinotopy.axis_descriptions `dims` and `shape`
4. Remove `help` attribute from scratch group
5. Remove redundant data and data.unit from IZeroClampSeries