### PR TITLE
Enh/dtselect

### DIFF
--- a/docs/gallery/domain/ecephys.py
+++ b/docs/gallery/domain/ecephys.py
@@ -68,7 +68,7 @@ electrode_group = nwbfile.create_electrode_group(electrode_name,
 
 
 for idx in [1, 2, 3, 4]:
-    nwbfile.add_electrode(idx,
+    nwbfile.add_electrode(id=idx,
                           x=1.0, y=2.0, z=3.0,
                           imp=float(-idx),
                           location='CA1', filtering='none',

--- a/docs/gallery/general/extensions.py
+++ b/docs/gallery/general/extensions.py
@@ -179,7 +179,7 @@ electrode_group = nwbfile.create_electrode_group(electrode_name,
                                                  location=location,
                                                  device=device)
 for idx in [1, 2, 3, 4]:
-    nwbfile.add_electrode(idx,
+    nwbfile.add_electrode(id=idx,
                           x=1.0, y=2.0, z=3.0,
                           imp=float(-idx),
                           location='CA1', filtering='none',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 chardet==3.0.4
 h5py==2.10.0
-hdmf==1.3.3
+hdmf==1.4.0
 numpy==1.17.2
 pandas==0.25.1
 python-dateutil==2.8.0

--- a/tests/integration/ui_write/test_core.py
+++ b/tests/integration/ui_write/test_core.py
@@ -111,7 +111,10 @@ class TestElectrodes(base.TestMapRoundTrip):
 
     def test_roundtrip(self):
         super(TestElectrodes, self).test_roundtrip()
-        self.assertContainerEqual(self.read_container[0][7], self.container[0][7])
+        # When comparing the pandas dataframes for the row we drop the 'group' column since the
+        # ElectrodeGroup object after reading will naturally have a different address
+        pd.testing.assert_frame_equal(self.read_container[0].drop('group', axis=1),
+                                      self.container[0].drop('group', axis=1))
 
 
 class TestElectrodesRegion(base.TestMapRoundTrip):
@@ -153,6 +156,5 @@ class TestElectrodesRegion(base.TestMapRoundTrip):
 
     def test_roundtrip(self):
         super(TestElectrodesRegion, self).test_roundtrip()
-
         for ii, item in enumerate(self.read_container):
-            self.assertEqual(self.table[ii+1], item)
+            pd.testing.assert_frame_equal(self.table[ii+1], item)

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -163,8 +163,8 @@ class TestElectricalSeriesIO(base.TestDataInterfaceIO):
         read = self.roundtripContainer()
         row1 = read.electrodes[0]
         row2 = read.electrodes[1]
-        self.assertIsInstance(row1[7], ElectrodeGroup)
-        self.assertIsInstance(row2[7], ElectrodeGroup)
+        self.assertIsInstance(row1.iloc[0]['group'], ElectrodeGroup)
+        self.assertIsInstance(row2.iloc[0]['group'], ElectrodeGroup)
 
 
 class TestMultiElectricalSeries(with_metaclass(ABCMeta, base.TestDataInterfaceIO)):

--- a/tests/unit/test_epoch.py
+++ b/tests/unit/test_epoch.py
@@ -18,10 +18,11 @@ class TimeIntervalsTest(unittest.TestCase):
         self.assertEqual(ept.name, 'epochs')
         ept.add_interval(10.0, 20.0, ["test", "unittest", "pynwb"], ts)
         row = ept[0]
-        self.assertEqual(row[1], 10.0)
-        self.assertEqual(row[2], 20.0)
-        self.assertEqual(row[3], ["test", "unittest", "pynwb"])
-        self.assertEqual(row[4], [(90, 100, ts)])
+        self.assertEqual(row.index[0], 0)
+        self.assertEqual(row.loc[0]['start_time'], 10.0)
+        self.assertEqual(row.loc[0]['stop_time'], 20.0)
+        self.assertEqual(row.loc[0]['tags'], ["test", "unittest", "pynwb"])
+        self.assertEqual(row.loc[0]['timeseries'], [(90, 100, ts)])
 
     def get_timeseries(self):
         return [

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -248,14 +248,14 @@ class NWBFileTest(unittest.TestCase):
         dev1 = self.nwbfile.create_device('dev1')
         group = self.nwbfile.create_electrode_group('tetrode1', 'tetrode description', 'tetrode location', dev1)
         self.nwbfile.add_electrode(1.0, 2.0, 3.0, -1.0, 'CA1', 'none', group=group, id=1)
-        self.assertEqual(self.nwbfile.electrodes[0][0], 1)
-        self.assertEqual(self.nwbfile.electrodes[0][1], 1.0)
-        self.assertEqual(self.nwbfile.electrodes[0][2], 2.0)
-        self.assertEqual(self.nwbfile.electrodes[0][3], 3.0)
-        self.assertEqual(self.nwbfile.electrodes[0][4], -1.0)
-        self.assertEqual(self.nwbfile.electrodes[0][5], 'CA1')
-        self.assertEqual(self.nwbfile.electrodes[0][6], 'none')
-        self.assertEqual(self.nwbfile.electrodes[0][7], group)
+        elec = self.nwbfile.electrodes[0]
+        self.assertEqual(elec.index[0], 1)
+        self.assertEqual(elec.iloc[0]['x'], 1.0)
+        self.assertEqual(elec.iloc[0]['y'], 2.0)
+        self.assertEqual(elec.iloc[0]['z'], 3.0)
+        self.assertEqual(elec.iloc[0]['location'], 'CA1')
+        self.assertEqual(elec.iloc[0]['filtering'], 'none')
+        self.assertEqual(elec.iloc[0]['group'], group)
 
     def test_all_children(self):
         ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5], 'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])


### PR DESCRIPTION
## Motivation
This is the matching PR for https://github.com/hdmf-dev/hdmf/pull/191 The selection behavior of DynamicTable and DynamicTableRegion has changed in HDMF to return Pandas DataFrames. This updates the tests in PyNWB to conform with the new changes/

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
