### PR TITLE
Run minimum requirements CI on Python 3.6 instead of 3.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,14 +163,14 @@ jobs:
      - TEST_WHEELINSTALL_ENV: "wheelinstall-py37"
     <<: *ci-steps
 
-  python35-min-req:
+  python36-min-req:
     docker:
-      - image: circleci/python:3.5.9-stretch
+      - image: circleci/python:3.6.10-stretch
     environment:
-     - TEST_TOX_ENV: "py35-min-req"
+     - TEST_TOX_ENV: "py36-min-req"
      - COVERAGE_TOX_ENV: ""
-     - BUILD_TOX_ENV: "build-py35-min-req"
-     - TEST_WHEELINSTALL_ENV: "wheelinstall-py35-min-req"
+     - BUILD_TOX_ENV: "build-py36-min-req"
+     - TEST_WHEELINSTALL_ENV: "wheelinstall-py36-min-req"
     <<: *ci-steps
 
   miniconda35:
@@ -283,7 +283,7 @@ workflows:
           <<: *no_filters
       - python37:
           <<: *no_filters
-      - python35-min-req:
+      - python36-min-req:
           <<: *no_filters
       - miniconda35:
           <<: *no_filters
@@ -303,7 +303,7 @@ workflows:
             - python35
             - python36
             - python37
-            - python35-min-req
+            - python36-min-req
             - miniconda35
             - miniconda36
             - miniconda37
@@ -324,7 +324,7 @@ workflows:
             - python35
             - python36
             - python37
-            - python35-min-req
+            - python36-min-req
             - miniconda35
             - miniconda36
             - miniconda37

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,13 +29,13 @@ jobs:
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
 
-      macOS-py3.5-min-req:
+      macOS-py3.6-min-req:
         imageName: 'macos-10.13'
-        pythonVersion: '3.5'
-        testToxEnv: 'py35-min-req'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36-min-req'
         coverageToxEnv: ''
-        buildToxEnv: 'build-py35-min-req'
-        testWheelInstallEnv: 'wheelinstall-py35-min-req'
+        buildToxEnv: 'build-py36-min-req'
+        testWheelInstallEnv: 'wheelinstall-py36-min-req'
 
       Windows-py3.7:
         imageName: 'vs2017-win2016'
@@ -61,13 +61,13 @@ jobs:
         buildToxEnv: 'build-py35'
         testWheelInstallEnv: 'wheelinstall-py35'
 
-      Windows-py3.5-min-req:
+      Windows-py3.6-min-req:
         imageName: 'vs2017-win2016'
-        pythonVersion: '3.5'
-        testToxEnv: 'py35-min-req'
+        pythonVersion: '3.6'
+        testToxEnv: 'py36-min-req'
         coverageToxEnv: ''
-        buildToxEnv: 'build-py35-min-req'
-        testWheelInstallEnv: 'wheelinstall-py35-min-req'
+        buildToxEnv: 'build-py36-min-req'
+        testWheelInstallEnv: 'wheelinstall-py36-min-req'
 
   pool:
     vmImage: $(imageName)

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,9 @@ commands =
     coverage run test.py --pynwb
     coverage html -d tests/coverage/htmlcov
 
-# Test with python 3.5, pinned dev reqs, and minimum run requirements
-[testenv:py35-min-req]
-basepython = python3.5
+# Test with python 3.6, pinned dev reqs, and minimum run requirements
+[testenv:py36-min-req]
+basepython = python3.6
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -53,8 +53,8 @@ commands = {[testenv:build]commands}
 basepython = python3.7
 commands = {[testenv:build]commands}
 
-[testenv:build-py35-min-req]
-basepython = python3.5
+[testenv:build-py36-min-req]
+basepython = python3.6
 deps =
     -rrequirements-dev.txt
     -rrequirements-min.txt
@@ -82,7 +82,7 @@ commands = python -c "import pynwb"
 deps = null
 commands = python -c "import pynwb"
 
-[testenv:wheelinstall-py35-min-req]
+[testenv:wheelinstall-py36-min-req]
 deps = null
 commands = python -c "import pynwb"
 


### PR DESCRIPTION
Fix #1190