### PR TITLE
Rename mixin classes to not start with Test*

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,0 +1,6 @@
+# these minimum requirements specify '==' for testing; setup.py replaces '==' with '>='
+h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
+hdmf==1.5.4,<2
+numpy==1.16
+pandas==0.23
+python-dateutil==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 h5py==2.10.0
-hdmf==1.5.3
+hdmf==1.5.4
 numpy==1.18.1
 pandas==0.25.3
 python-dateutil==2.8.0

--- a/src/pynwb/testing/__init__.py
+++ b/src/pynwb/testing/__init__.py
@@ -1,5 +1,5 @@
-from hdmf.testing import TestCase, TestH5RoundTripMixin
-from .testh5io import TestNWBH5IOMixin, TestAcquisitionH5IOMixin
+from hdmf.testing import TestCase, H5RoundTripMixin
+from .testh5io import NWBH5IOMixin, AcquisitionH5IOMixin
 from .utils import remove_test_file
 
 CORE_NAMESPACE = 'core'

--- a/src/pynwb/testing/testh5io.py
+++ b/src/pynwb/testing/testh5io.py
@@ -10,7 +10,7 @@ from hdmf.backends.warnings import BrokenLinkWarning
 from hdmf.build.warnings import MissingRequiredWarning, OrphanContainerWarning
 
 
-class TestNWBH5IOMixin(metaclass=ABCMeta):
+class NWBH5IOMixin(metaclass=ABCMeta):
     """
     Mixin class for methods to run a roundtrip test writing an NWB file with an Container and reading the Container
     from the NWB file. The setUp, test_roundtrip, and tearDown methods will be run by unittest.
@@ -19,7 +19,7 @@ class TestNWBH5IOMixin(metaclass=ABCMeta):
     this mixin.
 
     Example:
-    class TestMyContainerIO(TestNWBH5IOMixin, TestCase):
+    class TestMyContainerIO(NWBH5IOMixin, TestCase):
         def setUpContainer(self):
             # return a test Container to read/write
         def addContainer(self, nwbfile):
@@ -27,7 +27,7 @@ class TestNWBH5IOMixin(metaclass=ABCMeta):
         def getContainer(self, nwbfile):
             # return the test Container from an NWB file
 
-    This code is adapted from hdmf.testing.TestH5RoundTripMixin.
+    This code is adapted from hdmf.testing.H5RoundTripMixin.
     """
 
     def setUp(self):
@@ -120,7 +120,7 @@ class TestNWBH5IOMixin(metaclass=ABCMeta):
                         raise Exception(err)
 
 
-class TestAcquisitionH5IOMixin(TestNWBH5IOMixin):
+class AcquisitionH5IOMixin(NWBH5IOMixin):
     """
     Mixin class for methods to run a roundtrip test writing an NWB file with an Container as an acquisition and reading
     the Container as an acquisition from the NWB file. The setUp, test_roundtrip, and tearDown methods will be run by
@@ -129,11 +129,11 @@ class TestAcquisitionH5IOMixin(TestNWBH5IOMixin):
     The abstract method setUpContainer needs to be implemented by classes that include this mixin.
 
     Example:
-    class TestMyContainerIO(TestNWBH5IOMixin, TestCase):
+    class TestMyContainerIO(NWBH5IOMixin, TestCase):
         def setUpContainer(self):
             # return a test Container to read/write
 
-    This code is adapted from hdmf.testing.TestH5RoundTripMixin.
+    This code is adapted from hdmf.testing.H5RoundTripMixin.
     """
 
     def addContainer(self, nwbfile):

--- a/tests/integration/hdf5/test_base.py
+++ b/tests/integration/hdf5/test_base.py
@@ -3,10 +3,10 @@ from datetime import datetime
 from dateutil.tz import tzlocal
 
 from pynwb import TimeSeries, NWBFile, NWBHDF5IO
-from pynwb.testing import TestAcquisitionH5IOMixin, TestCase
+from pynwb.testing import AcquisitionH5IOMixin, TestCase
 
 
-class TestTimeSeriesIO(TestAcquisitionH5IOMixin, TestCase):
+class TestTimeSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test TimeSeries to read/write """

--- a/tests/integration/hdf5/test_device.py
+++ b/tests/integration/hdf5/test_device.py
@@ -1,8 +1,8 @@
 from pynwb.device import Device
-from pynwb.testing import TestNWBH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, TestCase
 
 
-class TestDeviceIO(TestNWBH5IOMixin, TestCase):
+class TestDeviceIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test Device to read/write """

--- a/tests/integration/hdf5/test_ecephys.py
+++ b/tests/integration/hdf5/test_ecephys.py
@@ -4,10 +4,10 @@ from pynwb.ecephys import ElectrodeGroup, ElectricalSeries, FilteredEphys, LFP, 
                           SpikeEventSeries, EventWaveform, EventDetection, FeatureExtraction
 from pynwb.device import Device
 from pynwb.file import ElectrodeTable as get_electrode_table
-from pynwb.testing import TestNWBH5IOMixin, TestAcquisitionH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, AcquisitionH5IOMixin, TestCase
 
 
-class TestElectrodeGroupIO(TestNWBH5IOMixin, TestCase):
+class TestElectrodeGroupIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test ElectrodeGroup to read/write """
@@ -25,7 +25,7 @@ class TestElectrodeGroupIO(TestNWBH5IOMixin, TestCase):
         return nwbfile.get_electrode_group(self.container.name)
 
 
-class TestElectricalSeriesIO(TestAcquisitionH5IOMixin, TestCase):
+class TestElectricalSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     @staticmethod
     def make_electrode_table(self):
@@ -66,7 +66,7 @@ class TestElectricalSeriesIO(TestAcquisitionH5IOMixin, TestCase):
         self.assertIsInstance(row2.iloc[0]['group'], ElectrodeGroup)
 
 
-class TestMultiElectricalSeriesIOMixin(TestAcquisitionH5IOMixin):
+class MultiElectricalSeriesIOMixin(AcquisitionH5IOMixin):
     """
     Mixin class for methods to run a roundtrip test writing an NWB file with multiple ElectricalSeries.
 
@@ -95,7 +95,7 @@ class TestMultiElectricalSeriesIOMixin(TestAcquisitionH5IOMixin):
         nwbfile.add_acquisition(self.container)
 
 
-class TestLFPIO(TestMultiElectricalSeriesIOMixin, TestCase):
+class TestLFPIO(MultiElectricalSeriesIOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test LFP to read/write """
@@ -104,7 +104,7 @@ class TestLFPIO(TestMultiElectricalSeriesIOMixin, TestCase):
         return lfp
 
 
-class TestFilteredEphysIO(TestMultiElectricalSeriesIOMixin, TestCase):
+class TestFilteredEphysIO(MultiElectricalSeriesIOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test FilteredEphys to read/write """
@@ -113,7 +113,7 @@ class TestFilteredEphysIO(TestMultiElectricalSeriesIOMixin, TestCase):
         return fe
 
 
-class TestClusteringIO(TestAcquisitionH5IOMixin, TestCase):
+class TestClusteringIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test Clustering to read/write """
@@ -127,7 +127,7 @@ class TestClusteringIO(TestAcquisitionH5IOMixin, TestCase):
             return super().roundtripContainer(cache_spec)
 
 
-class EventWaveformConstructor(TestAcquisitionH5IOMixin, TestCase):
+class EventWaveformConstructor(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test EventWaveform to read/write """
@@ -145,7 +145,7 @@ class EventWaveformConstructor(TestAcquisitionH5IOMixin, TestCase):
         nwbfile.add_acquisition(self.container)
 
 
-class ClusterWaveformsConstructor(TestAcquisitionH5IOMixin, TestCase):
+class ClusterWaveformsConstructor(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test ClusterWaveforms to read/write """
@@ -171,7 +171,7 @@ class ClusterWaveformsConstructor(TestAcquisitionH5IOMixin, TestCase):
             return super().roundtripContainer(cache_spec)
 
 
-class FeatureExtractionConstructor(TestAcquisitionH5IOMixin, TestCase):
+class FeatureExtractionConstructor(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test FeatureExtraction to read/write """
@@ -191,7 +191,7 @@ class FeatureExtractionConstructor(TestAcquisitionH5IOMixin, TestCase):
         nwbfile.add_acquisition(self.container)
 
 
-class EventDetectionConstructor(TestAcquisitionH5IOMixin, TestCase):
+class EventDetectionConstructor(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test EventDetection to read/write """

--- a/tests/integration/hdf5/test_icephys.py
+++ b/tests/integration/hdf5/test_icephys.py
@@ -1,5 +1,3 @@
-from abc import ABCMeta
-
 from pynwb import NWBFile
 from pynwb.icephys import (IntracellularElectrode, PatchClampSeries, CurrentClampStimulusSeries,
                            SweepTable, VoltageClampStimulusSeries, CurrentClampSeries,

--- a/tests/integration/hdf5/test_icephys.py
+++ b/tests/integration/hdf5/test_icephys.py
@@ -5,10 +5,10 @@ from pynwb.icephys import (IntracellularElectrode, PatchClampSeries, CurrentClam
                            SweepTable, VoltageClampStimulusSeries, CurrentClampSeries,
                            VoltageClampSeries, IZeroClampSeries)
 from pynwb.device import Device
-from pynwb.testing import TestNWBH5IOMixin, TestAcquisitionH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, AcquisitionH5IOMixin, TestCase
 
 
-class TestIntracellularElectrode(TestNWBH5IOMixin, TestCase):
+class TestIntracellularElectrode(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test IntracellularElectrode to read/write """
@@ -32,7 +32,7 @@ class TestIntracellularElectrode(TestNWBH5IOMixin, TestCase):
         return nwbfile.get_ic_electrode(self.container.name)
 
 
-class TestPatchClampSeries(TestAcquisitionH5IOMixin, metaclass=ABCMeta):
+class TestPatchClampSeries(AcquisitionH5IOMixin, TestCase):
 
     def setUpElectrode(self):
         """ Set up the test IntracellularElectrode """
@@ -111,7 +111,7 @@ class TestIZeroClampSeries(TestPatchClampSeries):
                                 starting_time=123.6, rate=10e3, electrode=self.elec, gain=0.126)
 
 
-class TestSweepTableRoundTripEasy(TestNWBH5IOMixin, TestCase):
+class TestSweepTableRoundTripEasy(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test SweepTable to read/write """
@@ -154,7 +154,7 @@ class TestSweepTableRoundTripEasy(TestNWBH5IOMixin, TestCase):
         self.assertEqual(sweep_table['sweep_number'].data[0], 4711)
 
 
-class TestSweepTableRoundTripComplicated(TestNWBH5IOMixin, TestCase):
+class TestSweepTableRoundTripComplicated(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test SweepTable to read/write """

--- a/tests/integration/hdf5/test_image.py
+++ b/tests/integration/hdf5/test_image.py
@@ -1,10 +1,10 @@
 import numpy as np
 
 from pynwb.image import OpticalSeries
-from pynwb.testing import TestNWBH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, TestCase
 
 
-class TestOpticalSeriesIO(TestNWBH5IOMixin, TestCase):
+class TestOpticalSeriesIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return a test OpticalSeries to read/write """

--- a/tests/integration/hdf5/test_misc.py
+++ b/tests/integration/hdf5/test_misc.py
@@ -3,10 +3,10 @@ import numpy as np
 from hdmf.common import DynamicTable, VectorData
 from pynwb import TimeSeries
 from pynwb.misc import Units, DecompositionSeries
-from pynwb.testing import TestNWBH5IOMixin, TestAcquisitionH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, AcquisitionH5IOMixin, TestCase
 
 
-class TestUnitsIO(TestAcquisitionH5IOMixin, TestCase):
+class TestUnitsIO(AcquisitionH5IOMixin, TestCase):
     """ Test adding Units into acquisition and accessing Units after read """
 
     def setUpContainer(self):
@@ -35,7 +35,7 @@ class TestUnitsIO(TestAcquisitionH5IOMixin, TestCase):
         self.assertTrue(np.array_equal(ut['obs_intervals'][:], [[[0, 1], [2, 3]], [[2, 5], [6, 7]]]))
 
 
-class TestUnitsFileIO(TestNWBH5IOMixin, TestCase):
+class TestUnitsFileIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return placeholder Units object. Tested units are added directly to the NWBFile in addContainer """
@@ -71,7 +71,7 @@ class TestUnitsFileIO(TestNWBH5IOMixin, TestCase):
         units.to_dataframe()
 
 
-class TestDecompositionSeriesIO(TestNWBH5IOMixin, TestCase):
+class TestDecompositionSeriesIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test DecompositionSeries to read/write """

--- a/tests/integration/hdf5/test_nwbfile.py
+++ b/tests/integration/hdf5/test_nwbfile.py
@@ -10,7 +10,7 @@ from pynwb import NWBFile, TimeSeries, NWBHDF5IO, get_manager
 from pynwb.file import Subject
 from pynwb.epoch import TimeIntervals
 from pynwb.ecephys import ElectricalSeries
-from pynwb.testing import TestNWBH5IOMixin, TestCase, remove_test_file
+from pynwb.testing import NWBH5IOMixin, TestCase, remove_test_file
 
 
 class TestNWBFileHDF5IO(TestCase):
@@ -89,9 +89,9 @@ class TestNWBFileHDF5IO(TestCase):
         hdf5io.close()
 
 
-class TestNWBFileIO(TestNWBH5IOMixin, TestCase):
+class TestNWBFileIO(NWBH5IOMixin, TestCase):
     """ Test writing an NWBFile to disk and reading back the file """
-    # this uses methods tearDown, test_roundtrip, and validate from TestNWBH5IOMixin. the rest are overridden
+    # this uses methods tearDown, test_roundtrip, and validate from NWBH5IOMixin. the rest are overridden
 
     def setUp(self):
         super().setUp()
@@ -190,7 +190,7 @@ class TestPublicationsSetterRoundtrip(TestNWBFileIO):
         self.nwbfile.related_publications = ('pub1', 'pub2')
 
 
-class TestSubjectIO(TestNWBH5IOMixin, TestCase):
+class TestSubjectIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test Subject """
@@ -218,7 +218,7 @@ class TestEmptySubjectIO(TestSubjectIO):
         return Subject()
 
 
-class TestEpochsIO(TestNWBH5IOMixin, TestCase):
+class TestEpochsIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return placeholder epochs object. Tested epochs are added directly to the NWBFile in addContainer """
@@ -335,7 +335,7 @@ class TestEpochsIODf(TestEpochsIO):
         pd.testing.assert_frame_equal(df_exp, df_obt, check_like=True, check_dtype=False)
 
 
-class TestTrials(TestNWBH5IOMixin, TestCase):
+class TestTrials(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return placeholder Table for trials. Tested trials are added directly to the NWBFile in addContainer """
@@ -357,7 +357,7 @@ class TestTrials(TestNWBH5IOMixin, TestCase):
         return nwbfile.trials
 
 
-class TestInvalidTimes(TestNWBH5IOMixin, TestCase):
+class TestInvalidTimes(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """
@@ -381,7 +381,7 @@ class TestInvalidTimes(TestNWBH5IOMixin, TestCase):
         return nwbfile.invalid_times
 
 
-class TestUnits(TestNWBH5IOMixin, TestCase):
+class TestUnits(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return placeholder table for Units. Tested units are added directly to the NWBFile in addContainer """
@@ -401,7 +401,7 @@ class TestUnits(TestNWBH5IOMixin, TestCase):
         return nwbfile.units
 
 
-class TestDynamicTableFromDataframeIO(TestNWBH5IOMixin, TestCase):
+class TestDynamicTableFromDataframeIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         return DynamicTable.from_dataframe(pd.DataFrame({
@@ -424,7 +424,7 @@ class TestDynamicTableFromDataframeIO(TestNWBH5IOMixin, TestCase):
         dyn_tab.to_dataframe()  # also test 2D column round-trip
 
 
-class TestElectrodes(TestNWBH5IOMixin, TestCase):
+class TestElectrodes(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """
@@ -460,7 +460,7 @@ class TestElectrodes(TestNWBH5IOMixin, TestCase):
                                       self.container[0].drop('group', axis=1))
 
 
-class TestElectrodesRegion(TestNWBH5IOMixin, TestCase):
+class TestElectrodesRegion(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """

--- a/tests/integration/hdf5/test_ogen.py
+++ b/tests/integration/hdf5/test_ogen.py
@@ -1,9 +1,9 @@
 from pynwb.ogen import OptogeneticSeries, OptogeneticStimulusSite
 from pynwb.device import Device
-from pynwb.testing import TestNWBH5IOMixin, TestAcquisitionH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, AcquisitionH5IOMixin, TestCase
 
 
-class TestOptogeneticStimulusSiteIO(TestNWBH5IOMixin, TestCase):
+class TestOptogeneticStimulusSiteIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test OptogeneticStimulusSite to read/write """
@@ -20,7 +20,7 @@ class TestOptogeneticStimulusSiteIO(TestNWBH5IOMixin, TestCase):
         return nwbfile.get_ogen_site(self.container.name)
 
 
-class TestOptogeneticSeriesIO(TestAcquisitionH5IOMixin, TestCase):
+class TestOptogeneticSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test OptogeneticSeries to read/write """

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -11,10 +11,10 @@ from pynwb.ophys import (
 )
 from pynwb.image import ImageSeries
 from pynwb.device import Device
-from pynwb.testing import TestNWBH5IOMixin, TestAcquisitionH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, AcquisitionH5IOMixin, TestCase
 
 
-class TestImagingPlaneIO(TestNWBH5IOMixin, TestCase):
+class TestImagingPlaneIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test ImagingPlane to read/write """
@@ -33,7 +33,7 @@ class TestImagingPlaneIO(TestNWBH5IOMixin, TestCase):
         return nwbfile.get_imaging_plane(self.container.name)
 
 
-class TestTwoPhotonSeriesIO(TestAcquisitionH5IOMixin, TestCase):
+class TestTwoPhotonSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def make_imaging_plane(self):
         """ Make an ImagingPlane and related objects """
@@ -59,7 +59,7 @@ class TestTwoPhotonSeriesIO(TestAcquisitionH5IOMixin, TestCase):
         nwbfile.add_acquisition(self.container)
 
 
-class TestPlaneSegmentationIO(TestNWBH5IOMixin, TestCase):
+class TestPlaneSegmentationIO(NWBH5IOMixin, TestCase):
 
     @staticmethod
     def buildPlaneSegmentation(self):
@@ -164,7 +164,7 @@ class TestImageMaskIO(MaskIO):
         return pS
 
 
-class TestRoiResponseSeriesIO(TestAcquisitionH5IOMixin, TestCase):
+class TestRoiResponseSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test RoiResponseSeries to read/write """

--- a/tests/integration/hdf5/test_scratch.py
+++ b/tests/integration/hdf5/test_scratch.py
@@ -4,10 +4,10 @@ from numpy.testing import assert_array_equal
 
 from pynwb import NWBFile, NWBHDF5IO, TimeSeries
 from pynwb.core import ScratchData
-from pynwb.testing import TestNWBH5IOMixin, TestCase
+from pynwb.testing import NWBH5IOMixin, TestCase
 
 
-class TestScratchDataIO(TestNWBH5IOMixin, TestCase):
+class TestScratchDataIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test ScratchData to read/write """


### PR DESCRIPTION
Fix #1152. Requires HDMF 1.5.4. 