### PR TITLE
Fix readthedocs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -21,3 +21,8 @@ python:
   install:
     - requirements: requirements-doc.txt
     - requirements: requirements.txt
+
+# Optionally include all submodules
+submodules:
+  include: all
+  recursive: true

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  install:
+    - requirements: requirements-doc.txt
+    - requirements: requirements.txt


### PR DESCRIPTION
The ReadTheDocs build failed due to changes in the environment setup. This PR adds a .readthedocs.yaml file to configure ReadTheDocs for multiple requirements files. 

The docs build successfully for this branch here: https://pynwb.readthedocs.io/en/fix-docs/

This will be released as PyNWB 1.2.1.