### PR TITLE
Fix missing method UnitsMap.get_nwb_file

### DIFF
--- a/src/pynwb/io/misc.py
+++ b/src/pynwb/io/misc.py
@@ -46,5 +46,5 @@ class UnitsMap(DynamicTableMap):
             return ret
         # set the electrode table if it hasn't been set yet
         if ret.target.table is None:
-            ret.target.table = self.get_nwb_file(container).electrodes
+            ret.target.table = container.get_ancestor('NWBFile').electrodes
         return ret


### PR DESCRIPTION
`pynwb.io.misc.UnitsMap` calls the method `get_nwb_file` which doesn't exist. I replaced the function call with what it should be (there is similar code in `Units.add_unit`).


I got here because I accidentally called `Units.add_row` instead of `Units.add_unit`. Should we also make `Units.add_unit` and `Units.add_row` do the same thing?