### PR TITLE
Fix nightly builds failing due to missing package

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -124,5 +124,6 @@ install_command =
 deps =
     -rrequirements-dev.txt
     -rrequirements.txt
+    -rrequirements-doc.txt
 commands =
     python test.py --validation


### PR DESCRIPTION
Nightly validation tests fail because of a missing package. This PR fixes that.