### PR TITLE
.gitattributes: Treat IPython notebooks as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 src/pynwb/_version.py export-subst
+*.ipynb -text -diff


### PR DESCRIPTION
As IPython notebooks also hold embedded images, these files turn up a
lot when searching with git grep.

As these files are pretty stable as well, there is little use in
searching in them.