### PR TITLE
Update manifest to include requirements-min.txt to fix conda

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include license.txt Legal.txt versioneer.py src/pynwb/_version.py
-include requirements.txt requirements-dev.txt requirements-doc.txt
+include requirements.txt requirements-dev.txt requirements-doc.txt requirements-min.txt
 include test.py tox.ini
-
 
 graft tests


### PR DESCRIPTION
The conda build fails because the new `requirements-min.txt` is missing from `MANIFEST.in`. This PR adds the file to the manifest. 

This will be included in PyNWB 1.2.1.