### PR TITLE
NF: initial setup for ASV benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,9 @@ tests/coverage/htmlcov
 
 # macos
 .DS_Store
+
+# ASV benchmarks artifacts
+benchmarks/results
+benchmarks/html
+benchmarks/env
+benchmarks/pynwb

--- a/benchmarks/README.rst
+++ b/benchmarks/README.rst
@@ -1,0 +1,62 @@
+..  -*- rst -*-
+
+================
+PyNWB benchmarks
+================
+
+Benchmarking PyNWB with Airspeed Velocity.
+
+
+Usage
+-----
+
+Run ASV commands (record results and generate HTML)::
+
+    cd benchmarks
+    asv run --skip-existing-commits --steps 10 ALL
+    asv publish
+    asv preview
+
+More on how to use ``asv`` can be found in `ASV documentation`_
+Command-line help is available as usual via ``asv --help`` and
+``asv run --help``.
+
+.. _ASV documentation: https://asv.readthedocs.io/
+
+
+Writing benchmarks
+------------------
+
+See `ASV documentation`_ for basics on how to write benchmarks.
+
+Some things to consider:
+
+- The benchmark suite should be importable with any PyNWB version (>= TODO).
+
+- The benchmark parameters etc. should not depend on which PyNWB version
+  is installed.
+
+- Try to keep the runtime of the benchmark reasonable.
+
+- Prefer ASV's ``time_`` methods for benchmarking times rather than cooking up
+  time measurements via ``time.clock``, even if it requires some juggling when
+  writing the benchmark.
+
+- Preparing arrays etc. should generally be put in the ``setup`` method rather
+  than the ``time_`` methods, to avoid counting preparation time together with
+  the time of the benchmarked operation.
+
+- Be mindful that large arrays created with ``np.empty`` or ``np.zeros`` might
+  not be allocated in physical memory until the memory is accessed. If this is
+  desired behaviour, make sure to comment it in your setup function. If
+  you are benchmarking an algorithm, it is unlikely that a user will be
+  executing said algorithm on a newly created empty/zero array. One can force
+  pagefaults to occur in the setup phase either by calling ``np.ones`` or
+  ``arr.fill(value)`` after creating the array,
+
+
+Acknowledgement
+---------------
+
+Benchmarks setup is bootstrapped from NumPy project benchmarks.
+NumPy is Copyrighted by NumPy Developers, and distributed under BSD-3 license.

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -1,0 +1,84 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "pynwb",
+
+    // The project's homepage
+    "project_url": "https://github.com/NeurodataWithoutBorders/pynwb/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "..",
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "tip" (for mercurial).
+    "branches": ["dev"],
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "virtualenv",
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/NeurodataWithoutBorders/pynwb/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["3.7"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list indicates to just test against the default (latest)
+    // version.
+    "matrix": {
+    },
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": "env",
+
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": "results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": "html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache wheels of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // number of builds to keep, per environment.
+    "build_cache_size": 8,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // }
+}

--- a/benchmarks/benchmarks/__init__.py
+++ b/benchmarks/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+from . import common  # noqa: F401

--- a/benchmarks/benchmarks/bench_create.py
+++ b/benchmarks/benchmarks/bench_create.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from dateutil.tz import tzlocal
+
+import numpy as np
+from pynwb import NWBFile, TimeSeries
+
+from .common import Benchmark
+
+# Common useful pre-instantiated variables
+# which do not need to be re-created and could be reused across benchmarks
+
+start_time = datetime(2019, 4, 3, 11, tzinfo=tzlocal())
+timestamps = np.linspace(0, 100, 1024)
+timeseries_data = np.sin(0.333 * timestamps) + np.cos(0.1 * timestamps)
+
+
+class Create(Benchmark):
+
+    def time_NWBFile(self):
+        NWBFile(session_description='benchmark',
+                identifier='SOME',
+                session_start_time=start_time)
+
+    def time_TimeSeries(self):
+        TimeSeries(
+            name='raw_timeseries',
+            data=timeseries_data,
+            unit='m',
+            timestamps=timestamps)

--- a/benchmarks/benchmarks/bench_import.py
+++ b/benchmarks/benchmarks/bench_import.py
@@ -1,0 +1,21 @@
+from subprocess import call
+from sys import executable
+from timeit import default_timer
+
+from .common import Benchmark
+
+
+class Import(Benchmark):
+    timer = default_timer
+
+    def execute(self, command):
+        call((executable, '-c', command))
+
+    def time_h5py(self):
+        # h5py might be taking too long to import on MPI-enabled builds
+        # and that would mask pynwb imports,  So let's monitor this import
+        # as well
+        self.execute('import h5py')
+
+    def time_pynwb(self):
+        self.execute('import pynwb')

--- a/benchmarks/benchmarks/common.py
+++ b/benchmarks/benchmarks/common.py
@@ -1,0 +1,117 @@
+import numpy
+import random
+
+# Various pre-crafted datasets/variables for testing
+# !!! Must not be changed -- only appended !!!
+# while testing numpy we better not rely on numpy to produce random
+# sequences
+random.seed(1)
+# but will seed it nevertheless
+numpy.random.seed(1)
+
+nx, ny = 1000, 1000
+# reduced squares based on indexes_rand, primarily for testing more
+# time-consuming functions (ufunc, linalg, etc)
+nxs, nys = 100, 100
+
+# a set of interesting types to test
+TYPES1 = [
+    'int16', 'float16',
+    'int32', 'float32',
+    'int64', 'float64',  'complex64',
+    'longfloat', 'complex128',
+]
+if 'complex256' in numpy.typeDict:
+    TYPES1.append('complex256')
+
+
+def memoize(func):
+    result = []
+
+    def wrapper():
+        if not result:
+            result.append(func())
+        return result[0]
+    return wrapper
+
+
+# values which will be used to construct our sample data matrices
+# replicate 10 times to speed up initial imports of this helper
+# and generate some redundancy
+
+@memoize
+def get_values():
+    rnd = numpy.random.RandomState(1)
+    values = numpy.tile(rnd.uniform(0, 100, size=nx*ny//10), 10)
+    return values
+
+
+@memoize
+def get_squares():
+    values = get_values()
+    squares = {t: numpy.array(values,
+                              dtype=getattr(numpy, t)).reshape((nx, ny))
+               for t in TYPES1}
+
+    # adjust complex ones to have non-degenerated imagery part -- use
+    # original data transposed for that
+    for t, v in squares.items():
+        if t.startswith('complex'):
+            v += v.T*1j
+    return squares
+
+
+@memoize
+def get_squares_():
+    # smaller squares
+    squares_ = {t: s[:nxs, :nys] for t, s in get_squares().items()}
+    return squares_
+
+
+@memoize
+def get_vectors():
+    # vectors
+    vectors = {t: s[0] for t, s in get_squares().items()}
+    return vectors
+
+
+@memoize
+def get_indexes():
+    indexes = list(range(nx))
+    # so we do not have all items
+    indexes.pop(5)
+    indexes.pop(95)
+
+    indexes = numpy.array(indexes)
+    return indexes
+
+
+@memoize
+def get_indexes_rand():
+    rnd = random.Random(1)
+
+    indexes_rand = get_indexes().tolist()       # copy
+    rnd.shuffle(indexes_rand)         # in-place shuffle
+    indexes_rand = numpy.array(indexes_rand)
+    return indexes_rand
+
+
+@memoize
+def get_indexes_():
+    # smaller versions
+    indexes = get_indexes()
+    indexes_ = indexes[indexes < nxs]
+    return indexes_
+
+
+@memoize
+def get_indexes_rand_():
+    indexes_rand = get_indexes_rand()
+    indexes_rand_ = indexes_rand[indexes_rand < nxs]
+    return indexes_rand_
+
+
+class Benchmark:
+    """Base class to possibly tune up some parameters for all benchmarks centrally
+    """
+    pass


### PR DESCRIPTION
## Motivation

To establish benchmarking for pynwb (and possibly later for hdmf).

For more info about ASV, visit https://asv.readthedocs.io/en/stable/.  I took the base for this PR from numpy's benchmarks setup. 

See benchmarks/README.rst within this PR for sample invocation.  But most likely

If it would be decided to proceed with this
- get a dedicated box where to run those benchmarks from time to time, and publish to github gh-pages branch the results so github.io could be "ab"used.  E.g. that is what numpy https://pv.github.io/numpy-bench/ and datalad  http://datalad.github.io/datalad/ do
- populate with (more) meaningful benchmarks
- adopt a helper from datalad to provide `asv compare` run for each PR. See e.g. https://github.com/datalad/datalad/pull/4080/checks?check_run_id=427777839#step:7:223 for a sample report