### PR TITLE
Use MacOS 10.15 instead of MacOS 10.13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ jobs:
   strategy:
     matrix:
       macOS-py3.7:
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         pythonVersion: '3.7'
         testToxEnv: 'py37'
         coverageToxEnv: 'coverage'
@@ -14,7 +14,7 @@ jobs:
         testWheelInstallEnv: 'wheelinstall-py37'
 
       macOS-py3.6:
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         pythonVersion: '3.6'
         testToxEnv: 'py36'
         coverageToxEnv: ''
@@ -22,7 +22,7 @@ jobs:
         testWheelInstallEnv: 'wheelinstall-py36'
 
       macOS-py3.5:
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         pythonVersion: '3.5'
         testToxEnv: 'py35'
         coverageToxEnv: ''
@@ -30,7 +30,7 @@ jobs:
         testWheelInstallEnv: 'wheelinstall-py35'
 
       macOS-py3.6-min-req:
-        imageName: 'macos-10.13'
+        imageName: 'macos-10.15'
         pythonVersion: '3.6'
         testToxEnv: 'py36-min-req'
         coverageToxEnv: ''


### PR DESCRIPTION
Similar to https://github.com/hdmf-dev/hdmf/pull/310

This fixes the issue that will break Azure Pipelines CI on March 23.
```
This pipeline uses a Microsoft-hosted agent image that will be removed on March 23, 2020 (MacOS-10.13). You must make changes to your pipeline before that date, or else your pipeline will fail. Learn more (https://aka.ms/removing-older-images-hosted-pools).
```