### PR TITLE
Refactor docval calls and improve unit test with implicit args

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -5,7 +5,7 @@ try:
 except ImportError:
     from collections import Iterable  # Python 2.7
 
-from hdmf.utils import docval, getargs, popargs, fmt_docval_args, call_docval_func
+from hdmf.utils import docval, getargs, popargs, call_docval_func
 from hdmf.common import DynamicTable
 
 
@@ -126,8 +126,7 @@ class TimeSeries(NWBDataInterface):
     def __init__(self, **kwargs):
         """Create a TimeSeries object
         """
-        pargs, pkwargs = fmt_docval_args(super(TimeSeries, self).__init__, kwargs)
-        super(TimeSeries, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(TimeSeries, self).__init__, kwargs)
         keys = ("resolution",
                 "comments",
                 "description",

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -293,9 +293,8 @@ class NWBFile(MultiContainerInterface):
             {'name': 'scratch', 'type': (list, tuple),
              'doc': 'scratch data', 'default': None})
     def __init__(self, **kwargs):
-        pargs, pkwargs = fmt_docval_args(super(NWBFile, self).__init__, kwargs)
-        pkwargs['name'] = 'root'
-        super(NWBFile, self).__init__(*pargs, **pkwargs)
+        kwargs['name'] = 'root'
+        call_docval_func(super(NWBFile, self).__init__, kwargs)
         self.fields['session_description'] = getargs('session_description', kwargs)
         self.fields['identifier'] = getargs('identifier', kwargs)
 

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -10,7 +10,7 @@ import copy as _copy
 import numpy as np
 import pandas as pd
 
-from hdmf.utils import docval, getargs, fmt_docval_args, call_docval_func, get_docval
+from hdmf.utils import docval, getargs, call_docval_func, get_docval
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, ProcessingModule
@@ -62,8 +62,7 @@ class Subject(NWBContainer):
              'doc': 'datetime of date of birth. May be supplied instead of age.'})
     def __init__(self, **kwargs):
         kwargs['name'] = 'subject'
-        pargs, pkwargs = fmt_docval_args(super(Subject, self).__init__, kwargs)
-        super(Subject, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(Subject, self).__init__, kwargs)
         self.age = getargs('age', kwargs)
         self.description = getargs('description', kwargs)
         self.genotype = getargs('genotype', kwargs)

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from hdmf.utils import docval, popargs, fmt_docval_args, call_docval_func, get_docval
+from hdmf.utils import docval, popargs, call_docval_func, get_docval
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries
@@ -27,8 +27,8 @@ class IntracellularElectrode(NWBContainer):
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record from this electrode'},
             {'name': 'description', 'type': str,
-             'doc': 'Recording description, description of electrode (e.g.,  whole-cell, sharp, etc) \
-             COMMENT: Free-form text (can be from Methods)'},
+             'doc': 'Recording description, description of electrode (e.g.,  whole-cell, sharp, etc) '
+                    'COMMENT: Free-form text (can be from Methods)'},
             {'name': 'slice', 'type': str, 'doc': 'Information about slice used for recording.', 'default': None},
             {'name': 'seal', 'type': str, 'doc': 'Information about seal used for recording.', 'default': None},
             {'name': 'location', 'type': str,
@@ -41,8 +41,7 @@ class IntracellularElectrode(NWBContainer):
         slice, seal, description, location, resistance, filtering, initial_access_resistance, device = popargs(
             'slice', 'seal', 'description', 'location', 'resistance',
             'filtering', 'initial_access_resistance', 'device', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(IntracellularElectrode, self).__init__, kwargs)
-        super(IntracellularElectrode, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(IntracellularElectrode, self).__init__, kwargs)
         self.slice = slice
         self.seal = seal
         self.description = description
@@ -70,15 +69,15 @@ class PatchClampSeries(TimeSeries):
              'doc': 'The data this TimeSeries dataset stores. Can also store binary data e.g. image frames'},
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)'},  # required
             {'name': 'electrode', 'type': IntracellularElectrode,  # required
-             'doc': 'IntracellularElectrode group that describes the electrode that was used to apply \
-                     or record this data.'},
+             'doc': 'IntracellularElectrode group that describes the electrode that was used to apply '
+                     'or record this data.'},
             {'name': 'gain', 'type': 'float', 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},  # required
             {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "NA"},
             *get_docval(TimeSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
                         'comments', 'description', 'control', 'control_description'),
             {'name': 'sweep_number', 'type': (int, 'uint64'),
-             'doc': 'Sweep number, allows for grouping different PatchClampSeries together \
-                     via the sweep_table', 'default': None})
+             'doc': 'Sweep number, allows for grouping different PatchClampSeries together '
+                    'via the sweep_table', 'default': None})
     def __init__(self, **kwargs):
         name, data, unit, stimulus_description = popargs('name', 'data', 'unit', 'stimulus_description', kwargs)
         electrode, gain, sweep_number = popargs('electrode', 'gain', 'sweep_number', kwargs)

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -1,4 +1,4 @@
-from hdmf.utils import docval, popargs, fmt_docval_args, get_docval
+from hdmf.utils import docval, popargs, get_docval, call_docval_func
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries
@@ -24,8 +24,7 @@ class OptogeneticStimulusSite(NWBContainer):
     def __init__(self, **kwargs):
         device, description, excitation_lambda, location = popargs(
             'device', 'description', 'excitation_lambda', 'location', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(OptogeneticStimulusSite, self).__init__, kwargs)
-        super(OptogeneticStimulusSite, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(OptogeneticStimulusSite, self).__init__, kwargs)
         self.device = device
         self.description = description
         self.excitation_lambda = excitation_lambda

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from collections import Iterable  # Python 2.7
 
-from hdmf.utils import docval, getargs, popargs, fmt_docval_args, call_docval_func, get_docval
+from hdmf.utils import docval, getargs, popargs, call_docval_func, get_docval
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries
@@ -27,8 +27,7 @@ class OpticalChannel(NWBContainer):
             {'name': 'emission_lambda', 'type': 'float', 'doc': 'Emission lambda for channel.'})  # required
     def __init__(self, **kwargs):
         description, emission_lambda = popargs("description", "emission_lambda", kwargs)
-        pargs, pkwargs = fmt_docval_args(super(OpticalChannel, self).__init__, kwargs)
-        super(OpticalChannel, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(OpticalChannel, self).__init__, kwargs)
         self.description = description
         self.emission_lambda = emission_lambda
 
@@ -77,8 +76,7 @@ class ImagingPlane(NWBContainer):
                 'optical_channel', 'description', 'device', 'excitation_lambda',
                 'imaging_rate', 'indicator', 'location', 'manifold', 'conversion',
                 'unit', 'reference_frame', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(ImagingPlane, self).__init__, kwargs)
-        super(ImagingPlane, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(ImagingPlane, self).__init__, kwargs)
         self.optical_channel = optical_channel if isinstance(optical_channel, list) else [optical_channel]
         self.description = description
         self.device = device
@@ -122,8 +120,7 @@ class TwoPhotonSeries(ImageSeries):
     def __init__(self, **kwargs):
         field_of_view, imaging_plane, pmt_gain, scan_line_rate = popargs(
             'field_of_view', 'imaging_plane', 'pmt_gain', 'scan_line_rate', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(TwoPhotonSeries, self).__init__, kwargs)
-        super(TwoPhotonSeries, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(TwoPhotonSeries, self).__init__, kwargs)
         self.field_of_view = field_of_view
         self.imaging_plane = imaging_plane
         self.pmt_gain = pmt_gain
@@ -153,7 +150,7 @@ class CorrectedImageStack(NWBDataInterface):
                     'for example, to align each frame to a reference image.'})
     def __init__(self, **kwargs):
         corrected, original, xy_translation = popargs('corrected', 'original', 'xy_translation', kwargs)
-        super(CorrectedImageStack, self).__init__(**kwargs)
+        call_docval_func(super(CorrectedImageStack, self).__init__, kwargs)
         self.corrected = corrected
         self.original = original
         self.xy_translation = xy_translation
@@ -203,8 +200,7 @@ class PlaneSegmentation(DynamicTable):
         if kwargs.get('name') is None:
             kwargs['name'] = imaging_plane.name
         columns, colnames = getargs('columns', 'colnames', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(PlaneSegmentation, self).__init__, kwargs)
-        super(PlaneSegmentation, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(PlaneSegmentation, self).__init__, kwargs)
         self.imaging_plane = imaging_plane
         if isinstance(reference_images, ImageSeries):
             reference_images = (reference_images,)
@@ -319,8 +315,7 @@ class RoiResponseSeries(TimeSeries):
                         'comments', 'description', 'control', 'control_description'))
     def __init__(self, **kwargs):
         rois = popargs('rois', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(RoiResponseSeries, self).__init__, kwargs)
-        super(RoiResponseSeries, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(RoiResponseSeries, self).__init__, kwargs)
         self.rois = rois
 
 

--- a/src/pynwb/retinotopy.py
+++ b/src/pynwb/retinotopy.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from collections import Iterable  # Python 2.7
 
-from hdmf.utils import docval, popargs, fmt_docval_args
+from hdmf.utils import docval, popargs, call_docval_func
 
 from . import register_class, CORE_NAMESPACE
 from .core import NWBContainer, NWBDataInterface
@@ -32,8 +32,7 @@ class AImage(NWBContainer):
     def __init__(self, **kwargs):
         data, bits_per_pixel, dimension, format, field_of_view = popargs(
             'data', 'bits_per_pixel', 'dimension', 'format', 'field_of_view', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(AImage, self).__init__, kwargs)
-        super(AImage, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(AImage, self).__init__, kwargs)
         self.data = data
         self.bits_per_pixel = bits_per_pixel
         self.dimension = format
@@ -57,8 +56,7 @@ class AxisMap(NWBContainer):
              'doc': 'Number of rows and columns in the image'})
     def __init__(self, **kwargs):
         data, field_of_view, unit, dimension = popargs('data', 'field_of_view', 'unit', 'dimension', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(AxisMap, self).__init__, kwargs)
-        super(AxisMap, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(AxisMap, self).__init__, kwargs)
         self.data = data
         self.field_of_view = field_of_view
         self.unit = unit
@@ -111,8 +109,7 @@ class ImagingRetinotopy(NWBDataInterface):
             focal_depth_image, sign_map, vasculature_image = popargs(
                 'axis_1_phase_map', 'axis_1_power_map', 'axis_2_phase_map', 'axis_2_power_map',
                 'axis_descriptions', 'focal_depth_image', 'sign_map', 'vasculature_image', kwargs)
-        pargs, pkwargs = fmt_docval_args(super(ImagingRetinotopy, self).__init__, kwargs)
-        super(ImagingRetinotopy, self).__init__(*pargs, **pkwargs)
+        call_docval_func(super(ImagingRetinotopy, self).__init__, kwargs)
         self.axis_1_phase_map = axis_1_phase_map
         self.axis_1_power_map = axis_1_power_map
         self.axis_2_phase_map = axis_2_phase_map

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -3,7 +3,7 @@ from copy import copy, deepcopy
 from hdmf.spec import LinkSpec, GroupSpec, DatasetSpec, SpecNamespace,\
                        NamespaceBuilder, AttributeSpec, DtypeSpec, RefSpec
 from hdmf.spec.write import export_spec  # noqa: F401
-from hdmf.utils import docval, get_docval, fmt_docval_args
+from hdmf.utils import docval, get_docval, call_docval_func
 
 from . import CORE_NAMESPACE
 
@@ -31,8 +31,7 @@ class NWBRefSpec(RefSpec):
 
     @docval(*_ref_docval)
     def __init__(self, **kwargs):
-        args, kwargs = fmt_docval_args(RefSpec.__init__, kwargs)
-        super(NWBRefSpec, self).__init__(*args, **kwargs)
+        call_docval_func(super(NWBRefSpec, self).__init__, kwargs)
 
 
 _attr_docval = __swap_inc_def(AttributeSpec)
@@ -42,8 +41,7 @@ class NWBAttributeSpec(AttributeSpec):
 
     @docval(*_attr_docval)
     def __init__(self, **kwargs):
-        args, kwargs = fmt_docval_args(AttributeSpec.__init__, kwargs)
-        super(NWBAttributeSpec, self).__init__(*args, **kwargs)
+        call_docval_func(super(NWBAttributeSpec, self).__init__, kwargs)
 
 
 _link_docval = __swap_inc_def(LinkSpec)
@@ -53,8 +51,7 @@ class NWBLinkSpec(LinkSpec):
 
     @docval(*_link_docval)
     def __init__(self, **kwargs):
-        args, kwargs = fmt_docval_args(LinkSpec.__init__, kwargs)
-        super(NWBLinkSpec, self).__init__(*args, **kwargs)
+        call_docval_func(super(NWBLinkSpec, self).__init__, kwargs)
 
     @property
     def neurodata_type_inc(self):
@@ -124,8 +121,7 @@ class NWBDtypeSpec(DtypeSpec):
 
     @docval(*_dtype_docval)
     def __init__(self, **kwargs):
-        args, kwargs = fmt_docval_args(DtypeSpec.__init__, kwargs)
-        super(NWBDtypeSpec, self).__init__(*args, **kwargs)
+        call_docval_func(super(NWBDtypeSpec, self).__init__, kwargs)
 
 
 _dataset_docval = __swap_inc_def(DatasetSpec)

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -206,7 +206,6 @@ class NWBNamespaceBuilder(NamespaceBuilder):
              'doc': 'List of emails. Ordering should be the same as for author', 'default': None})
     def __init__(self, **kwargs):
         ''' Create a NWBNamespaceBuilder '''
-        args, vargs = fmt_docval_args(NamespaceBuilder.__init__, kwargs)
         kwargs['namespace_cls'] = NWBNamespace
-        super(NWBNamespaceBuilder, self).__init__(*args, **kwargs)
+        call_docval_func(super(NWBNamespaceBuilder, self).__init__, kwargs)
         self.include_namespace(CORE_NAMESPACE)

--- a/tests/integration/ui_write/test_misc.py
+++ b/tests/integration/ui_write/test_misc.py
@@ -85,7 +85,7 @@ class TestUnitElectrodes(base.TestMapRoundTrip):
                                                          location=location,
                                                          device=device)
         for idx in [1, 2, 3, 4]:
-            nwbfile.add_electrode(idx,
+            nwbfile.add_electrode(id=idx,
                                   x=1.0, y=2.0, z=3.0,
                                   imp=float(-idx),
                                   location='CA1', filtering='none',


### PR DESCRIPTION
Minor improvement. Paired with, but should not require https://github.com/hdmf-dev/hdmf/pull/194

This PR:
1) changes how fixed values were injected into the keyword arguments of a superclass in some cases
2) replaces `fmt_docval_args` and the subsequent superclass constructor call with `call_docval_func`
3) fixes a unit test where the index to a dynamictable was implicitly provided
