### PR TITLE
Make setup.py require the latest pinned version of HDMF

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,8 @@ schema_dir = 'nwb-schema/core'
 reqs_re = re.compile("[<=>]+")
 with open('requirements.txt', 'r') as fp:
     reqs = [reqs_re.split(x.strip())[0] for x in fp.readlines()]
+reqs.remove('hdmf')
+reqs.append('hdmf>=1.3.2')
 
 print(reqs)
 

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,10 @@ print('found these packages:', pkgs)
 
 schema_dir = 'nwb-schema/core'
 
+# copy requirements from requirements.txt, ignore all pinned version info, but keep pinned version for hdmf
 reqs_re = re.compile("[<=>]+")
 with open('requirements.txt', 'r') as fp:
-    reqs = [reqs_re.split(x.strip())[0] for x in fp.readlines()]
-reqs.remove('hdmf')
-reqs.append('hdmf>=1.3.2')
+    reqs = [reqs_re.split(x.strip())[0] if not x.startswith('hdmf') else x.strip() for x in fp.readlines()]
 
 print(reqs)
 


### PR DESCRIPTION
## Motivation

All future releases of PyNWB will require HDMF>=1.3.2 (where generic types moved from PyNWB to HDMF), but `setup.py` currently does not specify which version of HDMF is required. If a user upgrades to the latest PyNWB (1.1.0), the version of HDMF that they are using must also be upgraded, but this is currently not happening. 

This PR puts into `setup.py` a requirement to use the release of HDMF that is pinned in `requirements.txt` (currently 1.3.2). This is almost always the latest version of HDMF.

This PR will also prevent another issue where a user has the latest release of PyNWB and the latest release of HDMF but these two versions are incompatible with each other, as they are currently (see https://github.com/NeurodataWithoutBorders/pynwb/issues/1071#issuecomment-538863978).