### PR TITLE
Update schema to 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,25 @@
 # PyNWB Changelog
 
-## PyNWB 1.3.1 (Upcoming)
+## PyNWB 1.3.1 (May 28, 2020)
 
 ### Bug fixes:
 - Fix bugged `Device` constructor. @rly (#1209)
+- Fix link to code of conduct page in docs. @rly (#1229)
+- Fix docs for get_type_map. @oruebel (#1233)
+- Pass file object to parent when loading namespaces (#1242)
 
 ### Internal improvements:
 - Update CI to use supported MacOS version. @rly (#1211)
+- Clean up tests to remove conversion warnings and use keyword args. @rly (#1202)
+- Fix flake8 errors. @rly (#1235)
+- Add changelog. @rly (#1215)
+- Update release process with notes about coordinating with nwb-schema. @rly (#1214)
+- Inform which unit value is actually overwritten. @yarikoptic (#1219)
+- Do not print out logging.DEBUG statements to stdout for test.py. @rly (#1240)
+- Add support for nwb-schema 2.2.4. @rly (#1213)
+  - Make `ImagingPlane.imaging_rate` optional. This moves the `imaging_rate` argument down the list of constructor
+    arguments for `ImagingPlane.__init__`. This will break existing code that calls the constructor of
+    `ImagingPlane` with at least 6 positional arguments, such that one positional argument matches `imaging_rate`.
 
 ## PyNWB 1.3.0 (Mar. 4, 2020)
 

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -20,8 +20,6 @@ clarity, we define them here:
 from datetime import datetime
 from dateutil.tz import tzlocal
 
-import numpy as np
-
 from pynwb import NWBFile
 from pynwb.ophys import TwoPhotonSeries, OpticalChannel, ImageSegmentation, Fluorescence
 from pynwb.device import Device
@@ -53,9 +51,12 @@ nwbfile = NWBFile('my first synthetic recording', 'EXAMPLE_ID', datetime.now(tzl
 device = Device('imaging_device_1')
 nwbfile.add_device(device)
 optical_channel = OpticalChannel('my_optchan', 'description', 500.)
-imaging_plane = nwbfile.create_imaging_plane('my_imgpln', optical_channel, 'a very interesting part of the brain',
-                                             device, 600., 300., 'GFP', 'my favorite brain location',
-                                             np.ones((5, 5, 3)), 4.0, 'manifold unit', 'A frame to refer to')
+imaging_plane = nwbfile.create_imaging_plane('my_imgpln', optical_channel,
+                                             description='a very interesting part of the brain',
+                                             device=device, excitation_lambda=600., imaging_rate=300., indicator='GFP',
+                                             location='my favorite brain location',
+                                             reference_frame='A frame to refer to',
+                                             grid_spacing=(.01, .01))
 
 
 ####################

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -51,9 +51,11 @@ class ImagingPlane(NWBContainer):
             {'name': 'description', 'type': str, 'doc': 'Description of this ImagingPlane.'},  # required
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record'},  # required
             {'name': 'excitation_lambda', 'type': 'float', 'doc': 'Excitation wavelength in nm.'},  # required
-            {'name': 'imaging_rate', 'type': 'float', 'doc': 'Rate images are acquired, in Hz.'},  # required
             {'name': 'indicator', 'type': str, 'doc': 'Calcium indicator'},  # required
             {'name': 'location', 'type': str, 'doc': 'Location of image plane.'},  # required
+            {'name': 'imaging_rate', 'type': 'float',
+             'doc': 'Rate images are acquired, in Hz. If the corresponding TimeSeries is present, the rate should be '
+                    'stored there instead.', 'default': None},
             {'name': 'manifold', 'type': 'array_data',
              'doc': ('DEPRECATED: Physical position of each pixel. size=("height", "width", "xyz"). '
                      'Deprecated in favor of origin_coords and grid_spacing.'),

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -175,7 +175,7 @@ class MaskIO(TestPlaneSegmentationIO, metaclass=ABCMeta):
                                         starting_frame=[1, 2, 3], format='tiff', timestamps=ts)
         self.device = Device(name='dev1')
         self.optical_channel = OpticalChannel(
-            name='test_optical_channel', 
+            name='test_optical_channel',
             description='optical channel description',
             emission_lambda=500.
         )

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -20,8 +20,9 @@ class TestImagingPlaneIO(NWBH5IOMixin, TestCase):
         """ Return the test ImagingPlane to read/write """
         self.device = Device(name='dev1')
         self.optical_channel = OpticalChannel('optchan1', 'a fake OpticalChannel', 500.)
-        return ImagingPlane('imgpln1', self.optical_channel, 'a fake ImagingPlane', self.device,
-                            600., 300., 'GFP', 'somewhere in the brain', reference_frame='unknonwn')
+        return ImagingPlane('imgpln1', self.optical_channel, description='a fake ImagingPlane', device=self.device,
+                            excitation_lambda=600., imaging_rate=300., indicator='GFP',
+                            location='somewhere in the brain', reference_frame='unknonwn')
 
     def addContainer(self, nwbfile):
         """ Add the test ImagingPlane and Device to the given NWBFile """
@@ -39,8 +40,9 @@ class TestTwoPhotonSeriesIO(AcquisitionH5IOMixin, TestCase):
         """ Make an ImagingPlane and related objects """
         self.device = Device(name='dev1')
         self.optical_channel = OpticalChannel('optchan1', 'a fake OpticalChannel', 500.)
-        self.imaging_plane = ImagingPlane('imgpln1', self.optical_channel, 'a fake ImagingPlane', self.device,
-                                          600., 300., 'GFP', 'somewhere in the brain', reference_frame='unknown')
+        self.imaging_plane = ImagingPlane('imgpln1', self.optical_channel, description='a fake ImagingPlane',
+                                          device=self.device, excitation_lambda=600., imaging_rate=300.,
+                                          indicator='GFP', location='somewhere in the brain', reference_frame='unknown')
 
     def setUpContainer(self):
         """ Return the test TwoPhotonSeries to read/write """
@@ -79,11 +81,12 @@ class TestPlaneSegmentationIO(NWBH5IOMixin, TestCase):
                                               'optical channel description', 500.)
         self.imaging_plane = ImagingPlane('imgpln1',
                                           self.optical_channel,
-                                          'a fake ImagingPlane',
-                                          self.device,
-                                          600., 200., 'GFP', 'somewhere in the brain',
-                                          (((1., 2., 3.), (4., 5., 6.)),),
-                                          2., 'a unit',
+                                          description='a fake ImagingPlane',
+                                          device=self.device,
+                                          excitation_lambda=600., imaging_rate=200., indicator='GFP',
+                                          location='somewhere in the brain',
+                                          manifold=(((1., 2., 3.), (4., 5., 6.)),),
+                                          conversion=2., unit='a unit',
                                           reference_frame='unknown')
 
         self.img_mask = deepcopy(img_mask)
@@ -131,11 +134,11 @@ class MaskIO(TestPlaneSegmentationIO, metaclass=ABCMeta):
                                               'optical channel description', 500.)
         self.imaging_plane = ImagingPlane('test_imaging_plane',
                                           self.optical_channel,
-                                          'imaging plane description',
-                                          self.device,
-                                          600., 300., 'GFP', 'somewhere in the brain',
-                                          (((1., 2., 3.), (4., 5., 6.)),),
-                                          4.0, 'manifold unit', 'A frame to refer to')
+                                          description='imaging plane description',
+                                          device=self.device,
+                                          excitation_lambda=600., imaging_rate=300., indicator='GFP',
+                                          location='somewhere in the brain', manifold=(((1., 2., 3.), (4., 5., 6.)),),
+                                          conversion=4.0, unit='manifold unit', reference_frame='A frame to refer to')
         return PlaneSegmentation('description', self.imaging_plane, 'test_plane_seg_name',
                                  self.image_series)
 

--- a/tests/unit/test_ophys.py
+++ b/tests/unit/test_ophys.py
@@ -20,8 +20,9 @@ def CreatePlaneSegmentation():
 
     oc = OpticalChannel('test_optical_channel', 'description', 500.)
     device = Device(name='device_name')
-    ip = ImagingPlane('test_imaging_plane', oc, 'description', device, 600.,
-                      300., 'indicator', 'location', reference_frame='reference_frame')
+    ip = ImagingPlane(name='test_imaging_plane', optical_channel=oc, description='description', device=device,
+                      excitation_lambda=600., imaging_rate=300., indicator='indicator', location='location',
+                      reference_frame='reference_frame')
 
     pS = PlaneSegmentation('description', ip, 'test_name', iSS)
     pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
@@ -36,8 +37,9 @@ class TwoPhotonSeriesConstructor(TestCase):
         self.assertEqual(oc.emission_lambda, 500.)
 
         device = Device(name='device_name')
-        ip = ImagingPlane('test_imaging_plane', oc, 'description', device, 600.,
-                          300., 'indicator', 'location', reference_frame='reference_frame',
+        ip = ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
+                          imaging_rate=300., indicator='indicator', location='location',
+                          reference_frame='reference_frame',
                           origin_coords=[10, 20], origin_coords_unit='oc_unit',
                           grid_spacing=[1, 2, 3], grid_spacing_unit='gs_unit')
         self.assertEqual(ip.optical_channel[0], oc)
@@ -69,8 +71,9 @@ class TwoPhotonSeriesConstructor(TestCase):
     def test_args(self):
         oc = OpticalChannel('test_name', 'description', 500.)
         device = Device(name='device_name')
-        ip = ImagingPlane('test_imaging_plane', oc, 'description', device, 600.,
-                          300., 'indicator', 'location', reference_frame='reference_frame')
+        ip = ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
+                          imaging_rate=300., indicator='indicator', location='location',
+                          reference_frame='reference_frame')
         with self.assertRaises(ValueError):  # no data or external file
             TwoPhotonSeries('test_tPS', unit='unit', field_of_view=[2., 3.],
                             imaging_plane=ip, pmt_gain=1.0, scan_line_rate=2.0,
@@ -85,8 +88,9 @@ class TwoPhotonSeriesConstructor(TestCase):
 
         msg = "The 'manifold' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'."
         with self.assertWarnsWith(DeprecationWarning, msg):
-            ImagingPlane('test_imaging_plane', oc, 'description', device, 600., 300., 'indicator', 'location',
-                         (1, 1, (2, 2, 2)))
+            ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
+                         imaging_rate=300., indicator='indicator', location='location',
+                         manifold=(1, 1, (2, 2, 2)))
 
     def test_conversion_deprecated(self):
         oc = OpticalChannel('test_name', 'description', 500.)
@@ -97,8 +101,8 @@ class TwoPhotonSeriesConstructor(TestCase):
 
         msg = "The 'conversion' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'."
         with self.assertWarnsWith(DeprecationWarning, msg):
-            ImagingPlane('test_imaging_plane', oc, 'description', device, 600., 300., 'indicator', 'location',
-                         None, 2.0)
+            ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
+                         imaging_rate=300., indicator='indicator', location='location',  conversion=2.0)
 
     def test_unit_deprecated(self):
         oc = OpticalChannel('test_name', 'description', 500.)
@@ -109,8 +113,8 @@ class TwoPhotonSeriesConstructor(TestCase):
 
         msg = "The 'unit' argument is deprecated in favor of 'origin_coords_unit' and 'grid_spacing_unit'."
         with self.assertWarnsWith(DeprecationWarning, msg):
-            ImagingPlane('test_imaging_plane', oc, 'description', device, 600., 300., 'indicator', 'location',
-                         None, 1.0, 'my_unit')
+            ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
+                         imaging_rate=300., indicator='indicator', location='location', conversion=1.0, unit='my_unit')
 
 
 class MotionCorrectionConstructor(TestCase):
@@ -190,8 +194,9 @@ class PlaneSegmentationConstructor(TestCase):
 
         device = Device(name='device_name')
         oc = OpticalChannel('test_optical_channel', 'description', 500.)
-        ip = ImagingPlane('test_imaging_plane', oc, 'description', device, 600.,
-                          300., 'indicator', 'location', reference_frame='reference_frame')
+        ip = ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
+                          imaging_rate=300., indicator='indicator', location='location',
+                          reference_frame='reference_frame')
         return iSS, ip
 
     def create_basic_plane_segmentation(self):


### PR DESCRIPTION
The current release of PyNWB, version 1.3.0, supports nwb-schema version 2.2.2. This PR adds support for nwb-schema bugfix version 2.2.3 and 2.2.4. 

This PR tracks the dev branch of nwb-schema to ensure that changes in nwb-schema are compatible with PyNWB or are accompanied with corresponding changes in PyNWB. Those changes in PyNWB should be merged into this branch. 

nwb-schema changelog:
- [x] Move nested type definitions to root of YAML files. This does not functionally change the schema.
- [x] Make `ImagingPlane.imaging_rate` optional to handle cases where an imaging plane is associated with multiple time series with different rates.
- [x] Add release process documentation.
- [x] Fix typo in nwb.ophys.yaml that prevents proper parsing of the schema.

TODO:
- [x] After new version of nwb-schema is released, update nwb-schema submodule to point to latest release: `cd src/pynwb/nwb-schema/`, `git pull origin dev`, `git fetch --tags`, `git checkout [new_release]`, `cd ../../..`, git add, commit, and push

When the new version of nwb-schema is released, this branch should be merged into dev _without_ squashing commits. 