### PR TITLE
docs: Use hdmf-docutils instead of deprecated nwb-docutils

### DIFF
--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -319,11 +319,11 @@ Documenting Extensions
 Using the same tools used to generate the documentation for the `NWB-N core format <https://nwb-schema.readthedocs.io/en/latest/>`_
 one can easily generate documentation in HTML, PDF, ePub and many other format for extensions as well.
 
-Code to generate this documentation is maintained in a separate repo: https://github.com/NeurodataWithoutBorders/nwb-docutils. To use these utilities, install the package with pip:
+Code to generate this documentation is maintained in a separate repo: https://github.com/hdmf-dev/hdmf-docutils. To use these utilities, install the package with pip:
 
 .. code-block:: text
 
-    pip install nwb-docutils
+    pip install hdmf-docutils
 
 For the purpose of this example, we assume that our current directory has the following structure.
 


### PR DESCRIPTION
Update extension tutorial to have up-to-date information

```
make htmldoc
```


- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?