### PR TITLE
Update CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,12 @@ references:
           # While pip installing tox does not output by default. Circle thinks task is dead after 10 min.
           no_output_timeout: 30m
       - run:
-          name: Run coverage and submit to codecov-io
+          name: Run coverage and submit to codecov-io if COVERAGE_TOX_ENV != ""
           command: |
             . ../venv/bin/activate
-            tox -e $COVERAGE_TOX_ENV
+            if [[ "${COVERAGE_TOX_ENV}" != "" ]]; then
+              tox -e $COVERAGE_TOX_ENV
+            fi
       - run:
           name: Build wheel and source distribution
           command: |
@@ -75,7 +77,7 @@ references:
             conda config --set always_yes yes --set changeps1 no
             conda config --add channels conda-forge
             conda install python=$CONDA_PYTHON_VER
-            conda install virtualenv==16.0.0
+            conda install virtualenv
             conda install tox
       - run:
           name: Run the tests
@@ -122,7 +124,7 @@ references:
 jobs:
   flake8:
     docker:
-      - image: circleci/python:3.6.3-jessie
+      - image: circleci/python:3.8.1-buster
     steps:
       - checkout
       - run:
@@ -132,20 +134,20 @@ jobs:
 
   python35:
     docker:
-      - image: circleci/python:3.5.7-jessie
+      - image: circleci/python:3.5.9-stretch
     environment:
      - TEST_TOX_ENV: "py35"
-     - COVERAGE_TOX_ENV: "coverage-py35"
+     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py35"
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py35"
     <<: *ci-steps
 
   python36:
     docker:
-      - image: circleci/python:3.6.3-jessie
+      - image: circleci/python:3.6.10-stretch
     environment:
      - TEST_TOX_ENV: "py36"
-     - COVERAGE_TOX_ENV: "coverage-py36"
+     - COVERAGE_TOX_ENV: ""
      - BUILD_TOX_ENV: "build-py36"
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py36"
      - UPLOAD_WHEELS: "true"
@@ -153,10 +155,10 @@ jobs:
 
   python37:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: circleci/python:3.7.6-stretch
     environment:
      - TEST_TOX_ENV: "py37"
-     - COVERAGE_TOX_ENV: "coverage-py37"
+     - COVERAGE_TOX_ENV: "coverage"
      - BUILD_TOX_ENV: "build-py37"
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py37"
     <<: *ci-steps
@@ -173,7 +175,7 @@ jobs:
 
   miniconda36:
     docker:
-      - image: continuumio/miniconda3:4.6.14
+      - image: continuumio/miniconda3:4.7.12
     environment:
       - CONDA_PYTHON_VER: "3.6"
       - TEST_TOX_ENV: "py36"
@@ -183,7 +185,7 @@ jobs:
 
   miniconda37:
     docker:
-      - image: continuumio/miniconda3:4.6.14
+      - image: continuumio/miniconda3:4.7.12
     environment:
       - CONDA_PYTHON_VER: "3.7"
       - TEST_TOX_ENV: "py37"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,10 @@ references:
   no_filters: &no_filters
     filters:
       tags:
-        only: /.*/
+        ignore:
+          # exclude tags created by "ci_addons publish_github_release"
+          - /^latest$/
+          - /^latest-tmp$/
 
 jobs:
   flake8:
@@ -293,6 +296,11 @@ workflows:
             - gallery36
             - gallery37
           filters:
+            tags:
+              ignore:
+                # exclude tags created by "ci_addons publish_github_release"
+                - /^latest$/
+                - /^latest-tmp$/
             branches:
               only: dev
       - deploy-release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -209,14 +209,14 @@ jobs:
 
   gallery37:
     docker:
-      - image: dozturk2/python37-hdf5
+      - image: circleci/python:3.7.6-stretch
     environment:
      - TEST_TOX_ENV: "gallery-py37"
     <<: *gallery-steps
 
   deploy-dev:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: circleci/python:3.7.6-stretch
     steps:
       - checkout
       - attach_workspace:
@@ -238,7 +238,7 @@ jobs:
 
   deploy-release:
     docker:
-      - image: circleci/python:3.7.0-stretch
+      - image: circleci/python:3.7.6-stretch
     steps:
       - attach_workspace:
           at: ./

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ jobs:
         imageName: 'macos-10.13'
         pythonVersion: '3.7'
         testToxEnv: 'py37'
-        coverageToxEnv: 'coverage-py37'
+        coverageToxEnv: 'coverage'
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall-py37'
 
@@ -17,7 +17,7 @@ jobs:
         imageName: 'macos-10.13'
         pythonVersion: '3.6'
         testToxEnv: 'py36'
-        coverageToxEnv: 'coverage-py36'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall-py36'
 
@@ -25,7 +25,7 @@ jobs:
         imageName: 'macos-10.13'
         pythonVersion: '3.5'
         testToxEnv: 'py35'
-        coverageToxEnv: 'coverage-py35'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
 
@@ -33,7 +33,7 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.7'
         testToxEnv: 'py37'
-        coverageToxEnv: 'coverage-py37'
+        coverageToxEnv: 'coverage'
         buildToxEnv: 'build-py37'
         testWheelInstallEnv: 'wheelinstall-py37'
 
@@ -41,7 +41,7 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.6'
         testToxEnv: 'py36'
-        coverageToxEnv: 'coverage-py36'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py36'
         testWheelInstallEnv: 'wheelinstall-py36'
 
@@ -49,7 +49,7 @@ jobs:
         imageName: 'vs2017-win2016'
         pythonVersion: '3.5'
         testToxEnv: 'py35'
-        coverageToxEnv: 'coverage-py35'
+        coverageToxEnv: ''
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
 
@@ -77,8 +77,10 @@ jobs:
     displayName: 'Run tox tests'
 
   - bash: |
-      tox -e $(coverageToxEnv)
-    displayName: 'Run coverage tests'
+      if [[ "$(coverageToxEnv)" != "" ]]; then
+        tox -e $(coverageToxEnv)
+      fi
+    displayName: 'Run coverage tests if coverageToxEnv != ""'
 
   - bash: |
       tox -e $(buildToxEnv)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[wheel]
+[bdist_wheel]
 universal = 1
 
 [versioneer]

--- a/tox.ini
+++ b/tox.ini
@@ -47,25 +47,12 @@ commands = {[testenv:build]commands}
 
 # Envs that will only be executed on CI that does coverage reporting
 [testenv:coverage]
+passenv = CODECOV_TOKEN
+basepython = python3.7
 commands =
     coverage run test.py --pynwb
     coverage report -m
     codecov -X fix
-
-[testenv:coverage-py35]
-passenv = CODECOV_TOKEN
-basepython = python3.5
-commands = {[testenv:coverage]commands}
-
-[testenv:coverage-py36]
-passenv = CODECOV_TOKEN
-basepython = python3.6
-commands = {[testenv:coverage]commands}
-
-[testenv:coverage-py37]
-passenv = CODECOV_TOKEN
-basepython = python3.7
-commands = {[testenv:coverage]commands}
 
 # Envs that will test installation from a wheel
 [testenv:wheelinstall-py35]


### PR DESCRIPTION
- Do not run CI on latest and latest-tmp tags. This should stop the workflow failed emails and wasted CI cycles (parallel PR https://github.com/hdmf-dev/hdmf/pull/254)
- Run coverage tests only on py37 (parallel PR https://github.com/hdmf-dev/hdmf/pull/258)
- Update CI images
- Update deprecated wheel tag in setup.cfg