### PR TITLE
Add 'unit' attribute back as an optional attribute in icephys classes

### DIFF
--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -1,11 +1,12 @@
+import warnings
+
+from hdmf.common import DynamicTable
 from hdmf.utils import docval, popargs, call_docval_func, get_docval
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries
 from .core import NWBContainer
 from .device import Device
-
-from hdmf.common import DynamicTable
 
 
 @register_class('IntracellularElectrode', CORE_NAMESPACE)
@@ -39,7 +40,7 @@ class IntracellularElectrode(NWBContainer):
         slice, seal, description, location, resistance, filtering, initial_access_resistance, device = popargs(
             'slice', 'seal', 'description', 'location', 'resistance',
             'filtering', 'initial_access_resistance', 'device', kwargs)
-        call_docval_func(super(IntracellularElectrode, self).__init__, kwargs)
+        call_docval_func(super().__init__, kwargs)
         self.slice = slice
         self.seal = seal
         self.description = description
@@ -79,7 +80,7 @@ class PatchClampSeries(TimeSeries):
     def __init__(self, **kwargs):
         name, data, unit, stimulus_description = popargs('name', 'data', 'unit', 'stimulus_description', kwargs)
         electrode, gain, sweep_number = popargs('electrode', 'gain', 'sweep_number', kwargs)
-        super(PatchClampSeries, self).__init__(name, data, unit, **kwargs)
+        super().__init__(name, data, unit, **kwargs)
         self.electrode = electrode
         self.gain = gain
         self.stimulus_description = stimulus_description
@@ -110,13 +111,18 @@ class CurrentClampSeries(PatchClampSeries):
             {'name': 'bridge_balance', 'type': 'float', 'doc': 'Unit: Ohm', 'default': None},
             {'name': 'capacitance_compensation', 'type': 'float', 'doc': 'Unit: Farad', 'default': None},
             *get_docval(PatchClampSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
-                        'comments', 'description', 'control', 'control_description', 'sweep_number'))
+                        'comments', 'description', 'control', 'control_description', 'sweep_number'),
+            {'name': 'unit', 'type': str, 'doc': "The base unit of measurement (must be 'volts')",
+             'default': 'volts'})
     def __init__(self, **kwargs):
-        name, data, electrode, gain = popargs('name', 'data', 'electrode', 'gain', kwargs)
+        name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
+        if unit != 'volts':
+            warnings.warn("Unit for %s '%s' is ignored and will be set to 'volts' as per NWB 2.1.0."
+                          % (self.__class__.__name__, name))
         unit = 'volts'
         bias_current, bridge_balance, capacitance_compensation = popargs(
             'bias_current', 'bridge_balance', 'capacitance_compensation', kwargs)
-        super(CurrentClampSeries, self).__init__(name, data, unit, electrode, gain, **kwargs)
+        super().__init__(name, data, unit, electrode, gain, **kwargs)
         self.bias_current = bias_current
         self.bridge_balance = bridge_balance
         self.capacitance_compensation = capacitance_compensation
@@ -137,12 +143,14 @@ class IZeroClampSeries(CurrentClampSeries):
             {'name': 'gain', 'type': 'float', 'doc': 'Units: Volt/Volt'},  # required
             *get_docval(CurrentClampSeries.__init__, 'stimulus_description', 'resolution', 'conversion', 'timestamps',
                         'starting_time', 'rate', 'comments', 'description', 'control', 'control_description',
-                        'sweep_number'))
+                        'sweep_number'),
+            {'name': 'unit', 'type': str, 'doc': "The base unit of measurement (must be 'volts')",
+             'default': 'volts'})
     def __init__(self, **kwargs):
         name, data, electrode, gain = popargs('name', 'data', 'electrode', 'gain', kwargs)
         bias_current, bridge_balance, capacitance_compensation = (0.0, 0.0, 0.0)
-        super(IZeroClampSeries, self).__init__(name, data, electrode, gain, bias_current,
-                                               bridge_balance, capacitance_compensation, **kwargs)
+        super().__init__(name, data, electrode, gain, bias_current, bridge_balance, capacitance_compensation,
+                         **kwargs)
 
 
 @register_class('CurrentClampStimulusSeries', CORE_NAMESPACE)
@@ -157,11 +165,16 @@ class CurrentClampStimulusSeries(PatchClampSeries):
     @docval(*get_docval(PatchClampSeries.__init__, 'name', 'data', 'electrode', 'gain'),  # required
             *get_docval(PatchClampSeries.__init__, 'stimulus_description', 'resolution', 'conversion', 'timestamps',
                         'starting_time', 'rate', 'comments', 'description', 'control', 'control_description',
-                        'sweep_number'))
+                        'sweep_number'),
+            {'name': 'unit', 'type': str, 'doc': "The base unit of measurement (must be 'amperes')",
+             'default': 'amperes'})
     def __init__(self, **kwargs):
-        name, data, electrode, gain = popargs('name', 'data', 'electrode', 'gain', kwargs)
+        name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
+        if unit != 'amperes':
+            warnings.warn("Unit for %s '%s' is ignored and will be set to 'amperes' as per "
+                          "NWB 2.1.0." % (self.__class__.__name__, name))
         unit = 'amperes'
-        super(CurrentClampStimulusSeries, self).__init__(name, data, unit, electrode, gain, **kwargs)
+        super().__init__(name, data, unit, electrode, gain, **kwargs)
 
 
 @register_class('VoltageClampSeries', CORE_NAMESPACE)
@@ -191,16 +204,21 @@ class VoltageClampSeries(PatchClampSeries):
             {'name': 'whole_cell_capacitance_comp', 'type': 'float', 'doc': 'Unit: Farad', 'default': None},
             {'name': 'whole_cell_series_resistance_comp', 'type': 'float', 'doc': 'Unit: Ohm', 'default': None},
             *get_docval(PatchClampSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
-                        'comments', 'description', 'control', 'control_description', 'sweep_number'))
+                        'comments', 'description', 'control', 'control_description', 'sweep_number'),
+            {'name': 'unit', 'type': str, 'doc': "The base unit of measurement (must be 'amperes')",
+             'default': 'amperes'})
     def __init__(self, **kwargs):
-        name, data, electrode, gain = popargs('name', 'data', 'electrode', 'gain', kwargs)
+        name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
+        if unit != 'amperes':
+            warnings.warn("Unit for %s '%s' is ignored and will be set to 'amperes' as per NWB 2.1.0."
+                          % (self.__class__.__name__, name))
         unit = 'amperes'
         capacitance_fast, capacitance_slow, resistance_comp_bandwidth, resistance_comp_correction, \
             resistance_comp_prediction, whole_cell_capacitance_comp, whole_cell_series_resistance_comp = popargs(
                 'capacitance_fast', 'capacitance_slow', 'resistance_comp_bandwidth',
                 'resistance_comp_correction', 'resistance_comp_prediction', 'whole_cell_capacitance_comp',
                 'whole_cell_series_resistance_comp', kwargs)
-        super(VoltageClampSeries, self).__init__(name, data, unit, electrode, gain, **kwargs)
+        super().__init__(name, data, unit, electrode, gain, **kwargs)
         self.capacitance_fast = capacitance_fast
         self.capacitance_slow = capacitance_slow
         self.resistance_comp_bandwidth = resistance_comp_bandwidth
@@ -222,11 +240,16 @@ class VoltageClampStimulusSeries(PatchClampSeries):
     @docval(*get_docval(PatchClampSeries.__init__, 'name', 'data', 'electrode', 'gain'),  # required
             *get_docval(PatchClampSeries.__init__, 'stimulus_description', 'resolution', 'conversion', 'timestamps',
                         'starting_time', 'rate', 'comments', 'description', 'control', 'control_description',
-                        'sweep_number'))
+                        'sweep_number'),
+            {'name': 'unit', 'type': str, 'doc': "The base unit of measurement (must be 'volts')",
+             'default': 'volts'})
     def __init__(self, **kwargs):
-        name, data, electrode, gain = popargs('name', 'data', 'electrode', 'gain', kwargs)
+        name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
+        if unit != 'volts':
+            warnings.warn("Unit for %s '%s' is ignored and will be set to 'volts' as per "
+                          "NWB 2.1.0." % (self.__class__.__name__, name))
         unit = 'volts'
-        super(VoltageClampStimulusSeries, self).__init__(name, data, unit, electrode, gain, **kwargs)
+        super().__init__(name, data, unit, electrode, gain, **kwargs)
 
 
 @register_class('SweepTable', CORE_NAMESPACE)
@@ -247,7 +270,7 @@ class SweepTable(DynamicTable):
              'default': "A sweep table groups different PatchClampSeries together."},
             *get_docval(DynamicTable.__init__, 'id', 'columns', 'colnames'))
     def __init__(self, **kwargs):
-        call_docval_func(super(SweepTable, self).__init__, kwargs)
+        call_docval_func(super().__init__, kwargs)
 
     @docval({'name': 'pcs', 'type': PatchClampSeries,
              'doc': 'PatchClampSeries to add to the table must have a valid sweep_number'})

--- a/tests/unit/test_icephys.py
+++ b/tests/unit/test_icephys.py
@@ -116,7 +116,8 @@ class CurrentClampSeriesConstructor(TestCase):
     def test_init(self):
         electrode_name = GetElectrode()
 
-        cCS = CurrentClampSeries('test_cCS', list(), electrode_name, 1.0, "stimset", 2.0, 3.0, 4.0, timestamps=list())
+        cCS = CurrentClampSeries('test_cCS', list(), electrode_name, 1.0, "stimset", 2.0, 3.0, 4.0,
+                                 timestamps=list())
         self.assertEqual(cCS.name, 'test_cCS')
         self.assertEqual(cCS.unit, 'volts')
         self.assertEqual(cCS.electrode, electrode_name)
@@ -125,6 +126,15 @@ class CurrentClampSeriesConstructor(TestCase):
         self.assertEqual(cCS.bias_current, 2.0)
         self.assertEqual(cCS.bridge_balance, 3.0)
         self.assertEqual(cCS.capacitance_compensation, 4.0)
+
+    def test_unit_warning(self):
+        electrode_name = GetElectrode()
+
+        msg = "Unit for CurrentClampSeries 'test_cCS' is ignored and will be set to 'volts' as per NWB 2.1.0."
+        with self.assertWarnsWith(UserWarning, msg):
+            cCS = CurrentClampSeries('test_cCS', list(), electrode_name, 1.0, "stimset", 2.0, 3.0, 4.0,
+                                     timestamps=list(), unit='unit')
+        self.assertEqual(cCS.unit, 'volts')
 
 
 class IZeroClampSeriesConstructor(TestCase):
@@ -141,6 +151,14 @@ class IZeroClampSeriesConstructor(TestCase):
         self.assertEqual(iZCS.bridge_balance, 0.0)
         self.assertEqual(iZCS.capacitance_compensation, 0.0)
 
+    def test_unit_warning(self):
+        electrode_name = GetElectrode()
+
+        msg = "Unit for IZeroClampSeries 'test_iZCS' is ignored and will be set to 'volts' as per NWB 2.1.0."
+        with self.assertWarnsWith(UserWarning, msg):
+            iZCS = IZeroClampSeries('test_iZCS', list(), electrode_name, 1.0, timestamps=list(), unit='unit')
+        self.assertEqual(iZCS.unit, 'volts')
+
 
 class CurrentClampStimulusSeriesConstructor(TestCase):
 
@@ -152,6 +170,15 @@ class CurrentClampStimulusSeriesConstructor(TestCase):
         self.assertEqual(cCSS.unit, 'amperes')
         self.assertEqual(cCSS.electrode, electrode_name)
         self.assertEqual(cCSS.gain, 1.0)
+
+    def test_unit_warning(self):
+        electrode_name = GetElectrode()
+
+        msg = ("Unit for CurrentClampStimulusSeries 'test_cCSS' is ignored and will be set to 'amperes' as per NWB "
+               "2.1.0.")
+        with self.assertWarnsWith(UserWarning, msg):
+            cCSS = CurrentClampStimulusSeries('test_cCSS', list(), electrode_name, 1.0, timestamps=list(), unit='unit')
+        self.assertEqual(cCSS.unit, 'amperes')
 
 
 class VoltageClampSeriesConstructor(TestCase):
@@ -174,6 +201,15 @@ class VoltageClampSeriesConstructor(TestCase):
         self.assertEqual(vCS.whole_cell_capacitance_comp, 7.0)
         self.assertEqual(vCS.whole_cell_series_resistance_comp, 8.0)
 
+    def test_unit_warning(self):
+        electrode_name = GetElectrode()
+
+        msg = "Unit for VoltageClampSeries 'test_vCS' is ignored and will be set to 'amperes' as per NWB 2.1.0."
+        with self.assertWarnsWith(UserWarning, msg):
+            vCS = VoltageClampSeries('test_vCS', list(), electrode_name,
+                                     1.0, "stimset", 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, timestamps=list(), unit='unit')
+        self.assertEqual(vCS.unit, 'amperes')
+
 
 class VoltageClampStimulusSeriesConstructor(TestCase):
 
@@ -184,3 +220,11 @@ class VoltageClampStimulusSeriesConstructor(TestCase):
         self.assertEqual(vCSS.name, 'test_vCSS')
         self.assertEqual(vCSS.unit, 'volts')
         self.assertEqual(vCSS.electrode, electrode_name)
+
+    def test_unit_warning(self):
+        electrode_name = GetElectrode()
+
+        msg = "Unit for VoltageClampStimulusSeries 'test_vCSS' is ignored and will be set to 'volts' as per NWB 2.1.0."
+        with self.assertWarnsWith(UserWarning, msg):
+            vCSS = VoltageClampStimulusSeries('test_vCSS', list(), electrode_name, 1.0, timestamps=list(), unit='unit')
+        self.assertEqual(vCSS.unit, 'volts')


### PR DESCRIPTION
Fix #1186. Also simplify calls to super since we no longer support Python 2.