### PR TITLE
ENH+RF: inform which unit value is actually overwritten (ignored and set)

### DIFF
--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -116,10 +116,7 @@ class CurrentClampSeries(PatchClampSeries):
              'default': 'volts'})
     def __init__(self, **kwargs):
         name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
-        if unit != 'volts':
-            warnings.warn("Unit for %s '%s' is ignored and will be set to 'volts' as per NWB 2.1.0."
-                          % (self.__class__.__name__, name))
-        unit = 'volts'
+        unit = ensure_unit(self, name, unit, 'volts', '2.1.0')
         bias_current, bridge_balance, capacitance_compensation = popargs(
             'bias_current', 'bridge_balance', 'capacitance_compensation', kwargs)
         super().__init__(name, data, unit, electrode, gain, **kwargs)
@@ -170,10 +167,7 @@ class CurrentClampStimulusSeries(PatchClampSeries):
              'default': 'amperes'})
     def __init__(self, **kwargs):
         name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
-        if unit != 'amperes':
-            warnings.warn("Unit for %s '%s' is ignored and will be set to 'amperes' as per "
-                          "NWB 2.1.0." % (self.__class__.__name__, name))
-        unit = 'amperes'
+        unit = ensure_unit(self, name, unit, 'amperes', '2.1.0')
         super().__init__(name, data, unit, electrode, gain, **kwargs)
 
 
@@ -209,10 +203,7 @@ class VoltageClampSeries(PatchClampSeries):
              'default': 'amperes'})
     def __init__(self, **kwargs):
         name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
-        if unit != 'amperes':
-            warnings.warn("Unit for %s '%s' is ignored and will be set to 'amperes' as per NWB 2.1.0."
-                          % (self.__class__.__name__, name))
-        unit = 'amperes'
+        unit = ensure_unit(self, name, unit, 'amperes', '2.1.0')
         capacitance_fast, capacitance_slow, resistance_comp_bandwidth, resistance_comp_correction, \
             resistance_comp_prediction, whole_cell_capacitance_comp, whole_cell_series_resistance_comp = popargs(
                 'capacitance_fast', 'capacitance_slow', 'resistance_comp_bandwidth',
@@ -245,10 +236,7 @@ class VoltageClampStimulusSeries(PatchClampSeries):
              'default': 'volts'})
     def __init__(self, **kwargs):
         name, data, unit, electrode, gain = popargs('name', 'data', 'unit', 'electrode', 'gain', kwargs)
-        if unit != 'volts':
-            warnings.warn("Unit for %s '%s' is ignored and will be set to 'volts' as per "
-                          "NWB 2.1.0." % (self.__class__.__name__, name))
-        unit = 'volts'
+        unit = ensure_unit(self, name, unit, 'volts', '2.1.0')
         super().__init__(name, data, unit, electrode, gain, **kwargs)
 
 
@@ -309,3 +297,17 @@ class SweepTable(DynamicTable):
         """
 
         return [index for index, elem in enumerate(self['sweep_number'].data) if elem == sweep_number]
+
+
+def ensure_unit(self, name, current_unit, unit, nwb_version):
+    """A helper to ensure correct unit used.
+
+    Issues a warning with details if `current_unit` is to be ignored, and
+    `unit` to be used instead.
+    """
+    if current_unit != unit:
+        warnings.warn(
+            "Unit '%s' for %s '%s' is ignored and will be set to '%s' "
+            "as per NWB %s."
+            % (current_unit, self.__class__.__name__, name, unit, nwb_version))
+    return unit

--- a/tests/unit/test_icephys.py
+++ b/tests/unit/test_icephys.py
@@ -205,7 +205,7 @@ class CurrentClampSeriesConstructor(TestCase):
     def test_unit_warning(self):
         electrode_name = GetElectrode()
 
-        msg = "Unit for CurrentClampSeries 'test_cCS' is ignored and will be set to 'volts' as per NWB 2.1.0."
+        msg = "Unit 'unit' for CurrentClampSeries 'test_cCS' is ignored and will be set to 'volts' as per NWB 2.1.0."
         with self.assertWarnsWith(UserWarning, msg):
             cCS = CurrentClampSeries('test_cCS', list(), electrode_name, 1.0, "stimset", 2.0, 3.0, 4.0,
                                      timestamps=list(), unit='unit')
@@ -229,7 +229,7 @@ class IZeroClampSeriesConstructor(TestCase):
     def test_unit_warning(self):
         electrode_name = GetElectrode()
 
-        msg = "Unit for IZeroClampSeries 'test_iZCS' is ignored and will be set to 'volts' as per NWB 2.1.0."
+        msg = "Unit 'unit' for IZeroClampSeries 'test_iZCS' is ignored and will be set to 'volts' as per NWB 2.1.0."
         with self.assertWarnsWith(UserWarning, msg):
             iZCS = IZeroClampSeries('test_iZCS', list(), electrode_name, 1.0, timestamps=list(), unit='unit')
         self.assertEqual(iZCS.unit, 'volts')
@@ -249,8 +249,8 @@ class CurrentClampStimulusSeriesConstructor(TestCase):
     def test_unit_warning(self):
         electrode_name = GetElectrode()
 
-        msg = ("Unit for CurrentClampStimulusSeries 'test_cCSS' is ignored and will be set to 'amperes' as per NWB "
-               "2.1.0.")
+        msg = ("Unit 'unit' for CurrentClampStimulusSeries 'test_cCSS' is ignored and will be set "
+               "to 'amperes' as per NWB 2.1.0.")
         with self.assertWarnsWith(UserWarning, msg):
             cCSS = CurrentClampStimulusSeries('test_cCSS', list(), electrode_name, 1.0, timestamps=list(), unit='unit')
         self.assertEqual(cCSS.unit, 'amperes')
@@ -279,7 +279,8 @@ class VoltageClampSeriesConstructor(TestCase):
     def test_unit_warning(self):
         electrode_name = GetElectrode()
 
-        msg = "Unit for VoltageClampSeries 'test_vCS' is ignored and will be set to 'amperes' as per NWB 2.1.0."
+        msg = "Unit 'unit' for VoltageClampSeries 'test_vCS' is ignored and will be set " \
+              "to 'amperes' as per NWB 2.1.0."
         with self.assertWarnsWith(UserWarning, msg):
             vCS = VoltageClampSeries('test_vCS', list(), electrode_name,
                                      1.0, "stimset", 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, timestamps=list(), unit='unit')
@@ -299,7 +300,8 @@ class VoltageClampStimulusSeriesConstructor(TestCase):
     def test_unit_warning(self):
         electrode_name = GetElectrode()
 
-        msg = "Unit for VoltageClampStimulusSeries 'test_vCSS' is ignored and will be set to 'volts' as per NWB 2.1.0."
+        msg = "Unit 'unit' for VoltageClampStimulusSeries 'test_vCSS' is ignored and will be set " \
+              "to 'volts' as per NWB 2.1.0."
         with self.assertWarnsWith(UserWarning, msg):
             vCSS = VoltageClampStimulusSeries('test_vCSS', list(), electrode_name, 1.0, timestamps=list(), unit='unit')
         self.assertEqual(vCSS.unit, 'volts')


### PR DESCRIPTION
While at it I RF code to avoid duplication (evil, tiresome to change) in the touched code

## Motivation

Otherwise user is left wondering "what was ignored? it might have been millivolts and now it became volts?" and alike.
