### PR TITLE
fix mistake: 'str' -> 'text'

### DIFF
--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -42,7 +42,7 @@ Specifying datasets is done with :py:class:`~pynwb.spec.NWBDatasetSpec`.
     spec = NWBDatasetSpec('A custom NWB type',
                         name='qux',
                         attribute=[
-                            NWBAttributeSpec('baz', 'a value for baz', 'str'),
+                            NWBAttributeSpec('baz', 'a value for baz', 'text'),
                         ],
                         shape=(None, None))
 
@@ -60,7 +60,7 @@ list of :py:class:`~pynwb.spec.NWBDtypeSpec` objects to the *dtype* argument.
     spec = NWBDatasetSpec('A custom NWB type',
                         name='qux',
                         attribute=[
-                            NWBAttributeSpec('baz', 'a value for baz', 'str'),
+                            NWBAttributeSpec('baz', 'a value for baz', 'text'),
                         ],
                         dtype=[
                             NWBDtypeSpec('foo', 'column for foo', 'int'),


### PR DESCRIPTION
## Motivation

'str' is not a valid dtype in the schema language. Use 'text' instead in tutorial.
