### PR TITLE
Update reqs to use hdmf==1.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # PyNWB Changelog
 
+## PyNWB 1.3.3 (June 26, 2020)
+
+### Internal improvements:
+- Update requirements to use HDMF 1.6.4. @rly (#1256)
+
+### Bug fixes:
+- Fix writing optional args to electrodes table. @rly (#1246)
+- Fix missing method UnitsMap.get_nwb_file. @rly (#1227)
+
 ## PyNWB 1.3.2 (June 1, 2020)
 
 ### Bug fixes:

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # these minimum requirements specify '==' for testing; setup.py replaces '==' with '>='
 h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
-hdmf==1.6.2,<2
+hdmf==1.6.4,<2
 numpy==1.16
 pandas==0.23
 python-dateutil==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 h5py==2.10.0
-hdmf==1.6.2
+hdmf==1.6.4
 numpy==1.18.1
 pandas==0.25.3
 python-dateutil==2.8.1


### PR DESCRIPTION
## Motivation

Update requirements to use hdmf==1.6.4.

On release, conda dependencies should also be updated.


## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
