### PR TITLE
pass file object to parent when loading namespaces

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # these minimum requirements specify '==' for testing; setup.py replaces '==' with '>='
 h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
-hdmf==1.6.1,<2
+hdmf==1.6.2,<2
 numpy==1.16
 pandas==0.23
 python-dateutil==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 h5py==2.10.0
-hdmf==1.6.1
+hdmf==1.6.2
 numpy==1.18.1
 pandas==0.25.3
 python-dateutil==2.8.1

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -227,7 +227,7 @@ class NWBHDF5IO(_HDF5IO):
                 raise ValueError("cannot load namespaces from file when writing to it")
 
             tm = get_type_map()
-            super(NWBHDF5IO, self).load_namespaces(tm, path)
+            super(NWBHDF5IO, self).load_namespaces(tm, path, file=file_obj)
             manager = BuildManager(tm)
 
             # XXX: Leaving this here in case we want to revert to this strategy for


### PR DESCRIPTION
This is a very minor change, companion to https://github.com/hdmf-dev/hdmf/pull/348. It updates the NWBHDF5IO constructor to pass an argued file (or None) to its parent when loading namespaces. 

This should not be merged until a version of hdmf with pr 438 incorporated is released. 