### PR TITLE
Change min req for pandas from 0.23 -> 0.23.3

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,5 +2,5 @@
 h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 hdmf==1.5.4,<2
 numpy==1.16
-pandas==0.23
+pandas==0.23.3
 python-dateutil==2.7


### PR DESCRIPTION
Attempt to fix #1190 by changing the minimum pandas version. This is the latest version supported by debian.

I will need to run the failing test multiple times to see if this fixes the issue.