### PR TITLE
Change Azure to run CI on every push, not just PRs & pushes to dev

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,3 @@
-trigger:
-- dev
-
 jobs:
 
 - job: 'Test'


### PR DESCRIPTION
Minor enhancement:
CircleCI runs on every push, so when a new branch is made for a PR and pushed to GitHub, CircleCI tests are immediately triggered. Azure runs only after a PR is made or when a push is made only to the dev branch. This PR changes Azure behavior to run on every push. 

Pro:
Since writing a new PR takes some time, by the time I actually create the PR, CircleCI tests are usually done or near done but Azure tests will not have yet begun. It would be nice if the Azure tests started on the first push like for CircleCI so we can get feedback on all of the tests sooner. 

Con:
If you push to a testing branch often, but before a PR has been made, this could lead to wasted CI runs.