### PR TITLE
Update legacy import of ObjectMapper

### DIFF
--- a/src/pynwb/legacy/map.py
+++ b/src/pynwb/legacy/map.py
@@ -1,5 +1,5 @@
 
-from hdmf.build.map import ObjectMapper, TypeMap
+from hdmf.build import ObjectMapper, TypeMap
 from hdmf.build.builders import GroupBuilder
 
 


### PR DESCRIPTION
This one-liner is necessary for PyNWB to work with the moving of `ObjectMapper` from `hdmf.build.map` to `hdmf.build.objectmapper`: https://github.com/hdmf-dev/hdmf/pull/221