### PR TITLE
Expose export_spec from hdmf.spec.write for import from pynwb.spec

### DIFF
--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -2,6 +2,7 @@ from copy import copy, deepcopy
 
 from hdmf.spec import LinkSpec, GroupSpec, DatasetSpec, SpecNamespace,\
                        NamespaceBuilder, AttributeSpec, DtypeSpec, RefSpec
+from hdmf.spec import export_spec  # noqa: F401
 from hdmf.utils import docval, get_docval, fmt_docval_args
 
 from . import CORE_NAMESPACE

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -2,7 +2,7 @@ from copy import copy, deepcopy
 
 from hdmf.spec import LinkSpec, GroupSpec, DatasetSpec, SpecNamespace,\
                        NamespaceBuilder, AttributeSpec, DtypeSpec, RefSpec
-from hdmf.spec import export_spec  # noqa: F401
+from hdmf.spec.write import export_spec  # noqa: F401
 from hdmf.utils import docval, get_docval, fmt_docval_args
 
 from . import CORE_NAMESPACE


### PR DESCRIPTION
Paired with https://github.com/hdmf-dev/hdmf/pull/170

HDMF now includes a utility function `export_spec` for use by extension developers. To shield the user from needing to know about HDMF, this PR allows a user to import `export_spec` from pynwb.spec instead of from hdmf.spec.write. 