### PR TITLE
create Electrodes class to replace electrodes table

### DIFF
--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -199,6 +199,9 @@ class NWBFileMap(ObjectMapper):
     @ObjectMapper.constructor_arg('electrodes')
     def electrodes_carg(self, builder, manager):
         # change typing of constructed electrodes table from DynamicTable to Electrodes
+        if ('extracellular_ephys' not in builder['general'] or
+                'electrodes' not in builder['general']['extracellular_ephys']):
+            return None
         electrodes_builder = builder['general']['extracellular_ephys']['electrodes']
         # construct the electrodes table from the spec (as a DynamicTable)
         # this has happened earlier in the construct process but this function does not have access to the previously

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -207,35 +207,14 @@ class NWBFileMap(ObjectMapper):
         # this has happened earlier in the construct process but this function does not have access to the previously
         # constructed object, so we do it again here
         constructed = manager.construct(electrodes_builder)
-        ret = Electrodes.__new__(
-            Electrodes,
-            container_source=constructed.container_source,
-            parent=constructed.parent,
-            object_id=constructed.object_id
-        )
-
-        ret.__init__(
-            name=constructed.name,
-            description=constructed.description,
-            id=constructed.id,
-            columns=constructed.columns,
-            colnames=constructed.colnames
-        )
+        ret = Electrodes.cast(constructed)
         return ret
 
     @ObjectMapper.object_attr('electrodes')
     def electrodes_obj_attr(self, container, manager):
         ret = None
-        if isinstance(container.electrodes, Electrodes):
-            ret = container.electrodes
-        elif isinstance(container.electrodes, DynamicTable):
-            ret = Electrodes(
-                name=container.electrodes.name,
-                description=container.electrodes.description,
-                id=container.electrodes.id,
-                columns=container.electrodes.columns,
-                colnames=container.electrodes.colnames
-            )
+        if not isinstance(container.electrodes, Electrodes) and isinstance(container.electrodes, DynamicTable):
+            ret = Electrodes.cast(container.electrodes)
         return ret
 
 

--- a/tests/integration/hdf5/test_ecephys.py
+++ b/tests/integration/hdf5/test_ecephys.py
@@ -3,7 +3,7 @@ from hdmf.common import DynamicTableRegion
 from pynwb.ecephys import ElectrodeGroup, ElectricalSeries, FilteredEphys, LFP, Clustering, ClusterWaveforms,\
                           SpikeEventSeries, EventWaveform, EventDetection, FeatureExtraction
 from pynwb.device import Device
-from pynwb.file import ElectrodeTable as get_electrode_table
+from pynwb.file import Electrodes
 from pynwb.testing import NWBH5IOMixin, AcquisitionH5IOMixin, TestCase
 
 
@@ -30,7 +30,7 @@ class TestElectricalSeriesIO(AcquisitionH5IOMixin, TestCase):
     @staticmethod
     def make_electrode_table(self):
         """ Make an electrode table, electrode group, and device """
-        self.table = get_electrode_table()
+        self.table = Electrodes()
         self.dev1 = Device('dev1')
         self.group = ElectrodeGroup('tetrode1',
                                     'tetrode description', 'tetrode location', self.dev1)

--- a/tests/integration/hdf5/test_nwbfile.py
+++ b/tests/integration/hdf5/test_nwbfile.py
@@ -438,13 +438,13 @@ class TestElectrodes(NWBH5IOMixin, TestCase):
         self.group = nwbfile.create_electrode_group('tetrode1', 'tetrode description', 'tetrode location', self.dev1)
 
         nwbfile.add_electrode(id=1, x=1.0, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
+                              group_name='tetrode1', rel_x=1.0)
         nwbfile.add_electrode(id=2, x=1.0, y=2.0, z=3.0, imp=-2.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
+                              group_name='tetrode1', rel_x=1.0)
         nwbfile.add_electrode(id=3, x=1.0, y=2.0, z=3.0, imp=-3.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
+                              group_name='tetrode1', rel_x=1.0)
         nwbfile.add_electrode(id=4, x=1.0, y=2.0, z=3.0, imp=-4.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
+                              group_name='tetrode1', rel_x=1.0)
 
         self.container = nwbfile.electrodes  # override self.container which has the placeholder
 

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -3,14 +3,14 @@ import numpy as np
 from pynwb.ecephys import ElectricalSeries, SpikeEventSeries, EventDetection, Clustering, EventWaveform,\
                           ClusterWaveforms, LFP, FilteredEphys, FeatureExtraction, ElectrodeGroup
 from pynwb.device import Device
-from pynwb.file import ElectrodeTable
+from pynwb.file import Electrodes
 from pynwb.testing import TestCase
 
 from hdmf.common import DynamicTableRegion
 
 
 def make_electrode_table():
-    table = ElectrodeTable()
+    table = Electrodes()
     dev1 = Device('dev1')
     group = ElectrodeGroup('tetrode1', 'tetrode description', 'tetrode location', dev1)
     table.add_row(id=1, x=1.0, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none',

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -248,7 +248,7 @@ class NWBFileTest(TestCase):
         dev1 = self.nwbfile.create_device('dev1')
         group = self.nwbfile.create_electrode_group('tetrode1', 'tetrode description', 'tetrode location', dev1)
         self.nwbfile.add_electrode(x=1.0, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none', group=group, id=1)
-        self.assertIsIstance(self.electrodes, Electrodes)
+        self.assertIsInstance(self.nwbfile.electrodes, Electrodes)
         elec = self.nwbfile.electrodes[0]
         self.assertEqual(elec.index[0], 1)
         self.assertEqual(elec.iloc[0]['x'], 1.0)
@@ -258,13 +258,32 @@ class NWBFileTest(TestCase):
         self.assertEqual(elec.iloc[0]['location'], 'CA1')
         self.assertEqual(elec.iloc[0]['filtering'], 'none')
         self.assertEqual(elec.iloc[0]['group'], group)
-        self.assertEqual(set(self.electrodes.colnames), {'id', 'x', 'y', 'z', 'imp', 'location', 'filtering', 'group',
-                                                         'group_name'})
+        self.assertEqual(set(self.nwbfile.electrodes.colnames),
+                         {'x', 'y', 'z', 'imp', 'location', 'filtering', 'group', 'group_name'})
+
+    def test_add_electrode_opt_col(self):
+        dev1 = self.nwbfile.create_device('dev1')
+        group = self.nwbfile.create_electrode_group('tetrode1', 'tetrode description', 'tetrode location', dev1)
+        self.nwbfile.add_electrode(x=1.0, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none', group=group, id=1,
+                                   rel_x=5.0)
+        self.assertIsInstance(self.nwbfile.electrodes, Electrodes)
+        elec = self.nwbfile.electrodes[0]
+        self.assertEqual(elec.index[0], 1)
+        self.assertEqual(elec.iloc[0]['x'], 1.0)
+        self.assertEqual(elec.iloc[0]['y'], 2.0)
+        self.assertEqual(elec.iloc[0]['z'], 3.0)
+        self.assertEqual(elec.iloc[0]['imp'], -1.0)
+        self.assertEqual(elec.iloc[0]['location'], 'CA1')
+        self.assertEqual(elec.iloc[0]['filtering'], 'none')
+        self.assertEqual(elec.iloc[0]['group'], group)
+        self.assertEqual(elec.iloc[0]['rel_x'], 5.0)
+        self.assertEqual(set(self.nwbfile.electrodes.colnames),
+                         {'x', 'y', 'z', 'imp', 'location', 'filtering', 'group', 'group_name', 'rel_x'})
 
     def test_add_electrode_column(self):
         self.nwbfile.add_electrode_column(name='new_col', description='a new column')
-        self.assertEqual(set(self.electrodes.colnames), {'id', 'x', 'y', 'z', 'imp', 'location', 'filtering', 'group',
-                                                         'group_name', 'a new column'})
+        self.assertEqual(set(self.nwbfile.electrodes.colnames),
+                         {'x', 'y', 'z', 'imp', 'location', 'filtering', 'group', 'group_name', 'new_col'})
 
     def test_all_children(self):
         ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5], 'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])


### PR DESCRIPTION
@ajtritt I am trying to create an `Electrodes` class to use for the electrodes table instead of a `DynamicTable` to solve #1204. Without being its own class, we cannot specify in PyNWB that certain columns of the electrodes table are optional.

This involves changing the `ObjectMapper` for `NWBFile` such that it constructs an `Electrodes` object instead of a `DynamicTable` object for the `NWBFile.electrodes` constructor argument. 

I thought of a few ways to do it:
1. Construct an `Electrodes` object from the `/general/extracellular_ephys/electrodes/` group builder by setting each value and creating each `VectorData` individually, but this would be very tedious and involve a lot of hard coding. 
2. Construct an `Electrodes` object from the `/general/extracellular_ephys/electrodes/` group builder by setting the values of the `Electrodes` object to the values of the `DynamicTable` that is already generated. This doesn't work because I cannot change the parent of the `VectorData` classes to the new object. That is what I have coded up in the PR here.
3. Override the container class associated with the `/general/extracellular_ephys/electrodes/` group builder. This doesn't seem possible.

Can you think of a better way to do this? Would this even be possible? Would it require substantial changes to HDMF to work?

Stepping back at the source problem, it might be easier to change how adding columns works in `DynamicTable` to handle optional columns. What do you think?