### PR TITLE
Remove unittest2 dependency

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,5 @@
 codecov==2.0.15
 coverage==4.5.4
 flake8==3.7.8
-pytz==2019.2
 tox==3.14.0
-traceback2==1.4.0
-unittest2==1.1.0
 -r requirements.txt

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -1,9 +1,5 @@
 from warnings import warn
-
-try:
-    from collections.abc import Iterable  # Python 3
-except ImportError:
-    from collections import Iterable  # Python 2.7
+from collections.abc import Iterable
 
 from hdmf.utils import docval, getargs, popargs, call_docval_func
 from hdmf.common import DynamicTable

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Iterable  # Python 3
-except ImportError:
-    from collections import Iterable  # Python 2.7
+from collections.abc import Iterable
 
 from hdmf.utils import docval, getargs, popargs, call_docval_func, get_docval
 from hdmf.data_utils import DataChunkIterator, assertEqualShape

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -1,9 +1,6 @@
 from datetime import datetime
 from dateutil.tz import tzlocal
-try:
-    from collections.abc import Iterable  # Python 3
-except ImportError:
-    from collections import Iterable  # Python 2.7
+from collections.abc import Iterable
 from warnings import warn
 import copy as _copy
 

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -1,8 +1,5 @@
 import warnings
-try:
-    from collections.abc import Iterable  # Python 3
-except ImportError:
-    from collections import Iterable  # Python 2.7
+from collections.abc import Iterable
 
 from hdmf.utils import docval, popargs, call_docval_func, get_docval
 

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -1,8 +1,5 @@
 import numpy as np
-try:
-    from collections.abc import Iterable  # Python 3
-except ImportError:
-    from collections import Iterable  # Python 2.7
+from collections.abc import Iterable
 import warnings
 from bisect import bisect_left, bisect_right
 

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Iterable  # Python 3
-except ImportError:
-    from collections import Iterable  # Python 2.7
+from collections.abc import Iterable
 
 from hdmf.utils import docval, getargs, popargs, call_docval_func, get_docval
 

--- a/src/pynwb/retinotopy.py
+++ b/src/pynwb/retinotopy.py
@@ -1,7 +1,4 @@
-try:
-    from collections.abc import Iterable  # Python 3
-except ImportError:
-    from collections import Iterable  # Python 2.7
+from collections.abc import Iterable
 
 from hdmf.utils import docval, popargs, call_docval_func
 

--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 from argparse import ArgumentParser

--- a/test.py
+++ b/test.py
@@ -12,7 +12,7 @@ import os.path
 import os
 import sys
 import traceback
-import unittest2 as unittest
+import unittest
 from tests.coloredtestrunner import ColoredTestRunner, ColoredTestResult
 
 flags = {'pynwb': 2, 'integration': 3, 'example': 4}

--- a/test.py
+++ b/test.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-
-from __future__ import print_function
-
 import warnings
 import re
 import argparse

--- a/tests/coloredtestrunner.py
+++ b/tests/coloredtestrunner.py
@@ -48,7 +48,7 @@ except ImportError:
     from io import StringIO
 import sys
 import re
-import unittest2 as unittest
+import unittest
 import textwrap
 
 

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 from datetime import datetime
 from dateutil.tz import tzlocal, tzutc
 import re

--- a/tests/integration/test_io.py
+++ b/tests/integration/test_io.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 from datetime import datetime
 from dateutil.tz import tzlocal, tzutc
 import re

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 from datetime import datetime
 from dateutil.tz import tzlocal, tzutc
 import os

--- a/tests/integration/ui_write/base.py
+++ b/tests/integration/ui_write/base.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 from datetime import datetime
 from dateutil.tz import tzlocal, tzutc
 import os

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 
 from hdmf.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder
 

--- a/tests/integration/ui_write/test_ecephys.py
+++ b/tests/integration/ui_write/test_ecephys.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 
 from hdmf.build import GroupBuilder, DatasetBuilder, LinkBuilder, ReferenceBuilder
 

--- a/tests/integration/ui_write/test_legacy.py
+++ b/tests/integration/ui_write/test_legacy.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest2 as unittest
+import unittest as unittest
 
 import pynwb
 

--- a/tests/integration/ui_write/test_legacy.py
+++ b/tests/integration/ui_write/test_legacy.py
@@ -1,6 +1,6 @@
 import os
 
-import unittest as unittest
+import unittest
 
 import pynwb
 

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 import numpy as np
 from copy import deepcopy
 

--- a/tests/integration/ui_write/test_ophys.py
+++ b/tests/integration/ui_write/test_ophys.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 import numpy as np
 from copy import deepcopy
 

--- a/tests/unit/test_MultiContainerInterface.py
+++ b/tests/unit/test_MultiContainerInterface.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 
 from pynwb.file import MultiContainerInterface, NWBDataInterface
 from hdmf.utils import docval, get_docval

--- a/tests/unit/test_MultiContainerInterface.py
+++ b/tests/unit/test_MultiContainerInterface.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 
 from pynwb.file import MultiContainerInterface, NWBDataInterface
 from hdmf.utils import docval, get_docval

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 import numpy as np
 
 from pynwb.base import ProcessingModule, TimeSeries, Images, Image

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 import numpy as np
 
 from pynwb.base import ProcessingModule, TimeSeries, Images, Image

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-import unittest as unittest
+import unittest
 from dateutil.tz import tzlocal
 from pynwb import NWBFile, TimeSeries, available_namespaces
 from pynwb.core import LabelledDict

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-import unittest2 as unittest
+import unittest as unittest
 from dateutil.tz import tzlocal
 from pynwb import NWBFile, TimeSeries, available_namespaces
 from pynwb.core import LabelledDict

--- a/tests/unit/test_core_NWBContainer.py
+++ b/tests/unit/test_core_NWBContainer.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 
 from pynwb.core import NWBContainer
 from hdmf.utils import docval, call_docval_func

--- a/tests/unit/test_core_NWBContainer.py
+++ b/tests/unit/test_core_NWBContainer.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 
 from pynwb.core import NWBContainer
 from hdmf.utils import docval, call_docval_func

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -1,4 +1,4 @@
-import unittest as unittest
+import unittest
 import re
 import numpy as np
 

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest as unittest
 import re
 import numpy as np
 

--- a/tests/unit/test_extension.py
+++ b/tests/unit/test_extension.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from dateutil.tz import tzlocal
 from tempfile import gettempdir
 
-import unittest2 as unittest
+import unittest as unittest
 from pynwb import get_type_map, TimeSeries, NWBFile, register_class, docval, load_namespaces, popargs, get_class
 from hdmf.spec.spec import RefSpec
 from hdmf.utils import get_docval

--- a/tests/unit/test_extension.py
+++ b/tests/unit/test_extension.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from dateutil.tz import tzlocal
 from tempfile import gettempdir
 
-import unittest as unittest
+import unittest
 from pynwb import get_type_map, TimeSeries, NWBFile, register_class, docval, load_namespaces, popargs, get_class
 from hdmf.spec.spec import RefSpec
 from hdmf.utils import get_docval

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -1,5 +1,5 @@
 ''' Tests for NWBFile '''
-import unittest2 as unittest
+import unittest
 import numpy as np
 import os
 import pandas as pd


### PR DESCRIPTION
Python 2 will no longer be supported, so we can remove the dependency and usage of unittest2 and  traceback2. This helps break up the mega PR https://github.com/NeurodataWithoutBorders/pynwb/pull/1117