### PR TITLE
Clarify comment on deprecated ImageSeries.bits_per_pixel

### DIFF
--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -37,7 +37,8 @@ class ImageSeries(TimeSeries):
             {'name': 'starting_frame', 'type': Iterable,
              'doc': 'Each entry is the frame number in the corresponding external_file variable. '
                     'This serves as an index to what frames each file contains.', 'default': None},
-            {'name': 'bits_per_pixel', 'type': int, 'doc': 'Number of bit per image pixel', 'default': None},
+            {'name': 'bits_per_pixel', 'type': int, 'doc': 'DEPRECATED: Number of bits per image pixel',
+             'default': None},
             {'name': 'dimension', 'type': Iterable,
              'doc': 'Number of pixels on x, y, (and z) axes.', 'default': None},
             *get_docval(TimeSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',


### PR DESCRIPTION
The API documentation for `bits_per_pixel` of `ImageSeries` does not state that the attribute is deprecated. This PR fixes that.