### PR TITLE
Handle unmapped attributes

### DIFF
--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -38,6 +38,10 @@ class TimeSeriesMap(NWBContainerMapper):
         self.map_spec('starting_time_unit', startingtime_spec.get_attribute('unit'))
         self.map_spec('rate', startingtime_spec.get_attribute('rate'))
 
+        # TODO map the sync group to something
+        sync_spec = self.spec.get_group('sync')
+        self.unmap(sync_spec)
+
     @NWBContainerMapper.constructor_arg('name')
     def name(self, builder, manager):
         return builder.name

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -22,6 +22,8 @@ class NWBFileMap(ObjectMapper):
         # map constructor arg and property 'stimulus' -> stimulus__presentation
         stimulus_spec = self.spec.get_group('stimulus')
         self.unmap(stimulus_spec)
+        self.unmap(stimulus_spec.get_group('presentation'))
+        self.unmap(stimulus_spec.get_group('templates'))
         self.map_spec('stimulus', stimulus_spec.get_group('presentation').get_neurodata_type('TimeSeries'))
         self.map_spec('stimulus_template', stimulus_spec.get_group('templates').get_neurodata_type('TimeSeries'))
 
@@ -38,20 +40,28 @@ class NWBFileMap(ObjectMapper):
         self.map_spec('invalid_times', invalid_times_spec)
 
         general_spec = self.spec.get_group('general')
+        self.unmap(general_spec)
 
         icephys_spec = general_spec.get_group('intracellular_ephys')
+        self.unmap(icephys_spec)
         self.map_spec('ic_electrodes', icephys_spec.get_neurodata_type('IntracellularElectrode'))
         self.map_spec('sweep_table', icephys_spec.get_neurodata_type('SweepTable'))
 
+        # TODO map the filtering dataset to something or deprecate it
+        self.unmap(icephys_spec.get_dataset('filtering'))
+
         ecephys_spec = general_spec.get_group('extracellular_ephys')
+        self.unmap(ecephys_spec)
         self.map_spec('electrodes', ecephys_spec.get_group('electrodes'))
         self.map_spec('electrode_groups', ecephys_spec.get_neurodata_type('ElectrodeGroup'))
 
-        self.map_spec('ogen_sites',
-                      general_spec.get_group('optogenetics').get_neurodata_type('OptogeneticStimulusSite'))
+        ogen_spec = general_spec.get_group('optogenetics')
+        self.unmap(ogen_spec)
+        self.map_spec('ogen_sites', ogen_spec.get_neurodata_type('OptogeneticStimulusSite'))
 
-        self.map_spec('imaging_planes',
-                      general_spec.get_group('optophysiology').get_neurodata_type('ImagingPlane'))
+        ophys_spec = general_spec.get_group('optophysiology')
+        self.unmap(ophys_spec)
+        self.map_spec('imaging_planes', ophys_spec.get_neurodata_type('ImagingPlane'))
 
         general_datasets = ['data_collection',
                             'experiment_description',
@@ -77,7 +87,11 @@ class NWBFileMap(ObjectMapper):
         self.map_spec('source_script_file_name', general_spec.get_dataset('source_script').get_attribute('file_name'))
 
         self.map_spec('subject', general_spec.get_group('subject'))
-        self.map_spec('devices', general_spec.get_group('devices').get_neurodata_type('Device'))
+
+        device_spec = general_spec.get_group('devices')
+        self.unmap(device_spec)
+        self.map_spec('devices', device_spec.get_neurodata_type('Device'))
+
         self.map_spec('lab_meta_data', general_spec.get_neurodata_type('LabMetaData'))
 
         proc_spec = self.spec.get_group('processing')

--- a/tests/unit/test_epoch.py
+++ b/tests/unit/test_epoch.py
@@ -37,7 +37,7 @@ class TimeIntervalsTest(unittest.TestCase):
             'start_time': [0.2, 0.25, 0.30, 0.35],
             'stop_time': [0.25, 0.30, 0.40, 0.45],
             'timeseries': [[tsa], [tsb], [], [tsb, tsa]],
-            'description': ['q', 'w', 'e', 'r'],
+            'keys': ['q', 'w', 'e', 'r'],
             'tags': [[], [], ['fizz', 'buzz'], ['qaz']]
         })
 


### PR DESCRIPTION
This PR fixes errors that will occur when https://github.com/hdmf-dev/hdmf/pull/196 is merged.

- Make explicit that the `NWBFile/general/intracellular_ephys/filtering` dataset does not map to any attribute in the `NWBFile` class.
- Make explicit that the `TimeSeries/sync` group does not map to any attribute in the `TimeSeries` class.
- Fix a test where a DataFrame had the column name "description". Since "description" is an attribute of `DynamicTable`, the name "description" is not allowed for new column names (see https://github.com/hdmf-dev/hdmf/pull/196)

