### PR TITLE
Make Azure run CI for commits only on dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PyNWB Changelog
 
-## PyNWB 1.4.0 (August 11, 2020)
+## PyNWB 1.4.0 (August 12, 2020)
 
 ### Internal improvements:
 - Update requirements to use HDMF 2.1.0. @rly (#1256)
@@ -12,6 +12,7 @@
 ### Bug fixes:
 - For `ImageSeries`, add check if `external_file` is provided without `starting_frame` in `__init__`. @rly (#1264)
 - Improve docstrings for `TimeSeries.data` and for the electrode table. @rly (#1271, #1272)
+- Fix Azure Pipelines configuration. @rly (#1281)
 
 ## PyNWB 1.3.3 (June 26, 2020)
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+trigger:
+- dev
+
 jobs:
 
 - job: 'Test'


### PR DESCRIPTION
## Motivation

Azure Pipelines CI is running on all commits. This is super slow. It should run only on PRs (with auto-cancel) and all commits of the dev branch.

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
