### PR TITLE
add continuity optional arg to TimeSeries.__init__

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -120,7 +120,7 @@ class TimeSeries(NWBDataInterface):
              'default': None},
             {'name': 'control_description', 'type': Iterable, 'doc': 'Description of each control value',
              'default': None},
-            {'name': 'continuity', 'type': str, 'default': None,
+            {'name': 'continuity', 'type': str, 'default': None, 'enum': ["continuous", "instantaneous", "step"],
              'doc': 'Optionally describe the continuity of the data. Can be "continuous", "instantaneous", or'
                     '"step". For example, a voltage trace would be "continuous", because samples are recorded from a '
                     'continuous process. An array of lick times would be "instantaneous", because the data represents '
@@ -131,11 +131,6 @@ class TimeSeries(NWBDataInterface):
     def __init__(self, **kwargs):
         """Create a TimeSeries object
         """
-        # validate continuity value
-        if kwargs['continuity'] not in (None, "continuous", "instantaneous", "step"):
-            raise ValueError(
-                'If "continuity" is defined, it must be of value "continuous", "instantaneous", or "step". Received '
-                'value "{}" for {} named {}'.format(kwargs['continuity'], self.__class__.__name__, kwargs['name']))
 
         call_docval_func(super(TimeSeries, self).__init__, kwargs)
         keys = ("resolution",

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -92,7 +92,8 @@ class TimeSeries(NWBDataInterface):
                      "rate",
                      "starting_time_unit",
                      "control",
-                     "control_description")
+                     "control_description",
+                     "continuity")
 
     __time_unit = "seconds"
 
@@ -118,10 +119,24 @@ class TimeSeries(NWBDataInterface):
             {'name': 'control', 'type': Iterable, 'doc': 'Numerical labels that apply to each element in data',
              'default': None},
             {'name': 'control_description', 'type': Iterable, 'doc': 'Description of each control value',
-             'default': None})
+             'default': None},
+            {'name': 'continuity', 'type': str, 'default': None,
+             'doc': 'Optionally describe the continuity of the data. Can be "continuous", "instantaneous", or'
+                    '"step". For example, a voltage trace would be "continuous", because samples are recorded from a '
+                    'continuous process. An array of lick times would be "instantaneous", because the data represents '
+                    'distinct moments in time. Times of image presentations would be  "step" because the picture '
+                    'remains the same until the next time-point. This field is optional, but is useful in providing '
+                    'information about the underlying data. It may inform the way this data is interpreted, the way it '
+                    'is visualized, and what analysis methods are applicable.'})
     def __init__(self, **kwargs):
         """Create a TimeSeries object
         """
+        # validate continuity value
+        if kwargs['continuity'] not in (None, "continuous", "instantaneous", "step"):
+            raise ValueError(
+                'If "continuity" is defined, it must be of value "continuous", "instantaneous", or "step". Received '
+                'value "{}" for {} named {}'.format(kwargs['continuity'], self.__class__.__name__, kwargs['name']))
+
         call_docval_func(super(TimeSeries, self).__init__, kwargs)
         keys = ("resolution",
                 "comments",
@@ -129,7 +144,8 @@ class TimeSeries(NWBDataInterface):
                 "conversion",
                 "unit",
                 "control",
-                "control_description")
+                "control_description",
+                "continuity")
         for key in keys:
             val = kwargs.get(key)
             if val is not None:

--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -29,6 +29,7 @@ class TimeSeriesMap(NWBContainerMapper):
         self.map_spec('unit', data_spec.get_attribute('unit'))
         self.map_spec('resolution', data_spec.get_attribute('resolution'))
         self.map_spec('conversion', data_spec.get_attribute('conversion'))
+        self.map_spec('continuity', data_spec.get_attribute('continuity'))
 
         timestamps_spec = self.spec.get_dataset('timestamps')
         self.map_spec('timestamps_unit', timestamps_spec.get_attribute('unit'))

--- a/tests/integration/hdf5/test_base.py
+++ b/tests/integration/hdf5/test_base.py
@@ -15,7 +15,8 @@ class TestTimeSeriesIO(AcquisitionH5IOMixin, TestCase):
             data=list(range(1000)),
             unit='SIunit',
             timestamps=np.arange(1000.),
-            resolution=0.1
+            resolution=0.1,
+            continuity='continuous',
         )
 
 

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -124,6 +124,20 @@ class TestTimeSeries(TestCase):
                          'grams', timestamps=ts1)
         self.assertEqual(ts2.timestamps, [0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
 
+    def test_good_continuity_timeseries(self):
+
+        ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],
+                         'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+                         continuity='continuous')
+        self.assertEqual(ts1.continuity, 'continuous')
+
+    def test_bad_continuity_timeseries(self):
+
+        with self.assertRaises(ValueError):
+            ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],
+                             'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+                             continuity='wrong')
+
     def test_nodata(self):
         ts1 = TimeSeries('test_ts1', starting_time=0.0, rate=0.1)
         with self.assertWarns(UserWarning):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -125,18 +125,16 @@ class TestTimeSeries(TestCase):
         self.assertEqual(ts2.timestamps, [0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
 
     def test_good_continuity_timeseries(self):
-
         ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],
                          'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
                          continuity='continuous')
         self.assertEqual(ts1.continuity, 'continuous')
 
     def test_bad_continuity_timeseries(self):
-
         with self.assertRaises(ValueError):
-            ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],
-                             'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
-                             continuity='wrong')
+            TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],
+                       'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
+                        continuity='wrong')
 
     def test_nodata(self):
         ts1 = TimeSeries('test_ts1', starting_time=0.0, rate=0.1)

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -134,7 +134,7 @@ class TestTimeSeries(TestCase):
         with self.assertRaises(ValueError):
             TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5],
                        'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5],
-                        continuity='wrong')
+                       continuity='wrong')
 
     def test_nodata(self):
         ts1 = TimeSeries('test_ts1', starting_time=0.0, rate=0.1)


### PR DESCRIPTION
## Motivation

develop API for https://github.com/NeurodataWithoutBorders/nwb-schema/pull/425

depends on https://github.com/hdmf-dev/hdmf/issues/334

## How to test the behavior?
```python
TimeSeries(name='my_name', description='my_description', data=[1,2,3], timestamps=[1,2,3], continuity='step')

TimeSeries(name='my_name', description='my_description', data=[1,2,3], timestamps=[1,2,3], continuity='result_in_error')
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
