### PR TITLE
Add support for NWB schema 2.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # PyNWB Changelog
 
+## PyNWB 1.3.2 (June 1, 2020)
+
+### Bug fixes:
+- Add support for nwb-schema 2.2.5. @rly (#1243)
+  - This schema version fixes incorrect dims and shape for `ImagingPlane.origin_coords` and `ImagingPlane.grid_spacing`,
+   and fixes incorrect dims for `TwoPhotonSeries.field_of_view`.
+
 ## PyNWB 1.3.1 (May 28, 2020)
 
 ### Bug fixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 ### Bug fixes:
 - Fix bugged `Device` constructor. @rly (#1209)
 - Fix link to code of conduct page in docs. @rly (#1229)
-- Fix docs for get_type_map. @oruebel (#1233)
-- Pass file object to parent when loading namespaces (#1242)
+- Fix docs for `get_type_map`. @oruebel (#1233)
+- Pass file object to parent when loading namespaces. @NileGraddis (#1242)
 
 ### Internal improvements:
 - Update CI to use supported MacOS version. @rly (#1211)
@@ -17,17 +17,15 @@
 - Inform which unit value is actually overwritten. @yarikoptic (#1219)
 - Do not print out logging.DEBUG statements to stdout for test.py. @rly (#1240)
 - Add support for nwb-schema 2.2.4. @rly (#1213)
-  - Make `ImagingPlane.imaging_rate` optional. This moves the `imaging_rate` argument down the list of constructor
-    arguments for `ImagingPlane.__init__`. This will break existing code that calls the constructor of
-    `ImagingPlane` with at least 6 positional arguments, such that one positional argument matches `imaging_rate`.
+  - Make `ImagingPlane.imaging_rate` optional. This moves the `imaging_rate` argument down the list of constructor arguments for `ImagingPlane.__init__`. This will break existing code that calls the constructor of `ImagingPlane` with at least 6 positional arguments, such that one positional argument matches `imaging_rate`.
 
 ## PyNWB 1.3.0 (Mar. 4, 2020)
 
 ### New features:
 - Add support for nwb-schema 2.2.2. @rly (#1146)
-  - This is a large change. See the PR and schema release notes for more information: nwb-schema.readthedocs.io/en/latest/format_release_notes.html#march-2-2020
+  - This is a large change. See the PR and [schema release notes](http://nwb-schema.readthedocs.io/en/latest/format_release_notes.html#march-2-2020) for more information.
 - Validate against most specific namespace. @t-b, @rly (#1094)
-- Replace 'ic_electrode' with 'icephys_electrode' in NWBFile. @oruebel (#1200)
+- Replace 'ic_electrode' with 'icephys_electrode' in `NWBFile`. @oruebel (#1200)
 - Integrate minor enhancements and bug fixes introduced in HDMF 1.6.0 and 1.6.1, including improved handling of namespaces that lack a version key,
 
 ### Internal improvements:
@@ -42,7 +40,7 @@
 - Fix unit testing output. @rly (#1158)
 - Fix copying files with Subject. @rly (#1171)
 - Add "unit" attribute back as an optional attribute in icephys classes. @rly (#1188)
-- Fix reported development status in setup.py. @rly (#1201)
+- Fix reported development status in `setup.py`. @rly (#1201)
 
 ## PyNWB 1.2.1 (Jan. 22, 2020)
 

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -33,7 +33,11 @@ class TestImagingPlaneIO(NWBH5IOMixin, TestCase):
             imaging_rate=300.,
             indicator='GFP',
             location='somewhere in the brain',
-            reference_frame='unknown'
+            reference_frame='unknown',
+            origin_coords=[10, 20],
+            origin_coords_unit='millimeters',
+            grid_spacing=[0.001, 0.001],
+            grid_spacing_unit='millimeters',
         )
 
     def addContainer(self, nwbfile):

--- a/tests/unit/test_ophys.py
+++ b/tests/unit/test_ophys.py
@@ -1,47 +1,110 @@
 import numpy as np
 
-from pynwb.ophys import TwoPhotonSeries, RoiResponseSeries, DfOverF, Fluorescence, PlaneSegmentation, \
-    ImageSegmentation, OpticalChannel, ImagingPlane, MotionCorrection, CorrectedImageStack
-from pynwb.image import ImageSeries
 from pynwb.base import TimeSeries
 from pynwb.device import Device
-from pynwb.base import ProcessingModule
+from pynwb.image import ImageSeries
+from pynwb.ophys import (TwoPhotonSeries, RoiResponseSeries, DfOverF, Fluorescence, PlaneSegmentation,
+                         ImageSegmentation, OpticalChannel, ImagingPlane, MotionCorrection, CorrectedImageStack)
 from pynwb.testing import TestCase
 
 
-def CreatePlaneSegmentation():
+def create_imaging_plane():
+    oc = OpticalChannel(
+        name='test_optical_channel',
+        description='description',
+        emission_lambda=500.
+    )
+
+    device = Device(name='device_name')
+
+    ip = ImagingPlane(
+        name='test_imaging_plane',
+        optical_channel=oc,
+        description='description',
+        device=device,
+        excitation_lambda=600.,
+        imaging_rate=300.,
+        indicator='indicator',
+        location='location',
+        reference_frame='reference_frame',
+        origin_coords=[10, 20],
+        origin_coords_unit='oc_unit',
+        grid_spacing=[1, 2, 3],
+        grid_spacing_unit='gs_unit'
+    )
+    return ip
+
+
+def create_plane_segmentation():
     w, h = 5, 5
     img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
     pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
                 [7, 8, 2.0], [9, 10, 2.0]]
 
-    iSS = ImageSeries(name='test_iS', data=np.ones((2, 2, 2)), unit='unit',
-                      external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=[1., 2.])
+    iSS = ImageSeries(
+        name='test_iS',
+        data=np.ones((2, 2, 2)),
+        unit='unit',
+        external_file=['external_file'],
+        starting_frame=[1, 2, 3],
+        format='tiff',
+        timestamps=[1., 2.]
+    )
 
-    oc = OpticalChannel('test_optical_channel', 'description', 500.)
-    device = Device(name='device_name')
-    ip = ImagingPlane(name='test_imaging_plane', optical_channel=oc, description='description', device=device,
-                      excitation_lambda=600., imaging_rate=300., indicator='indicator', location='location',
-                      reference_frame='reference_frame')
+    ip = create_imaging_plane()
 
-    pS = PlaneSegmentation('description', ip, 'test_name', iSS)
+    pS = PlaneSegmentation(
+        description='description',
+        imaging_plane=ip,
+        name='test_name',
+        reference_images=iSS
+    )
     pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
     pS.add_roi(pixel_mask=pix_mask[3:5], image_mask=img_mask[1])
     return pS
 
 
-class TwoPhotonSeriesConstructor(TestCase):
+class OpticalChannelConstructor(TestCase):
     def test_init(self):
-        oc = OpticalChannel('test_name', 'description', 500.)
+        oc = OpticalChannel(
+            name='test_optical_channel',
+            description='description',
+            emission_lambda=500.
+        )
+        self.assertEqual(oc.name, 'test_optical_channel')
         self.assertEqual(oc.description, 'description')
         self.assertEqual(oc.emission_lambda, 500.)
 
+
+class ImagingPlaneConstructor(TestCase):
+
+    def set_up_dependencies(self):
+        oc = OpticalChannel(
+            name='test_optical_channel',
+            description='description',
+            emission_lambda=500.
+        )
         device = Device(name='device_name')
-        ip = ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
-                          imaging_rate=300., indicator='indicator', location='location',
-                          reference_frame='reference_frame',
-                          origin_coords=[10, 20], origin_coords_unit='oc_unit',
-                          grid_spacing=[1, 2, 3], grid_spacing_unit='gs_unit')
+        return oc, device
+
+    def test_init(self):
+        oc, device = self.set_up_dependencies()
+
+        ip = ImagingPlane(
+            name='test_imaging_plane',
+            optical_channel=oc,
+            description='description',
+            device=device,
+            excitation_lambda=600.,
+            imaging_rate=300.,
+            indicator='indicator',
+            location='location',
+            reference_frame='reference_frame',
+            origin_coords=[10, 20],
+            origin_coords_unit='oc_unit',
+            grid_spacing=[1, 2, 3],
+            grid_spacing_unit='gs_unit'
+        )
         self.assertEqual(ip.optical_channel[0], oc)
         self.assertEqual(ip.device, device)
         self.assertEqual(ip.excitation_lambda, 600.)
@@ -54,9 +117,75 @@ class TwoPhotonSeriesConstructor(TestCase):
         self.assertEqual(ip.grid_spacing, [1, 2, 3])
         self.assertEqual(ip.grid_spacing_unit, 'gs_unit')
 
-        tPS = TwoPhotonSeries('test_tPS', unit='unit', field_of_view=[2., 3.],
-                              imaging_plane=ip, pmt_gain=1.0, scan_line_rate=2.0, external_file=['external_file'],
-                              starting_frame=[1, 2, 3], format='tiff', timestamps=list())
+    def test_manifold_deprecated(self):
+        oc, device = self.set_up_dependencies()
+
+        msg = "The 'manifold' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'."
+        with self.assertWarnsWith(DeprecationWarning, msg):
+            ImagingPlane(
+                name='test_imaging_plane',
+                optical_channel=oc,
+                description='description',
+                device=device,
+                excitation_lambda=600.,
+                imaging_rate=300.,
+                indicator='indicator',
+                location='location',
+                manifold=(1, 1, (2, 2, 2))
+            )
+
+    def test_conversion_deprecated(self):
+        oc, device = self.set_up_dependencies()
+
+        msg = "The 'conversion' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'."
+        with self.assertWarnsWith(DeprecationWarning, msg):
+            ImagingPlane(
+                name='test_imaging_plane',
+                optical_channel=oc,
+                description='description',
+                device=device,
+                excitation_lambda=600.,
+                imaging_rate=300.,
+                indicator='indicator',
+                location='location',
+                conversion=2.0
+            )
+
+    def test_unit_deprecated(self):
+        oc, device = self.set_up_dependencies()
+
+        msg = "The 'unit' argument is deprecated in favor of 'origin_coords_unit' and 'grid_spacing_unit'."
+        with self.assertWarnsWith(DeprecationWarning, msg):
+            ImagingPlane(
+                name='test_imaging_plane',
+                optical_channel=oc,
+                description='description',
+                device=device,
+                excitation_lambda=600.,
+                imaging_rate=300.,
+                indicator='indicator',
+                location='location',
+                reference_frame='reference_frame',
+                unit='my_unit'
+            )
+
+
+class TwoPhotonSeriesConstructor(TestCase):
+
+    def test_init(self):
+        ip = create_imaging_plane()
+        tPS = TwoPhotonSeries(
+            name='test_tPS',
+            unit='unit',
+            field_of_view=[2., 3.],
+            imaging_plane=ip,
+            pmt_gain=1.0,
+            scan_line_rate=2.0,
+            external_file=['external_file'],
+            starting_frame=[1, 2, 3],
+            format='tiff',
+            timestamps=list()
+        )
         self.assertEqual(tPS.name, 'test_tPS')
         self.assertEqual(tPS.unit, 'unit')
         self.assertEqual(tPS.field_of_view, [2., 3.])
@@ -68,53 +197,22 @@ class TwoPhotonSeriesConstructor(TestCase):
         self.assertEqual(tPS.format, 'tiff')
         self.assertIsNone(tPS.dimension)
 
-    def test_args(self):
-        oc = OpticalChannel('test_name', 'description', 500.)
-        device = Device(name='device_name')
-        ip = ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
-                          imaging_rate=300., indicator='indicator', location='location',
-                          reference_frame='reference_frame')
-        with self.assertRaises(ValueError):  # no data or external file
-            TwoPhotonSeries('test_tPS', unit='unit', field_of_view=[2., 3.],
-                            imaging_plane=ip, pmt_gain=1.0, scan_line_rate=2.0,
-                            starting_frame=[1, 2, 3], format='tiff', timestamps=[1., 2.])
+    def test_missing_data_external(self):
+        ip = create_imaging_plane()
 
-    def test_manifold_deprecated(self):
-        oc = OpticalChannel('test_name', 'description', 500.)
-        self.assertEqual(oc.description, 'description')
-        self.assertEqual(oc.emission_lambda, 500.)
-
-        device = Device(name='device_name')
-
-        msg = "The 'manifold' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'."
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
-                         imaging_rate=300., indicator='indicator', location='location',
-                         manifold=(1, 1, (2, 2, 2)))
-
-    def test_conversion_deprecated(self):
-        oc = OpticalChannel('test_name', 'description', 500.)
-        self.assertEqual(oc.description, 'description')
-        self.assertEqual(oc.emission_lambda, 500.)
-
-        device = Device(name='device_name')
-
-        msg = "The 'conversion' argument is deprecated in favor of 'origin_coords' and 'grid_spacing'."
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
-                         imaging_rate=300., indicator='indicator', location='location',  conversion=2.0)
-
-    def test_unit_deprecated(self):
-        oc = OpticalChannel('test_name', 'description', 500.)
-        self.assertEqual(oc.description, 'description')
-        self.assertEqual(oc.emission_lambda, 500.)
-
-        device = Device(name='device_name')
-
-        msg = "The 'unit' argument is deprecated in favor of 'origin_coords_unit' and 'grid_spacing_unit'."
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
-                         imaging_rate=300., indicator='indicator', location='location', conversion=1.0, unit='my_unit')
+        msg = 'must supply either external_file or data to test_tPS'
+        with self.assertRaisesWith(ValueError, msg):  # no data or external file
+            TwoPhotonSeries(
+                name='test_tPS',
+                unit='unit',
+                field_of_view=[2., 3.],
+                imaging_plane=ip,
+                pmt_gain=1.0,
+                scan_line_rate=2.0,
+                starting_frame=[1, 2, 3],
+                format='tiff',
+                timestamps=[1., 2.]
+            )
 
 
 class MotionCorrectionConstructor(TestCase):
@@ -124,14 +222,36 @@ class MotionCorrectionConstructor(TestCase):
 
 class CorrectedImageStackConstructor(TestCase):
     def test_init(self):
-        is1 = ImageSeries(name='is1', data=np.ones((2, 2, 2)), unit='unit',
-                          external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=[1., 2.])
-        is2 = ImageSeries(name='is2', data=np.ones((2, 2, 2)), unit='unit',
-                          external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=[1., 2.])
+        is1 = ImageSeries(
+            name='is1',
+            data=np.ones((2, 2, 2)),
+            unit='unit',
+            external_file=['external_file'],
+            starting_frame=[1, 2, 3],
+            format='tiff',
+            timestamps=[1., 2.]
+        )
+        is2 = ImageSeries(
+            name='is2',
+            data=np.ones((2, 2, 2)),
+            unit='unit',
+            external_file=['external_file'],
+            starting_frame=[1, 2, 3],
+            format='tiff',
+            timestamps=[1., 2.]
+        )
         tstamps = np.arange(1.0, 100.0, 0.1, dtype=np.float)
-        ts = TimeSeries("test_ts", list(range(len(tstamps))), 'unit', timestamps=tstamps)
-        cis = CorrectedImageStack(is1, is2, ts)
-        ProcessingModule('name', 'description').add(cis)
+        ts = TimeSeries(
+            name="test_ts",
+            data=list(range(len(tstamps))),
+            unit='unit',
+            timestamps=tstamps
+        )
+        cis = CorrectedImageStack(
+            corrected=is1,
+            original=is2,
+            xy_translation=ts
+        )
         self.assertEqual(cis.corrected, is1)
         self.assertEqual(cis.original, is2)
         self.assertEqual(cis.xy_translation, ts)
@@ -139,11 +259,16 @@ class CorrectedImageStackConstructor(TestCase):
 
 class RoiResponseSeriesConstructor(TestCase):
     def test_init(self):
-        ip = CreatePlaneSegmentation()
+        ps = create_plane_segmentation()
+        rt_region = ps.create_roi_table_region(description='the second ROI', region=[0])
 
-        rt_region = ip.create_roi_table_region('the second ROI', region=[0])
-
-        ts = RoiResponseSeries('test_ts', list(), rt_region, unit='unit', timestamps=list())
+        ts = RoiResponseSeries(
+            name='test_ts',
+            data=list(),
+            rois=rt_region,
+            unit='unit',
+            timestamps=list()
+        )
         self.assertEqual(ts.name, 'test_ts')
         self.assertEqual(ts.unit, 'unit')
         self.assertEqual(ts.rois, rt_region)
@@ -151,11 +276,16 @@ class RoiResponseSeriesConstructor(TestCase):
 
 class DfOverFConstructor(TestCase):
     def test_init(self):
-        ip = CreatePlaneSegmentation()
+        ps = create_plane_segmentation()
+        rt_region = ps.create_roi_table_region(description='the second ROI', region=[1])
 
-        rt_region = ip.create_roi_table_region('the second ROI', region=[1])
-
-        rrs = RoiResponseSeries('test_ts', list(), rt_region, unit='unit', timestamps=list())
+        rrs = RoiResponseSeries(
+            name='test_ts',
+            data=list(),
+            rois=rt_region,
+            unit='unit',
+            timestamps=list()
+        )
 
         dof = DfOverF(rrs)
         self.assertEqual(dof.roi_response_series['test_ts'], rrs)
@@ -163,21 +293,25 @@ class DfOverFConstructor(TestCase):
 
 class FluorescenceConstructor(TestCase):
     def test_init(self):
-        ip = CreatePlaneSegmentation()
+        ps = create_plane_segmentation()
+        rt_region = ps.create_roi_table_region(description='the second ROI', region=[1])
 
-        rt_region = ip.create_roi_table_region('the second ROI', region=[1])
-
-        ts = RoiResponseSeries('test_ts', list(), rt_region, unit='unit', timestamps=list())
+        ts = RoiResponseSeries(
+            name='test_ts',
+            data=list(),
+            rois=rt_region,
+            unit='unit',
+            timestamps=list()
+        )
 
         ff = Fluorescence(ts)
-        self.assertEqual(ff.roi_response_series['test_ts'], ts)
         self.assertEqual(ff.roi_response_series['test_ts'], ts)
 
 
 class ImageSegmentationConstructor(TestCase):
 
     def test_init(self):
-        ps = CreatePlaneSegmentation()
+        ps = create_plane_segmentation()
 
         iS = ImageSegmentation(ps, name='test_iS')
         self.assertEqual(iS.name, 'test_iS')
@@ -187,22 +321,30 @@ class ImageSegmentationConstructor(TestCase):
 
 class PlaneSegmentationConstructor(TestCase):
 
-    def getBoilerPlateObjects(self):
+    def set_up_dependencies(self):
+        iSS = ImageSeries(
+            name='test_iS',
+            data=np.ones((2, 2, 2)),
+            unit='unit',
+            external_file=['external_file'],
+            starting_frame=[1, 2, 3],
+            format='tiff',
+            timestamps=list()
+        )
 
-        iSS = ImageSeries(name='test_iS', data=np.ones((2, 2, 2)), unit='unit',
-                          external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff', timestamps=list())
-
-        device = Device(name='device_name')
-        oc = OpticalChannel('test_optical_channel', 'description', 500.)
-        ip = ImagingPlane('test_imaging_plane', oc, description='description', device=device, excitation_lambda=600.,
-                          imaging_rate=300., indicator='indicator', location='location',
-                          reference_frame='reference_frame')
+        ip = create_imaging_plane()
         return iSS, ip
 
     def create_basic_plane_segmentation(self):
         """Creates a basic plane segmentation used for testing"""
-        iSS, ip = self.getBoilerPlateObjects()
-        return PlaneSegmentation('description', ip, 'test_name', iSS)
+        iSS, ip = self.set_up_dependencies()
+        pS = PlaneSegmentation(
+            description='description',
+            imaging_plane=ip,
+            name='test_name',
+            reference_images=iSS
+        )
+        return iSS, ip, pS
 
     def test_init(self):
         w, h = 5, 5
@@ -210,14 +352,12 @@ class PlaneSegmentationConstructor(TestCase):
         pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
                     [7, 8, 2.0], [9, 10, 2.0]]
 
-        iSS, ip = self.getBoilerPlateObjects()
-
-        pS = PlaneSegmentation('description', ip, 'test_name', iSS)
+        iSS, ip, pS = self.create_basic_plane_segmentation()
         pS.add_roi(pixel_mask=pix_mask[0:3], image_mask=img_mask[0])
         pS.add_roi(pixel_mask=pix_mask[3:5], image_mask=img_mask[1])
 
+        self.assertEqual(pS.name, 'test_name')
         self.assertEqual(pS.description, 'description')
-
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, (iSS,))
 
@@ -230,14 +370,12 @@ class PlaneSegmentationConstructor(TestCase):
         pix_mask = [[1, 2, 1.0], [3, 4, 1.0], [5, 6, 1.0],
                     [7, 8, 2.0], [9, 10, 2.0]]
 
-        iSS, ip = self.getBoilerPlateObjects()
-
-        pS = PlaneSegmentation('description', ip, 'test_name', iSS)
+        iSS, ip, pS = self.create_basic_plane_segmentation()
         pS.add_roi(pixel_mask=pix_mask[0:3])
         pS.add_roi(pixel_mask=pix_mask[3:5])
 
+        self.assertEqual(pS.name, 'test_name')
         self.assertEqual(pS.description, 'description')
-
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, (iSS,))
 
@@ -249,14 +387,12 @@ class PlaneSegmentationConstructor(TestCase):
         vox_mask = [[1, 2, 3, 1.0], [3, 4, 1, 1.0], [5, 6, 3, 1.0],
                     [7, 8, 3, 2.0], [9, 10, 2, 2.0]]
 
-        iSS, ip = self.getBoilerPlateObjects()
-
-        pS = PlaneSegmentation('description', ip, 'test_name', iSS)
+        iSS, ip, pS = self.create_basic_plane_segmentation()
         pS.add_roi(voxel_mask=vox_mask[0:3])
         pS.add_roi(voxel_mask=vox_mask[3:5])
 
+        self.assertEqual(pS.name, 'test_name')
         self.assertEqual(pS.description, 'description')
-
         self.assertEqual(pS.imaging_plane, ip)
         self.assertEqual(pS.reference_images, (iSS,))
 
@@ -264,10 +400,25 @@ class PlaneSegmentationConstructor(TestCase):
         self.assertEqual(pS['voxel_mask'][0], vox_mask[0:3])
         self.assertEqual(pS['voxel_mask'][1], vox_mask[3:5])
 
+    def test_init_image_mask(self):
+        w, h = 5, 5
+        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
+
+        iSS, ip, pS = self.create_basic_plane_segmentation()
+        pS.add_roi(image_mask=img_mask[0])
+        pS.add_roi(image_mask=img_mask[1])
+
+        self.assertEqual(pS.name, 'test_name')
+        self.assertEqual(pS.description, 'description')
+        self.assertEqual(pS.imaging_plane, ip)
+        self.assertEqual(pS.reference_images, (iSS,))
+
+        self.assertEqual(pS['image_mask'].data, img_mask)
+
     def test_init_3d_image_mask(self):
         img_masks = np.random.randn(2, 20, 30, 4)
 
-        pS = self.create_basic_plane_segmentation()
+        _, _, pS = self.create_basic_plane_segmentation()
         pS.add_roi(image_mask=img_masks[0])
         pS.add_roi(image_mask=img_masks[1])
 
@@ -277,7 +428,7 @@ class PlaneSegmentationConstructor(TestCase):
     def test_conversion_of_2d_pixel_mask_to_image_mask(self):
         pixel_mask = [[0, 0, 1.0], [1, 0, 2.0], [2, 0, 2.0]]
 
-        pS = self.create_basic_plane_segmentation()
+        _, _, pS = self.create_basic_plane_segmentation()
 
         img_mask = pS.pixel_to_image(pixel_mask)
         np.testing.assert_allclose(img_mask, np.asarray([[1, 2, 2.0],
@@ -289,24 +440,7 @@ class PlaneSegmentationConstructor(TestCase):
                                  [0.0, 1.0, 0.0],
                                  [0.0, 0.0, 1.0]])
 
-        pS = self.create_basic_plane_segmentation()
+        _, _, pS = self.create_basic_plane_segmentation()
 
         pixel_mask = pS.image_to_pixel(image_mask)
         np.testing.assert_allclose(pixel_mask, np.asarray([[0, 0, 1.0], [1, 1, 1.0], [2, 2, 1.0]]))
-
-    def test_init_image_mask(self):
-        w, h = 5, 5
-        img_mask = [[[1.0 for x in range(w)] for y in range(h)], [[2.0 for x in range(w)] for y in range(h)]]
-
-        iSS, ip = self.getBoilerPlateObjects()
-
-        pS = PlaneSegmentation('description', ip, 'test_name', iSS)
-        pS.add_roi(image_mask=img_mask[0])
-        pS.add_roi(image_mask=img_mask[1])
-
-        self.assertEqual(pS.description, 'description')
-
-        self.assertEqual(pS.imaging_plane, ip)
-        self.assertEqual(pS.reference_images, (iSS,))
-
-        self.assertEqual(pS['image_mask'].data, img_mask)


### PR DESCRIPTION
The current release of PyNWB, version 1.3.1, supports nwb-schema version 2.2.4. This PR adds support for nwb-schema bugfix version 2.2.5.

This PR tracks the dev branch of nwb-schema to ensure that changes in nwb-schema are compatible with PyNWB or are accompanied with corresponding changes in PyNWB. Those changes in PyNWB should be merged into this branch.

- [x] Update PyNWB to work with changes in nwb-schema:

    - [x] Add schema validation CI.
    - [x] Fix incorrect dims and shape for ``ImagingPlane.origin_coords`` and ``ImagingPlane.grid_spacing``, and fix incorrect dims for ``TwoPhotonSeries.field_of_view``.
- [x] Add integration tests that use ``ImagingPlane.origin_coords`` and ``ImagingPlane.grid_spacing``
- [x] Run validation tests
- [x] Update changelog
- [x] After new version of nwb-schema is released, update the nwb-schema submodule to point to latest release: `cd src/pynwb/nwb-schema/`, `git checkout dev`, `git pull origin dev`, `git fetch --tags`, `git checkout dev`, `cd ../../..`, `git add .`, `git commit -m "Update nwb-schema submodule to [new_release]`, and `git push`

After merging:
- This branch should be merged into dev without squashing commits. Rebase if necessary.
- Prepare for immediate bugfix release of PyNWB 1.3.2