### PR TITLE
Update docs with instruction to use --recurse-submodules in git clone

### DIFF
--- a/docs/CONTRIBUTING.rst
+++ b/docs/CONTRIBUTING.rst
@@ -61,7 +61,7 @@ If you have not already, you will need to clone the repo:
 
 .. code-block:: bash
 
-    $ git clone https://github.com/NeurodataWithoutBorders/pynwb.git
+    $ git clone --recurse-submodules https://github.com/NeurodataWithoutBorders/pynwb.git
 
 1) First create a new branch to work on
 

--- a/docs/source/getting_started.rst
+++ b/docs/source/getting_started.rst
@@ -51,7 +51,7 @@ To install or update PyNWB distribution from conda-forge using conda simply run:
 Install latest pre-release
 --------------------------
 
-This is useful to tryout the latest features and also setup continuous integration of your
+This is useful to try out the latest features and also set up continuous integration of your
 own project against the latest version of PyNWB.
 
 .. code::
@@ -73,9 +73,9 @@ For development an editable install is recommended.
    $ pip install -U virtualenv
    $ virtualenv ~/pynwb
    $ source ~/pynwb/bin/activate
-   $ git clone git@github.com:NeurodataWithoutBorders/pynwb.git
+   $ git clone --recurse-submodules git@github.com:NeurodataWithoutBorders/pynwb.git
    $ cd pynwb
-   $ pip install -r requirements.txt -r requirements-dev.txt
+   $ pip install -r requirements.txt
    $ pip install -e .
 
 
@@ -89,7 +89,7 @@ For running the tests, it is required to install the development requirements.
    $ pip install -U virtualenv
    $ virtualenv ~/pynwb
    $ source ~/pynwb/bin/activate
-   $ git clone git@github.com:NeurodataWithoutBorders/pynwb.git
+   $ git clone --recurse-submodules git@github.com:NeurodataWithoutBorders/pynwb.git
    $ cd pynwb
    $ pip install -r requirements.txt -r requirements-dev.txt
    $ pip install -e .

--- a/docs/source/make_a_release.rst
+++ b/docs/source/make_a_release.rst
@@ -92,7 +92,7 @@ PyPI: Step-by-step
 
   .. code::
 
-    $ cd /tmp && git clone git@github.com:NeurodataWithoutBorders/pynwb && cd pynwb
+    $ cd /tmp && git clone --recurse-submodules git@github.com:NeurodataWithoutBorders/pynwb && cd pynwb
 
 
 5. Tag the release


### PR DESCRIPTION
The docs say to install pynwb from GitHub using `git clone [repo].git`. This should be updated to say `git clone --recurse-submodules [repo].git`.
