### PR TITLE
Clean up tests to remove conversion warnings and make pos arg -> kwargs

### DIFF
--- a/tests/integration/hdf5/test_base.py
+++ b/tests/integration/hdf5/test_base.py
@@ -10,8 +10,13 @@ class TestTimeSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test TimeSeries to read/write """
-        return TimeSeries('test_timeseries', list(range(100, 200, 10)),
-                          'SIunit', timestamps=list(range(10)), resolution=0.1)
+        return TimeSeries(
+            name='test_timeseries',
+            data=list(range(1000)),
+            unit='SIunit',
+            timestamps=np.arange(1000.),
+            resolution=0.1
+        )
 
 
 class TestTimeSeriesLinking(TestCase):
@@ -24,7 +29,7 @@ class TestTimeSeriesLinking(TestCase):
 
     def test_timestamps_linking(self):
         ''' Test that timestamps get linked to in TimeSeries '''
-        tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000), unit='m')
+        tsa = TimeSeries(name='a', data=np.linspace(0, 1, 1000), timestamps=np.arange(1000.), unit='m')
         tsb = TimeSeries(name='b', data=np.linspace(0, 1, 1000), timestamps=tsa, unit='m')
         nwbfile = NWBFile(identifier='foo',
                           session_start_time=datetime(2017, 5, 1, 12, 0, 0, tzinfo=tzlocal()),

--- a/tests/integration/hdf5/test_ecephys.py
+++ b/tests/integration/hdf5/test_ecephys.py
@@ -11,8 +11,11 @@ class TestElectrodeGroupIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test ElectrodeGroup to read/write """
-        self.dev1 = Device('dev1')
-        eg = ElectrodeGroup('elec1', 'a test ElectrodeGroup', 'a nonexistent place', self.dev1)
+        self.dev1 = Device(name='dev1')
+        eg = ElectrodeGroup(name='elec1',
+                            description='a test ElectrodeGroup',
+                            location='a nonexistent place',
+                            device=self.dev1)
         return eg
 
     def addContainer(self, nwbfile):
@@ -31,9 +34,11 @@ class TestElectricalSeriesIO(AcquisitionH5IOMixin, TestCase):
     def make_electrode_table(self):
         """ Make an electrode table, electrode group, and device """
         self.table = get_electrode_table()
-        self.dev1 = Device('dev1')
-        self.group = ElectrodeGroup('tetrode1',
-                                    'tetrode description', 'tetrode location', self.dev1)
+        self.dev1 = Device(name='dev1')
+        self.group = ElectrodeGroup(name='tetrode1',
+                                    description='tetrode description',
+                                    location='tetrode location',
+                                    device=self.dev1)
         for i in range(4):
             self.table.add_row(x=i, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none', group=self.group,
                                group_name='tetrode1')
@@ -41,10 +46,17 @@ class TestElectricalSeriesIO(AcquisitionH5IOMixin, TestCase):
     def setUpContainer(self):
         """ Return the test ElectricalSeries to read/write """
         self.make_electrode_table(self)
-        region = DynamicTableRegion('electrodes', [0, 2], 'the first and third electrodes', self.table)
+        region = DynamicTableRegion(name='electrodes',
+                                    data=[0, 2],
+                                    description='the first and third electrodes',
+                                    table=self.table)
         data = list(zip(range(10), range(10, 20)))
-        timestamps = list(map(lambda x: x/10, range(10)))
-        es = ElectricalSeries('test_eS', data, region, channel_conversion=[4., .4], timestamps=timestamps)
+        timestamps = list(map(lambda x: x/10., range(10)))
+        es = ElectricalSeries(name='test_eS',
+                              data=data,
+                              electrodes=region,
+                              channel_conversion=[4., .4],
+                              timestamps=timestamps)
         return es
 
     def addContainer(self, nwbfile):
@@ -78,13 +90,20 @@ class MultiElectricalSeriesIOMixin(AcquisitionH5IOMixin):
     def setUpTwoElectricalSeries(self):
         """ Return two test ElectricalSeries to read/write """
         TestElectricalSeriesIO.make_electrode_table(self)
-        region1 = DynamicTableRegion('electrodes', [0, 2], 'the first and third electrodes', self.table)
-        region2 = DynamicTableRegion('electrodes', [1, 3], 'the second and fourth electrodes', self.table)
+        region1 = DynamicTableRegion(name='electrodes',
+                                     data=[0, 2],
+                                     description='the first and third electrodes',
+                                     table=self.table)
+        region2 = DynamicTableRegion(name='electrodes',
+                                     data=[1, 3],
+                                     description='the second and fourth electrodes',
+                                     table=self.table)
         data1 = list(zip(range(10), range(10, 20)))
         data2 = list(zip(reversed(range(10)), reversed(range(10, 20))))
-        timestamps = list(map(lambda x: x/10, range(10)))
-        es1 = ElectricalSeries('test_eS1', data1, region1, timestamps=timestamps)
-        es2 = ElectricalSeries('test_eS2', data2, region2, channel_conversion=[4., .4], timestamps=timestamps)
+        timestamps = list(map(lambda x: x/10., range(10)))
+        es1 = ElectricalSeries(name='test_eS1', data=data1, electrodes=region1, timestamps=timestamps)
+        es2 = ElectricalSeries(name='test_eS2', data=data2, electrodes=region2, channel_conversion=[4., .4],
+                               timestamps=timestamps)
         return es1, es2
 
     def addContainer(self, nwbfile):
@@ -132,8 +151,14 @@ class EventWaveformConstructor(AcquisitionH5IOMixin, TestCase):
     def setUpContainer(self):
         """ Return a test EventWaveform to read/write """
         TestElectricalSeriesIO.make_electrode_table(self)
-        region = DynamicTableRegion('electrodes', [0, 2], 'the first and third electrodes', self.table)
-        sES = SpikeEventSeries('test_sES', ((1, 1, 1), (2, 2, 2)), list(range(2)), region)
+        region = DynamicTableRegion(name='electrodes',
+                                    data=[0, 2],
+                                    description='the first and third electrodes',
+                                    table=self.table)
+        sES = SpikeEventSeries(name='test_sES',
+                               data=((1, 1, 1), (2, 2, 2)),
+                               timestamps=[0., 1.],
+                               electrodes=region)
         ew = EventWaveform(sES)
         return ew
 
@@ -177,10 +202,13 @@ class FeatureExtractionConstructor(AcquisitionH5IOMixin, TestCase):
         """ Return a test FeatureExtraction to read/write """
         event_times = [1.9, 3.5]
         TestElectricalSeriesIO.make_electrode_table(self)
-        region = DynamicTableRegion('electrodes', [0, 2], 'the first and third electrodes', self.table)
+        region = DynamicTableRegion(name='electrodes',
+                                    data=[0, 2],
+                                    description='the first and third electrodes',
+                                    table=self.table)
         description = ['desc1', 'desc2', 'desc3']
         features = [[[0., 1., 2.], [3., 4., 5.]], [[6., 7., 8.], [9., 10., 11.]]]
-        fe = FeatureExtraction(region, description, event_times, features)
+        fe = FeatureExtraction(electrodes=region, description=description, times=event_times, features=features)
         return fe
 
     def addContainer(self, nwbfile):
@@ -196,11 +224,17 @@ class EventDetectionConstructor(AcquisitionH5IOMixin, TestCase):
     def setUpContainer(self):
         """ Return a test EventDetection to read/write """
         TestElectricalSeriesIO.make_electrode_table(self)
-        region = DynamicTableRegion('electrodes', [0, 2], 'the first and third electrodes', self.table)
+        region = DynamicTableRegion(name='electrodes',
+                                    data=[0, 2],
+                                    description='the first and third electrodes',
+                                    table=self.table)
         data = list(range(10))
         ts = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
-        self.eS = ElectricalSeries('test_eS', data, region, timestamps=ts)
-        eD = EventDetection('detection_method', self.eS, (1, 2, 3), (0.1, 0.2, 0.3))
+        self.eS = ElectricalSeries(name='test_eS', data=data, electrodes=region, timestamps=ts)
+        eD = EventDetection(detection_method='detection_method',
+                            source_electricalseries=self.eS,
+                            source_idx=(1, 2, 3),
+                            times=(0.1, 0.2, 0.3))
         return eD
 
     def addContainer(self, nwbfile):

--- a/tests/integration/hdf5/test_icephys.py
+++ b/tests/integration/hdf5/test_icephys.py
@@ -13,13 +13,15 @@ class TestIntracellularElectrode(NWBH5IOMixin, TestCase):
     def setUpContainer(self):
         """ Return the test IntracellularElectrode to read/write """
         self.device = Device(name='device_name')
-        elec = IntracellularElectrode(name="elec0", slice='tissue slice',
-                                           resistance='something measured in ohms',
-                                           seal='sealing method', description='a fake electrode object',
-                                           location='Springfield Elementary School',
-                                           filtering='a meaningless free-form text field',
-                                           initial_access_resistance='I guess this changes',
-                                           device=self.device)
+        elec = IntracellularElectrode(name="elec0",
+                                      slice='tissue slice',
+                                      resistance='something measured in ohms',
+                                      seal='sealing method',
+                                      description='a fake electrode object',
+                                      location='Springfield Elementary School',
+                                      filtering='a meaningless free-form text field',
+                                      initial_access_resistance='I guess this changes',
+                                      device=self.device)
         return elec
 
     def addContainer(self, nwbfile):
@@ -50,7 +52,7 @@ class TestPatchClampSeries(AcquisitionH5IOMixin, TestCase):
         self.setUpElectrode()
         return PatchClampSeries(name="pcs", data=[1, 2, 3, 4, 5], unit='A',
                                 starting_time=123.6, rate=10e3, electrode=self.elec, gain=0.126,
-                                stimulus_description="gotcha ya!", sweep_number=4711)
+                                stimulus_description="gotcha ya!", sweep_number=np.uint(4711))
 
     def addContainer(self, nwbfile):
         """

--- a/tests/integration/hdf5/test_image.py
+++ b/tests/integration/hdf5/test_image.py
@@ -15,7 +15,7 @@ class TestOpticalSeriesIO(NWBH5IOMixin, TestCase):
                                             data=np.ones((10, 3, 3)),
                                             unit='m',
                                             format='raw',
-                                            timestamps=np.arange(10))
+                                            timestamps=np.arange(10.))
         return self.optical_series
 
     def addContainer(self, nwbfile):

--- a/tests/integration/hdf5/test_nwbfile.py
+++ b/tests/integration/hdf5/test_nwbfile.py
@@ -23,8 +23,9 @@ class TestNWBFileHDF5IO(TestCase):
         self.create_date = datetime(2017, 4, 15, 12, tzinfo=tzlocal())
         self.manager = get_manager()
         self.filename = 'test_nwbfileio.h5'
-        self.nwbfile = NWBFile('a test NWB File', 'TEST123',
-                               self.start_time,
+        self.nwbfile = NWBFile(session_description='a test NWB File',
+                               identifier='TEST123',
+                               session_start_time=self.start_time,
                                timestamps_reference_time=self.ref_time,
                                file_create_date=self.create_date,
                                experimenter='test experimenter',
@@ -43,15 +44,15 @@ class TestNWBFileHDF5IO(TestCase):
                                surgery='nosurgery',
                                virus='novirus',
                                source_script_file_name='nofilename')
-        self.ts = TimeSeries('test_timeseries', list(range(100, 200, 10)),
-                             'SIunit', timestamps=list(range(10)), resolution=0.1)
+        self.ts = TimeSeries(name='test_timeseries', data=list(range(100, 200, 10)),
+                             unit='SIunit', timestamps=np.arange(10.), resolution=0.1)
         self.nwbfile.add_acquisition(self.ts)
-        self.ts2 = TimeSeries('test_timeseries2', list(range(200, 300, 10)),
-                              'SIunit', timestamps=list(range(10)), resolution=0.1)
+        self.ts2 = TimeSeries(name='test_timeseries2', data=list(range(200, 300, 10)),
+                              unit='SIunit', timestamps=np.arange(10.), resolution=0.1)
         self.nwbfile.add_analysis(self.ts2)
         self.mod = self.nwbfile.create_processing_module('test_module', 'a test module')
-        self.ts3 = TimeSeries('test_timeseries2', list(range(100, 200, 10)),
-                              'SIunit', timestamps=list(range(10)), resolution=0.1)
+        self.ts3 = TimeSeries(name='test_timeseries2', data=list(range(100, 200, 10)),
+                              unit='SIunit', timestamps=np.arange(10.), resolution=0.1)
         self.mod.add(self.ts3)
 
     def tearDown(self):
@@ -107,9 +108,9 @@ class TestNWBFileIO(NWBH5IOMixin, TestCase):
 
     def build_nwbfile(self):
         """ Create an NWB file """
-        self.container = NWBFile('a test session description for a test NWBFile',
-                                 'FILE123',
-                                 self.start_time,
+        self.container = NWBFile(session_description='a test session description for a test NWBFile',
+                                 identifier='FILE123',
+                                 session_start_time=self.start_time,
                                  file_create_date=self.create_dates,
                                  timestamps_reference_time=self.ref_time,
                                  experimenter='A test experimenter',
@@ -156,7 +157,9 @@ class TestExperimentersConstructorRoundtrip(TestNWBFileIO):
     def build_nwbfile(self):
         description = 'test nwbfile experimenter'
         identifier = 'TEST_experimenter'
-        self.nwbfile = NWBFile(description, identifier, self.start_time,
+        self.nwbfile = NWBFile(session_description=description,
+                               identifier=identifier,
+                               session_start_time=self.start_time,
                                experimenter=('experimenter1', 'experimenter2'))
 
 
@@ -166,7 +169,9 @@ class TestExperimentersSetterRoundtrip(TestNWBFileIO):
     def build_nwbfile(self):
         description = 'test nwbfile experimenter'
         identifier = 'TEST_experimenter'
-        self.nwbfile = NWBFile(description, identifier, self.start_time)
+        self.nwbfile = NWBFile(session_description=description,
+                               identifier=identifier,
+                               session_start_time=self.start_time)
         self.nwbfile.experimenter = ('experimenter1', 'experimenter2')
 
 
@@ -176,7 +181,9 @@ class TestPublicationsConstructorRoundtrip(TestNWBFileIO):
     def build_nwbfile(self):
         description = 'test nwbfile publications'
         identifier = 'TEST_publications'
-        self.nwbfile = NWBFile(description, identifier, self.start_time,
+        self.nwbfile = NWBFile(session_description=description,
+                               identifier=identifier,
+                               session_start_time=self.start_time,
                                related_publications=('pub1', 'pub2'))
 
 
@@ -186,7 +193,9 @@ class TestPublicationsSetterRoundtrip(TestNWBFileIO):
     def build_nwbfile(self):
         description = 'test nwbfile publications'
         identifier = 'TEST_publications'
-        self.nwbfile = NWBFile(description, identifier, self.start_time)
+        self.nwbfile = NWBFile(session_description=description,
+                               identifier=identifier,
+                               session_start_time=self.start_time)
         self.nwbfile.related_publications = ('pub1', 'pub2')
 
 
@@ -339,7 +348,7 @@ class TestTrials(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return placeholder Table for trials. Tested trials are added directly to the NWBFile in addContainer """
-        return DynamicTable('trials', 'a placeholder table')  # this will get ignored
+        return DynamicTable(name='trials', description='a placeholder table')  # this will get ignored
 
     def addContainer(self, nwbfile):
         """ Add trials and trial columns to the given NWBFile """
@@ -363,7 +372,7 @@ class TestInvalidTimes(NWBH5IOMixin, TestCase):
         """
         Return placeholder Table for trials. Tested invalid times are added directly to the NWBFile in addContainer
         """
-        return DynamicTable('invalid times', 'a placeholder table')
+        return DynamicTable(name='invalid times', description='a placeholder table')
 
     def addContainer(self, nwbfile):
         """ Add invalid times and invalid times columns to the given NWBFile """
@@ -385,7 +394,7 @@ class TestUnits(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return placeholder table for Units. Tested units are added directly to the NWBFile in addContainer """
-        return DynamicTable('units', 'a placeholder table')
+        return DynamicTable(name='units', description='a placeholder table')
 
     def addContainer(self, nwbfile):
         """ Add units and unit columns to the given NWBFile """
@@ -434,8 +443,9 @@ class TestElectrodes(NWBH5IOMixin, TestCase):
 
     def addContainer(self, nwbfile):
         """ Add electrodes and related objects to the given NWBFile """
-        self.dev1 = nwbfile.create_device('dev1')
-        self.group = nwbfile.create_electrode_group('tetrode1', 'tetrode description', 'tetrode location', self.dev1)
+        self.dev1 = nwbfile.create_device(name='dev1')
+        self.group = nwbfile.create_electrode_group(name='tetrode1', description='tetrode description',
+                                                    location='tetrode location', device=self.dev1)
 
         nwbfile.add_electrode(id=1, x=1.0, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none', group=self.group,
                               group_name='tetrode1')
@@ -470,8 +480,9 @@ class TestElectrodesRegion(NWBH5IOMixin, TestCase):
 
     def addContainer(self, nwbfile):
         """ Add electrode table region and related objects to the given NWBFile """
-        self.dev1 = nwbfile.create_device('dev1')
-        self.group = nwbfile.create_electrode_group('tetrode1', 'tetrode description', 'tetrode location', self.dev1)
+        self.dev1 = nwbfile.create_device(name='dev1')
+        self.group = nwbfile.create_electrode_group(name='tetrode1', description='tetrode description',
+                                                    location='tetrode location', device=self.dev1)
 
         nwbfile.add_electrode(id=1, x=1.0, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none', group=self.group,
                               group_name='tetrode1')
@@ -490,7 +501,7 @@ class TestElectrodesRegion(NWBH5IOMixin, TestCase):
         nwbfile.add_acquisition(ElectricalSeries(
             name='test_data',
             data=np.arange(10),
-            timestamps=np.arange(10),
+            timestamps=np.arange(10.),
             electrodes=region
         ))
 

--- a/tests/integration/hdf5/test_ogen.py
+++ b/tests/integration/hdf5/test_ogen.py
@@ -8,7 +8,8 @@ class TestOptogeneticStimulusSiteIO(NWBH5IOMixin, TestCase):
     def setUpContainer(self):
         """ Return the test OptogeneticStimulusSite to read/write """
         self.device = Device(name='dev1')
-        return OptogeneticStimulusSite('stim_site', self.device, 'my stim site', 300., 'in the brain')
+        return OptogeneticStimulusSite(name='stim_site', device=self.device, description='my stim site',
+                                       excitation_lambda=300., location='in the brain')
 
     def addContainer(self, nwbfile):
         """ Add the test OptogeneticStimulusSite and Device to the given NWBFile """
@@ -25,8 +26,9 @@ class TestOptogeneticSeriesIO(AcquisitionH5IOMixin, TestCase):
     def setUpContainer(self):
         """ Return the test OptogeneticSeries to read/write """
         self.device = Device(name='dev1')
-        self.ogen_stim_site = OptogeneticStimulusSite('stim_site', self.device, 'my stim site', 300., 'in the brain')
-        return OptogeneticSeries('stim_series', [1., 2., 3.], self.ogen_stim_site, rate=100.)
+        self.ogen_stim_site = OptogeneticStimulusSite(name='stim_site', device=self.device, description='my stim site',
+                                                      excitation_lambda=300., location='in the brain')
+        return OptogeneticSeries(name='stim_series', data=[1., 2., 3.], site=self.ogen_stim_site, rate=100.)
 
     def addContainer(self, nwbfile):
         """

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -19,9 +19,22 @@ class TestImagingPlaneIO(NWBH5IOMixin, TestCase):
     def setUpContainer(self):
         """ Return the test ImagingPlane to read/write """
         self.device = Device(name='dev1')
-        self.optical_channel = OpticalChannel('optchan1', 'a fake OpticalChannel', 500.)
-        return ImagingPlane('imgpln1', self.optical_channel, 'a fake ImagingPlane', self.device,
-                            600., 300., 'GFP', 'somewhere in the brain', reference_frame='unknonwn')
+        self.optical_channel = OpticalChannel(
+            name='optchan1',
+            description='a fake OpticalChannel',
+            emission_lambda=500.
+        )
+        return ImagingPlane(
+            name='imgpln1',
+            optical_channel=self.optical_channel,
+            description='a fake ImagingPlane',
+            device=self.device,
+            excitation_lambda=600.,
+            imaging_rate=300.,
+            indicator='GFP',
+            location='somewhere in the brain',
+            reference_frame='unknown'
+        )
 
     def addContainer(self, nwbfile):
         """ Add the test ImagingPlane and Device to the given NWBFile """
@@ -38,9 +51,22 @@ class TestTwoPhotonSeriesIO(AcquisitionH5IOMixin, TestCase):
     def make_imaging_plane(self):
         """ Make an ImagingPlane and related objects """
         self.device = Device(name='dev1')
-        self.optical_channel = OpticalChannel('optchan1', 'a fake OpticalChannel', 500.)
-        self.imaging_plane = ImagingPlane('imgpln1', self.optical_channel, 'a fake ImagingPlane', self.device,
-                                          600., 300., 'GFP', 'somewhere in the brain', reference_frame='unknown')
+        self.optical_channel = OpticalChannel(
+            name='optchan1',
+            description='a fake OpticalChannel',
+            emission_lambda=500.
+        )
+        self.imaging_plane = ImagingPlane(
+            name='imgpln1',
+            optical_channel=self.optical_channel,
+            description='a fake ImagingPlane',
+            device=self.device,
+            excitation_lambda=600.,
+            imaging_rate=300.,
+            indicator='GFP',
+            location='somewhere in the brain',
+            reference_frame='unknown'
+        )
 
     def setUpContainer(self):
         """ Return the test TwoPhotonSeries to read/write """
@@ -48,8 +74,18 @@ class TestTwoPhotonSeriesIO(AcquisitionH5IOMixin, TestCase):
         data = [[[1., 1.] * 2] * 2]
         timestamps = list(map(lambda x: x/10, range(10)))
         fov = [2.0, 2.0, 5.0]
-        ret = TwoPhotonSeries('test_2ps', self.imaging_plane, data, 'image_unit', 'raw', fov, 1.7, 3.4,
-                              timestamps=timestamps, dimension=[2])
+        ret = TwoPhotonSeries(
+            name='test_2ps',
+            imaging_plane=self.imaging_plane,
+            data=data,
+            unit='image_unit',
+            format='raw',
+            field_of_view=fov,
+            pmt_gain=1.7,
+            scan_line_rate=3.4,
+            timestamps=timestamps,
+            dimension=[2]
+        )
         return ret
 
     def addContainer(self, nwbfile):
@@ -75,22 +111,32 @@ class TestPlaneSegmentationIO(NWBH5IOMixin, TestCase):
                                         starting_frame=[1, 2, 3], format='tiff', timestamps=ts)
 
         self.device = Device(name='dev1')
-        self.optical_channel = OpticalChannel('test_optical_channel',
-                                              'optical channel description', 500.)
-        self.imaging_plane = ImagingPlane('imgpln1',
-                                          self.optical_channel,
-                                          'a fake ImagingPlane',
-                                          self.device,
-                                          600., 200., 'GFP', 'somewhere in the brain',
-                                          (((1., 2., 3.), (4., 5., 6.)),),
-                                          2., 'a unit',
-                                          reference_frame='unknown')
+        self.optical_channel = OpticalChannel(
+            name='test_optical_channel',
+            description='optical channel description',
+            emission_lambda=500.
+        )
+        self.imaging_plane = ImagingPlane(
+            name='imgpln1',
+            optical_channel=self.optical_channel,
+            description='a fake ImagingPlane',
+            device=self.device,
+            excitation_lambda=600.,
+            imaging_rate=300.,
+            indicator='GFP',
+            location='somewhere in the brain',
+            reference_frame='unknown'
+        )
 
         self.img_mask = deepcopy(img_mask)
         self.pix_mask = deepcopy(pix_mask)
         self.pxmsk_index = [3, 5]
-        pS = PlaneSegmentation('plane segmentation description',
-                               self.imaging_plane, 'test_plane_seg_name', self.image_series)
+        pS = PlaneSegmentation(
+            description='plane segmentation description',
+            imaging_plane=self.imaging_plane,
+            name='test_plane_seg_name',
+            reference_images=self.image_series
+        )
         pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
         pS.add_roi(pixel_mask=pix_mask[3:5], image_mask=img_mask[1])
         return pS
@@ -108,7 +154,8 @@ class TestPlaneSegmentationIO(NWBH5IOMixin, TestCase):
         nwbfile.add_imaging_plane(self.imaging_plane)
         img_seg = ImageSegmentation()
         img_seg.add_plane_segmentation(self.container)
-        self.mod = nwbfile.create_processing_module('plane_seg_test_module', 'a plain module for testing')
+        self.mod = nwbfile.create_processing_module(name='plane_seg_test_module',
+                                                    description='a plain module for testing')
         self.mod.add(img_seg)
 
     def getContainer(self, nwbfile):
@@ -127,17 +174,25 @@ class MaskIO(TestPlaneSegmentationIO, metaclass=ABCMeta):
                                         external_file=['images.tiff'],
                                         starting_frame=[1, 2, 3], format='tiff', timestamps=ts)
         self.device = Device(name='dev1')
-        self.optical_channel = OpticalChannel('test_optical_channel',
-                                              'optical channel description', 500.)
-        self.imaging_plane = ImagingPlane('test_imaging_plane',
-                                          self.optical_channel,
-                                          'imaging plane description',
-                                          self.device,
-                                          600., 300., 'GFP', 'somewhere in the brain',
-                                          (((1., 2., 3.), (4., 5., 6.)),),
-                                          4.0, 'manifold unit', 'A frame to refer to')
-        return PlaneSegmentation('description', self.imaging_plane, 'test_plane_seg_name',
-                                 self.image_series)
+        self.optical_channel = OpticalChannel(name='test_optical_channel', description='optical channel description',
+                                              emission_lambda=500.)
+        self.imaging_plane = ImagingPlane(
+            name='test_imaging_plane',
+            optical_channel=self.optical_channel,
+            description='imaging plane description',
+            device=self.device,
+            excitation_lambda=600.,
+            imaging_rate=300.,
+            indicator='GFP',
+            location='somewhere in the brain',
+            reference_frame='a frame to refer to'
+        )
+        return PlaneSegmentation(
+            description='description',
+            imaging_plane=self.imaging_plane,
+            name='test_plane_seg_name',
+            reference_images=self.image_series
+        )
 
 
 class TestPixelMaskIO(MaskIO):
@@ -174,8 +229,13 @@ class TestRoiResponseSeriesIO(AcquisitionH5IOMixin, TestCase):
         data = [0., 1., 2., 3., 4., 5., 6., 7., 8., 9.]
         timestamps = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9]
 
-        return RoiResponseSeries('test_roi_response_series', data, self.rt_region, unit='lumens',
-                                 timestamps=timestamps)
+        return RoiResponseSeries(
+            name='test_roi_response_series',
+            data=data,
+            rois=self.rt_region,
+            unit='lumens',
+            timestamps=timestamps
+        )
 
     def addContainer(self, nwbfile):
         """
@@ -186,7 +246,7 @@ class TestRoiResponseSeriesIO(AcquisitionH5IOMixin, TestCase):
         nwbfile.add_imaging_plane(self.imaging_plane)
         img_seg = ImageSegmentation()
         img_seg.add_plane_segmentation(self.plane_segmentation)
-        mod = nwbfile.create_processing_module('plane_seg_test_module',
-                                               'a plain module for testing')
+        mod = nwbfile.create_processing_module(name='plane_seg_test_module',
+                                               description='a plain module for testing')
         mod.add(img_seg)
         super().addContainer(nwbfile)

--- a/tests/integration/hdf5/test_scratch.py
+++ b/tests/integration/hdf5/test_scratch.py
@@ -11,7 +11,7 @@ class TestScratchDataIO(NWBH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test ScratchData to read/write """
-        return ScratchData('foo', [1, 2, 3, 4], notes='test scratch')
+        return ScratchData(name='foo', data=[1, 2, 3, 4], notes='test scratch')
 
     def addContainer(self, nwbfile):
         """ Add the test ScratchData to the given NWBFile """
@@ -25,7 +25,10 @@ class TestScratchDataIO(NWBH5IOMixin, TestCase):
         self.filename = 'test_scratch_%s.nwb' % case
         description = 'a file to test writing and reading a scratch data of type %s' % case
         identifier = 'TEST_scratch_%s' % case
-        nwbfile = NWBFile(description, identifier, self.start_time, file_create_date=self.create_date)
+        nwbfile = NWBFile(session_description=description,
+                          identifier=identifier,
+                          session_start_time=self.start_time,
+                          file_create_date=self.create_date)
         nwbfile.add_scratch(data, name='foo', notes='test scratch', **kwargs)
 
         self.writer = NWBHDF5IO(self.filename, mode='w')
@@ -65,7 +68,10 @@ class TestScratchDataIO(NWBH5IOMixin, TestCase):
         self.filename = 'test_scratch_%s.nwb' % case
         description = 'a file to test writing and reading a scratch data of type %s' % case
         identifier = 'TEST_scratch_%s' % case
-        nwbfile = NWBFile(description, identifier, self.start_time, file_create_date=self.create_date)
+        nwbfile = NWBFile(session_description=description,
+                          identifier=identifier,
+                          session_start_time=self.start_time,
+                          file_create_date=self.create_date)
         nwbfile.add_scratch(data, name='foo', table_description='my_table')
 
         self.writer = NWBHDF5IO(self.filename, mode='w')
@@ -83,8 +89,9 @@ class TestScratchDataIO(NWBH5IOMixin, TestCase):
         self.validate()
 
     def _test_scratch_container(self, validate=True, **kwargs):
-        data = TimeSeries('test_ts', [1, 2, 3, 4, 5], unit='unit', timestamps=[1.1, 1.2, 1.3, 1.4, 1.5])
-        nwbfile = NWBFile('test', 'test', self.start_time, file_create_date=self.create_date)
+        data = TimeSeries(name='test_ts', data=[1, 2, 3, 4, 5], unit='unit', timestamps=[1.1, 1.2, 1.3, 1.4, 1.5])
+        nwbfile = NWBFile(session_description='test', identifier='test', session_start_time=self.start_time,
+                          file_create_date=self.create_date)
 
         nwbfile.add_scratch(data, **kwargs)
 


### PR DESCRIPTION
HDMF 1.6.1 introduced warnings when HDMF performed type conversions under the hood (e.g., int32 -> float64 for timestamps). I cleaned up the tests so that a warning is not raised.

We also want to discourage the use of positional arguments when initializing a new neurodata_type class. We may decide to warn for this usage in the near future. I preemptively cleaned up the integration tests to remove those instances.