### PR TITLE
add Units.waveforms, unit test, and integration test

### DIFF
--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -525,9 +525,12 @@ class NWBFile(MultiContainerInterface):
                     ('rel_y', 'the y coordinate within the electrode group'),
                     ('rel_z', 'the z coordinate within the electrode group'),
                     ('reference', 'Description of the reference used for this electrode.')]
+        # add column if the arg is supplied and column does not yet exist
+        # do not pass arg to add_row if arg is not supplied
         for col_name, col_doc in new_cols:
-            if kwargs[col_name] is not None and col_name not in self.electrodes:
-                self.electrodes.add_column(col_name, col_doc)
+            if kwargs[col_name] is not None:
+                if col_name not in self.electrodes:
+                    self.electrodes.add_column(col_name, col_doc)
             else:
                 d.pop(col_name)  # remove args from d if not set
 

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -137,11 +137,11 @@ class Units(DynamicTable):
         'resolution'
     )
 
-    waveforms_desc = 'Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension ' \
-                     'shows the response from different electrodes that all observe this unit simultaneously. In this' \
-                     ' case, the `electrodes` column of this Units table should be used to indicate which electrodes ' \
-                     'are associated with this unit, and the electrodes dimension here should be in the same order as' \
-                     ' the electrodes referenced in the `electrodes` column of this table.'
+    waveforms_desc = ('Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension ' 
+                      'shows the response from different electrodes that all observe this unit simultaneously. In this' 
+                      ' case, the `electrodes` column of this Units table should be used to indicate which electrodes ' 
+                      'are associated with this unit, and the electrodes dimension here should be in the same order as' 
+                      ' the electrodes referenced in the `electrodes` column of this table.')
     __columns__ = (
         {'name': 'spike_times', 'description': 'the spike times for each unit', 'index': True},
         {'name': 'obs_intervals', 'description': 'the observation intervals for each unit',

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -137,10 +137,10 @@ class Units(DynamicTable):
         'resolution'
     )
 
-    waveforms_desc = ('Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension ' 
-                      'shows the response from different electrodes that all observe this unit simultaneously. In this' 
-                      ' case, the `electrodes` column of this Units table should be used to indicate which electrodes ' 
-                      'are associated with this unit, and the electrodes dimension here should be in the same order as' 
+    waveforms_desc = ('Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension '
+                      'shows the response from different electrodes that all observe this unit simultaneously. In this'
+                      ' case, the `electrodes` column of this Units table should be used to indicate which electrodes '
+                      'are associated with this unit, and the electrodes dimension here should be in the same order as'
                       ' the electrodes referenced in the `electrodes` column of this table.')
     __columns__ = (
         {'name': 'spike_times', 'description': 'the spike times for each unit', 'index': True},

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -137,6 +137,11 @@ class Units(DynamicTable):
         'resolution'
     )
 
+    waveforms_desc = 'Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension ' \
+                     'shows the response from different electrodes that all observe this unit simultaneously. In this' \
+                     ' case, the `electrodes` column of this Units table should be used to indicate which electrodes ' \
+                     'are associated with this unit, and the electrodes dimension here should be in the same order as' \
+                     ' the electrodes referenced in the `electrodes` column of this table.'
     __columns__ = (
         {'name': 'spike_times', 'description': 'the spike times for each unit', 'index': True},
         {'name': 'obs_intervals', 'description': 'the observation intervals for each unit',
@@ -145,7 +150,8 @@ class Units(DynamicTable):
          'index': True, 'table': True},
         {'name': 'electrode_group', 'description': 'the electrode group that each spike unit came from'},
         {'name': 'waveform_mean', 'description': 'the spike waveform mean for each spike unit'},
-        {'name': 'waveform_sd', 'description': 'the spike waveform standard deviation for each spike unit'}
+        {'name': 'waveform_sd', 'description': 'the spike waveform standard deviation for each spike unit'},
+        {'name': 'waveforms', 'description': waveforms_desc, 'index': True}
     )
 
     @docval({'name': 'name', 'type': str, 'doc': 'Name of this Units interface', 'default': 'Units'},
@@ -158,7 +164,7 @@ class Units(DynamicTable):
             {'name': 'waveform_unit', 'type': str,
              'doc': 'Unit of measurement of the waveform means', 'default': 'volts'},
             {'name': 'resolution', 'type': 'float',
-             'doc': 'The smallest possible difference between two spike times', 'default': None},
+             'doc': 'The smallest possible difference between two spike times', 'default': None}
             )
     def __init__(self, **kwargs):
         if kwargs.get('description', None) is None:
@@ -186,8 +192,9 @@ class Units(DynamicTable):
              'default': None},
             {'name': 'waveform_sd', 'type': 'array_data', 'default': None,
              'doc': 'the spike waveform standard deviation for each unit. Shape is (time,) or (time, electrodes)'},
-            {'name': 'id', 'type': int, 'default': None,
-             'doc': 'the id for each unit'},
+            {'name': 'waveforms', 'type': 'array_data', 'default': None, 'doc': waveforms_desc,
+             'shape': ((None, None), (None, None, None))},
+            {'name': 'id', 'type': int, 'default': None, 'doc': 'the id for each unit'},
             allow_extra=True)
     def add_unit(self, **kwargs):
         """

--- a/tests/integration/hdf5/test_misc.py
+++ b/tests/integration/hdf5/test_misc.py
@@ -13,9 +13,11 @@ class TestUnitsIO(AcquisitionH5IOMixin, TestCase):
         """ Return the test Units to read/write """
         ut = Units(name='UnitsTest', description='a simple table for testing Units')
         ut.add_unit(spike_times=[0, 1, 2], obs_intervals=[[0, 1], [2, 3]],
-                    waveform_mean=[1., 2., 3.], waveform_sd=[4., 5., 6.])
+                    waveform_mean=[1., 2., 3.], waveform_sd=[4., 5., 6.],
+                    waveforms=[[1, 2, 3], [1, 2, 3], [1, 2, 3]])
         ut.add_unit(spike_times=[3, 4, 5], obs_intervals=[[2, 5], [6, 7]],
-                    waveform_mean=[1., 2., 3.], waveform_sd=[4., 5., 6.])
+                    waveform_mean=[1., 2., 3.], waveform_sd=[4., 5., 6.],
+                    waveforms=[[1, 2, 3], [1, 2, 3], [1, 2, 3]])
         ut.waveform_rate = 40000.
         ut.resolution = 1/40000
         return ut

--- a/tests/integration/hdf5/test_nwbfile.py
+++ b/tests/integration/hdf5/test_nwbfile.py
@@ -444,17 +444,86 @@ class TestElectrodes(NWBH5IOMixin, TestCase):
     def addContainer(self, nwbfile):
         """ Add electrodes and related objects to the given NWBFile """
         self.dev1 = nwbfile.create_device(name='dev1')
-        self.group = nwbfile.create_electrode_group(name='tetrode1', description='tetrode description',
-                                                    location='tetrode location', device=self.dev1)
+        self.group = nwbfile.create_electrode_group(
+            name='tetrode1',
+            description='tetrode description',
+            location='tetrode location',
+            device=self.dev1
+        )
 
-        nwbfile.add_electrode(id=1, x=1.0, y=2.0, z=3.0, imp=-1.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
-        nwbfile.add_electrode(id=2, x=1.0, y=2.0, z=3.0, imp=-2.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
-        nwbfile.add_electrode(id=3, x=1.0, y=2.0, z=3.0, imp=-3.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
-        nwbfile.add_electrode(id=4, x=1.0, y=2.0, z=3.0, imp=-4.0, location='CA1', filtering='none', group=self.group,
-                              group_name='tetrode1')
+        nwbfile.add_electrode(
+            id=1,
+            x=1.0, y=2.0, z=3.0,
+            imp=-1.0,
+            location='CA1',
+            filtering='none',
+            group=self.group,
+            group_name='tetrode1'
+        )
+        nwbfile.add_electrode(
+            id=2,
+            x=1.0, y=2.0, z=3.0,
+            imp=-2.0,
+            location='CA1',
+            filtering='none',
+            group=self.group,
+            group_name='tetrode1'
+        )
+
+        self.container = nwbfile.electrodes  # override self.container which has the placeholder
+
+    def getContainer(self, nwbfile):
+        """ Return the test electrodes table from the given NWBFile """
+        return nwbfile.electrodes
+
+    def test_roundtrip(self):
+        super().test_roundtrip()
+        # When comparing the pandas dataframes for the row we drop the 'group' column since the
+        # ElectrodeGroup object after reading will naturally have a different address
+        pd.testing.assert_frame_equal(self.read_container[0].drop('group', axis=1),
+                                      self.container[0].drop('group', axis=1))
+
+
+class TestElectrodesOptColumns(NWBH5IOMixin, TestCase):
+
+    def setUpContainer(self):
+        """
+        Return placeholder table for electrodes. Tested electrodes are added directly to the NWBFile in addContainer
+        """
+        return DynamicTable('electrodes', 'a placeholder table')
+
+    def addContainer(self, nwbfile):
+        """ Add electrodes and related objects to the given NWBFile """
+        self.dev1 = nwbfile.create_device(name='dev1')
+        self.group = nwbfile.create_electrode_group(
+            name='tetrode1',
+            description='tetrode description',
+            location='tetrode location',
+            device=self.dev1
+        )
+
+        nwbfile.add_electrode(
+            id=1,
+            x=1.0, y=2.0, z=3.0,
+            imp=-1.0,
+            location='CA1',
+            filtering='none',
+            group=self.group,
+            group_name='tetrode1',
+            rel_x=4.0, rel_y=5.0, rel_z=6.0,
+            reference='ref1'
+        )
+        nwbfile.add_electrode(
+            id=2,
+            x=1.0, y=2.0, z=3.0,
+            imp=-2.0,
+            location='CA1',
+            filtering='none',
+            group=self.group,
+            group_name='tetrode1',
+            rel_x=4.0, rel_y=5.0, rel_z=6.0,
+            reference='ref1'
+        )
 
         self.container = nwbfile.electrodes  # override self.container which has the placeholder
 

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -242,9 +242,21 @@ class NWBFileTest(TestCase):
                                                timeseries=ts, tags=('hi', 'there'))
 
     def test_add_electrode(self):
-        dev1 = self.nwbfile.create_device('dev1')
-        group = self.nwbfile.create_electrode_group('tetrode1', 'tetrode description', 'tetrode location', dev1)
-        self.nwbfile.add_electrode(1.0, 2.0, 3.0, -1.0, 'CA1', 'none', group=group, id=1)
+        dev1 = self.nwbfile.create_device(name='dev1')
+        group = self.nwbfile.create_electrode_group(
+            name='tetrode1',
+            description='tetrode description',
+            location='tetrode location',
+            device=dev1
+        )
+        self.nwbfile.add_electrode(
+            x=1.0, y=2.0, z=3.0,
+            imp=-1.0,
+            location='CA1',
+            filtering='none',
+            group=group,
+            id=1
+        )
         elec = self.nwbfile.electrodes[0]
         self.assertEqual(elec.index[0], 1)
         self.assertEqual(elec.iloc[0]['x'], 1.0)
@@ -253,6 +265,45 @@ class NWBFileTest(TestCase):
         self.assertEqual(elec.iloc[0]['location'], 'CA1')
         self.assertEqual(elec.iloc[0]['filtering'], 'none')
         self.assertEqual(elec.iloc[0]['group'], group)
+
+    def test_add_electrode_some_opt(self):
+        dev1 = self.nwbfile.create_device(name='dev1')
+        group = self.nwbfile.create_electrode_group(
+            name='tetrode1',
+            description='tetrode description',
+            location='tetrode location',
+            device=dev1
+        )
+        self.nwbfile.add_electrode(
+            x=1.0, y=2.0, z=3.0,
+            imp=-1.0,
+            location='CA1',
+            filtering='none',
+            group=group,
+            id=1,
+            rel_x=4.0, rel_y=5.0, rel_z=6.0,
+            reference='ref1'
+        )
+        self.nwbfile.add_electrode(
+            x=1.0, y=2.0, z=3.0,
+            imp=-1.0,
+            location='CA1',
+            filtering='none',
+            group=group,
+            id=2,
+            rel_x=7.0, rel_y=8.0, rel_z=9.0,
+            reference='ref2'
+        )
+        elec = self.nwbfile.electrodes[0]
+        self.assertEqual(elec.iloc[0]['rel_x'], 4.0)
+        self.assertEqual(elec.iloc[0]['rel_y'], 5.0)
+        self.assertEqual(elec.iloc[0]['rel_z'], 6.0)
+        self.assertEqual(elec.iloc[0]['reference'], 'ref1')
+        elec = self.nwbfile.electrodes[1]
+        self.assertEqual(elec.iloc[0]['rel_x'], 7.0)
+        self.assertEqual(elec.iloc[0]['rel_y'], 8.0)
+        self.assertEqual(elec.iloc[0]['rel_z'], 9.0)
+        self.assertEqual(elec.iloc[0]['reference'], 'ref2')
 
     def test_all_children(self):
         ts1 = TimeSeries('test_ts1', [0, 1, 2, 3, 4, 5], 'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -113,6 +113,16 @@ class UnitsTests(TestCase):
         self.assertEqual(ut['spike_times'][0], [0, 1, 2])
         self.assertEqual(ut['spike_times'][1], [3, 4, 5])
 
+    def test_add_waveforms(self):
+        ut = Units()
+        ut.add_unit(waveforms=[[1, 2, 3], [1, 2, 3]])
+        ut.add_unit(waveforms=[[1, 2, 3], [1, 2, 3]])
+        self.assertEqual(ut.id.data, [0, 1])
+        self.assertEqual(ut['waveforms'].target.data, [[1, 2, 3], [1, 2, 3], [1, 2, 3], [1, 2, 3]])
+        self.assertEqual(ut['waveforms'].data, [2, 4])
+        self.assertEqual(ut['waveforms'][0], [[1, 2, 3], [1, 2, 3]])
+        self.assertEqual(ut['waveforms'][1], [[1, 2, 3], [1, 2, 3]])
+
     def test_get_spike_times(self):
         ut = Units()
         ut.add_unit(spike_times=[0, 1, 2])


### PR DESCRIPTION
## Motivation
pynwb API changes for adding waveforms to the Units table

depends on https://github.com/NeurodataWithoutBorders/nwb-schema/pull/448


## How to test the behavior?
```
nwbfile.add_unit(waveforms=[[1, 2, 3], [1, 2, 3], [1, 2, 3]])
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
