### PR TITLE
add warning

### DIFF
--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -186,6 +186,8 @@ class Units(DynamicTable):
                 if self.__electrode_table is None:
                     nwbfile = self.get_ancestor(data_type='NWBFile')
                     elec_col.table = nwbfile.electrodes
+                    if elec_col.table is None:
+                        warnings.warn('Reference to electrode table that does not yet exit')
                 else:
                     elec_col.table = self.__electrode_table
 

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -187,7 +187,7 @@ class Units(DynamicTable):
                     nwbfile = self.get_ancestor(data_type='NWBFile')
                     elec_col.table = nwbfile.electrodes
                     if elec_col.table is None:
-                        warnings.warn('Reference to electrode table that does not yet exit')
+                        warnings.warn('Reference to electrode table that does not yet exist')
                 else:
                     elec_col.table = self.__electrode_table
 


### PR DESCRIPTION
## Motivation

add warning when referencing electrode table before it exists

relates to #1097 