### PR TITLE
Make validation CI run on Python 3.7 again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
 
   test-validation:
     docker:
-      - image: circleci/python:3.8.1-buster
+      - image: circleci/python:3.7.6-stretch
     steps:
       - checkout
       - run: git submodule sync
@@ -258,7 +258,7 @@ jobs:
           command: |
             . ../venv/bin/activate
             pip install tox
-            tox -e validation-py38
+            tox -e validation-py37
           # Install is expected to be quick. Increase timeout in case there are some network issues.
           # While pip installing tox does not output by default. Circle thinks task is dead after 10 min.
           no_output_timeout: 30m

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # PyNWB Changelog
 
+## PyNWB 1.4.0 (August 10, 2020)
+
+### Internal improvements:
+- Update requirements to use HDMF 2.0.1. @rly (#1256)
+- Start FAQ section in documentation. @rly (#1249)
+- Improve deprecation warnings. @rly (#1261)
+- Update CI to test Python 3.8, update requirements. @rly (#1267, #1275)
+
+### Bug fixes:
+- For `ImageSeries`, add check if `external_file` is provided without `starting_frame` in `__init__`. @rly (#1264)
+- Improve docstrings for `TimeSeries.data` and for the electrode table. @rly (#1271, #1272)
+
 ## PyNWB 1.3.3 (June 26, 2020)
 
 ### Internal improvements:

--- a/tox.ini
+++ b/tox.ini
@@ -130,8 +130,8 @@ deps =
     -rrequirements-doc.txt
 commands = {[testenv:gallery]commands}
 
-[testenv:validation-py38]
-basepython = python3.8
+[testenv:validation-py37]
+basepython = python3.7
 install_command =
     pip install -U {opts} {packages}
 deps =


### PR DESCRIPTION
## Motivation

Nightly CI fails because the validation tests run on the sphinx-gallery files which use allensdk and allensdk does not yet support Python 3.8. I recently pushed a change in #1267 that made validation tests run on Python 3.8 instead of Python 3.7. This PR reverts that change.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
