### PR TITLE
Add check if external_file is provided without starting_frame

### DIFF
--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -45,7 +45,11 @@ class ImageSeries(TimeSeries):
             'bits_per_pixel', 'dimension', 'external_file', 'starting_frame', 'format', kwargs)
         call_docval_func(super(ImageSeries, self).__init__, kwargs)
         if external_file is None and self.data is None:
-            raise ValueError('must supply either external_file or data to ' + self.name)
+            raise ValueError("Must supply either external_file or data to %s '%s'."
+                             % (self.__class__.__name__, self.name))
+        if external_file is not None and starting_frame is None:
+            raise ValueError("Must supply starting_frame if external_file is provided for %s '%s'."
+                             % (self.__class__.__name__, self.name))
         self.bits_per_pixel = bits_per_pixel
         self.dimension = dimension
         self.external_file = external_file

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -33,7 +33,8 @@ class ImageSeries(TimeSeries):
                     'Either external_file or data must be specified, but not both.', 'default': None},
             {'name': 'starting_frame', 'type': Iterable,
              'doc': 'Each entry is the frame number in the corresponding external_file variable. '
-                    'This serves as an index to what frames each file contains.', 'default': None},
+                    'This serves as an index to what frames each file contains. If external_file is not '
+                    'provided, then this value will be None', 'default': [0]},
             {'name': 'bits_per_pixel', 'type': int, 'doc': 'DEPRECATED: Number of bits per image pixel',
              'default': None},
             {'name': 'dimension', 'type': Iterable,
@@ -47,13 +48,13 @@ class ImageSeries(TimeSeries):
         if external_file is None and self.data is None:
             raise ValueError("Must supply either external_file or data to %s '%s'."
                              % (self.__class__.__name__, self.name))
-        if external_file is not None and starting_frame is None:
-            raise ValueError("Must supply starting_frame if external_file is provided for %s '%s'."
-                             % (self.__class__.__name__, self.name))
         self.bits_per_pixel = bits_per_pixel
         self.dimension = dimension
         self.external_file = external_file
-        self.starting_frame = starting_frame
+        if external_file is not None:
+            self.starting_frame = starting_frame
+        else:
+            self.starting_frame = None
         self.format = format
 
     @property

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -18,6 +18,25 @@ class ImageSeriesConstructor(TestCase):
         self.assertEqual(iS.format, 'tiff')
         # self.assertEqual(iS.bits_per_pixel, np.nan)
 
+    def test_external_file_no_frame(self):
+        msg = "Must supply starting_frame if external_file is provided for ImageSeries 'test_iS'."
+        with self.assertRaisesWith(ValueError, msg):
+            ImageSeries(
+                name='test_iS',
+                unit='unit',
+                external_file=['external_file'],
+                timestamps=list()
+            )
+
+    def test_no_data_no_file(self):
+        msg = "Must supply either external_file or data to ImageSeries 'test_iS'."
+        with self.assertRaisesWith(ValueError, msg):
+            ImageSeries(
+                name='test_iS',
+                unit='unit',
+                timestamps=list()
+            )
+
 
 class IndexSeriesConstructor(TestCase):
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -18,16 +18,6 @@ class ImageSeriesConstructor(TestCase):
         self.assertEqual(iS.format, 'tiff')
         # self.assertEqual(iS.bits_per_pixel, np.nan)
 
-    def test_external_file_no_frame(self):
-        msg = "Must supply starting_frame if external_file is provided for ImageSeries 'test_iS'."
-        with self.assertRaisesWith(ValueError, msg):
-            ImageSeries(
-                name='test_iS',
-                unit='unit',
-                external_file=['external_file'],
-                timestamps=list()
-            )
-
     def test_no_data_no_file(self):
         msg = "Must supply either external_file or data to ImageSeries 'test_iS'."
         with self.assertRaisesWith(ValueError, msg):
@@ -36,6 +26,24 @@ class ImageSeriesConstructor(TestCase):
                 unit='unit',
                 timestamps=list()
             )
+
+    def test_external_file_no_frame(self):
+        iS = ImageSeries(
+            name='test_iS',
+            unit='unit',
+            external_file=['external_file'],
+            timestamps=list()
+        )
+        self.assertListEqual(iS.starting_frame, [0])
+
+    def test_data_no_frame(self):
+        iS = ImageSeries(
+            name='test_iS',
+            unit='unit',
+            data=np.ones((3, 3, 3)),
+            timestamps=list()
+        )
+        self.assertIsNone(iS.starting_frame)
 
 
 class IndexSeriesConstructor(TestCase):

--- a/tests/unit/test_ophys.py
+++ b/tests/unit/test_ophys.py
@@ -197,23 +197,6 @@ class TwoPhotonSeriesConstructor(TestCase):
         self.assertEqual(tPS.format, 'tiff')
         self.assertIsNone(tPS.dimension)
 
-    def test_missing_data_external(self):
-        ip = create_imaging_plane()
-
-        msg = 'must supply either external_file or data to test_tPS'
-        with self.assertRaisesWith(ValueError, msg):  # no data or external file
-            TwoPhotonSeries(
-                name='test_tPS',
-                unit='unit',
-                field_of_view=[2., 3.],
-                imaging_plane=ip,
-                pmt_gain=1.0,
-                scan_line_rate=2.0,
-                starting_frame=[1, 2, 3],
-                format='tiff',
-                timestamps=[1., 2.]
-            )
-
 
 class MotionCorrectionConstructor(TestCase):
     def test_init(self):


### PR DESCRIPTION
## Motivation

Fix #1263 

## How to test the behavior?
```python
# now raises ValueError
ImageSeries(
    name='test_iS',
    unit='unit',
    external_file=['external_file'],
    timestamps=list()
)
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
