### PR TITLE
Fix docs for get_type_map

### DIFF
--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -49,12 +49,12 @@ __TYPE_MAP.merge(hdmf_typemap)
 @docval({'name': 'extensions', 'type': (str, TypeMap, list),
          'doc': 'a path to a namespace, a TypeMap, or a list consisting of paths to namespaces and TypeMaps',
          'default': None},
-        returns="the namespaces loaded from the given file", rtype=tuple,
+        returns="TypeMap loaded for the given extension or NWB core namespace", rtype=tuple,
         is_method=False)
 def get_type_map(**kwargs):
     '''
-    Get a BuildManager to use for I/O using the given extensions. If no extensions are provided,
-    return a BuildManager that uses the core namespace
+    Get the TypeMap for the given extensions. If no extensions are provided,
+    return the TypeMap for the core namespace
     '''
     extensions = getargs('extensions', kwargs)
     type_map = None


### PR DESCRIPTION
## Motivation

The docstring of the ``get_type_map`` function seemed to be copied from the ``get_build_manager`` The PR attempts to fix the docstring. 

## Checklist

- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR description clearly describes problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
