### PR TITLE
OPT: make pandas (and may be scipy, ... anything else?) dependency optional

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -2,5 +2,4 @@
 h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
 hdmf==2.1.0,<3
 numpy==1.16
-pandas==0.23
 python-dateutil==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 h5py==2.10.0
 hdmf==2.1.0
 numpy==1.18.5
-pandas==0.25.3
 python-dateutil==2.8.1

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1,6 +1,5 @@
 from h5py import RegionReference
 import numpy as np
-import pandas as pd
 
 from hdmf import Container, Data, DataRegion, get_region_slicer
 from hdmf.container import AbstractContainer, MultiContainerInterface as hdmf_MultiContainerInterface
@@ -222,12 +221,14 @@ class NWBTable(NWBData):
         '''Produce a pandas DataFrame containing this table's data.
         '''
 
+        import pandas as pd
         data = {colname: self[colname] for ii, colname in enumerate(self.columns)}
         return pd.DataFrame(data)
 
     @classmethod
     @docval(
-        {'name': 'df', 'type': pd.DataFrame, 'doc': 'input data'},
+        # TODO: "real" pd.DataFrame?
+        {'name': 'df', 'type': "pd.DataFrame", 'doc': 'input data'},
         {'name': 'name', 'type': str, 'doc': 'the name of this container', 'default': None},
         {
             'name': 'extra_ok',
@@ -240,6 +241,8 @@ class NWBTable(NWBData):
         '''Construct an instance of NWBTable (or a subclass) from a pandas DataFrame. The columns of the dataframe
         should match the columns defined on the NWBTable subclass.
         '''
+
+        import pandas as pd
 
         df, name, extra_ok = getargs('df', 'name', 'extra_ok', kwargs)
 


### PR DESCRIPTION
## Motivation

Disclaimer:  I love pandas, matplotlib, scipy!

But AFAIK none of them must be needed for regular IO on .nwb files, unless I do have some pandas DataFrame I am working with and thus would have pandas imported already.

ATM 9 importing of `pynwb` causes import of over 800 modules from about 100 packages into sys.modules:

```shell
$> time python -c 'import sys; s1=set(sys.modules); import pynwb; s2=set(sys.modules).difference(s1); um=set(m.split(".")[0] for m in s2 if not m.startswith("_")); print(len(s2), len(um), sorted(um))' 
860 104 ['argparse', 'array', 'ast', 'asyncio', 'atexit', 'base64', 'binascii', 'bisect', 'bz2', 'calendar', 'collections', 'concurrent', 'contextvars', 'copy', 'copyreg', 'csv', 'ctypes', 'cycler', 'cython_runtime', 'datetime', 'dateutil', 'decimal', 'difflib', 'dis', 'distutils', 'email', 'enum', 'errno', 'fnmatch', 'fractions', 'gc', 'gettext', 'glob', 'grp', 'gzip', 'h5py', 'hashlib', 'hdmf', 'hmac', 'http', 'inspect', 'json', 'kiwisolver', 'linecache', 'locale', 'logging', 'lzma', 'math', 'matplotlib', 'mmap', 'multiprocessing', 'ntpath', 'numbers', 'numpy', 'opcode', 'pandas', 'pathlib', 'pickle', 'pkg_resources', 'pkgutil', 'platform', 'plistlib', 'pprint', 'pwd', 'pyexpat', 'pynwb', 'pyparsing', 'pytz', 'quopri', 'random', 're', 'ruamel', 'scipy', 'secrets', 'select', 'selectors', 'shlex', 'shutil', 'signal', 'six', 'socket', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'string', 'struct', 'subprocess', 'sysconfig', 'tempfile', 'textwrap', 'token', 'tokenize', 'traceback', 'typing', 'unicodedata', 'unittest', 'urllib', 'uu', 'uuid', 'weakref', 'xml', 'zipfile', 'zlib']
python -c   1.32s user 0.10s system 99% cpu 1.416 total
```
so -- 1.4 sec just to import top level pynwb module, possibly just to read or save a .nwb file.  That is seems what "contributes" to our attempts to parallelize some functionality in dandi-cli: see https://github.com/dandi/dandi-cli/issues/191

one of the main "abusers" is `pandas`.  it is the one causing matplotlib imports etc.  With this draft PR + following quick and dirty patch to hdmf (would need to be send there but I ran out of juice and wanted to first "palpate interest"):

```
$> diff -Naur ../hdmf-upstream/src/hdmf/common/table.py /home/yoh/proj/dandi/dandi-cli/venvs/dev3/lib/python3.8/site-packages/hdmf/common/table.py
--- ../hdmf-upstream/src/hdmf/common/table.py	2020-07-29 12:22:33.922776064 -0400
+++ /home/yoh/proj/dandi/dandi-cli/venvs/dev3/lib/python3.8/site-packages/hdmf/common/table.py	2020-08-13 19:24:19.174817618 -0400
@@ -5,7 +5,6 @@
 
 from h5py import Dataset
 import numpy as np
-import pandas as pd
 from collections import OrderedDict
 from warnings import warn
 
@@ -753,6 +752,7 @@
                 raise KeyError("Key type not supported by DynamicTable %s" % str(type(arg)))
 
             if df:
+                import pandas as pd
                 # reformat objects to fit into a pandas DataFrame
                 id_index = ret.pop('id')
                 if np.isscalar(id_index):
@@ -824,7 +824,7 @@
 
     @classmethod
     @docval(
-        {'name': 'df', 'type': pd.DataFrame, 'doc': 'source DataFrame'},
+        {'name': 'df', 'type': "TODO pd.DataFrame", 'doc': 'source DataFrame'},
         {'name': 'name', 'type': str, 'doc': 'the name of this table'},
         {
             'name': 'index_column',
```

import of pynwb drops almost that half a second which takes to import pandas:

```
$> time python -c 'import sys; s1=set(sys.modules); import pynwb; s2=set(sys.modules).difference(s1); um=set(m.split(".")[0] for m in s2 if not m.startswith("_")); print(len(s2), len(um), sorted(um))'
573 89 ['argparse', 'array', 'ast', 'asyncio', 'atexit', 'base64', 'binascii', 'bisect', 'bz2', 'calendar', 'collections', 'concurrent', 'contextvars', 'copy', 'copyreg', 'ctypes', 'cython_runtime', 'datetime', 'dateutil', 'decimal', 'difflib', 'dis', 'email', 'enum', 'errno', 'fnmatch', 'gc', 'gettext', 'glob', 'grp', 'h5py', 'hashlib', 'hdmf', 'hmac', 'inspect', 'json', 'linecache', 'locale', 'logging', 'lzma', 'math', 'multiprocessing', 'ntpath', 'numbers', 'numpy', 'opcode', 'pathlib', 'pickle', 'pkg_resources', 'pkgutil', 'platform', 'plistlib', 'pprint', 'pwd', 'pyexpat', 'pynwb', 'quopri', 'random', 're', 'ruamel', 'scipy', 'secrets', 'select', 'selectors', 'shutil', 'signal', 'six', 'socket', 'sre_compile', 'sre_constants', 'sre_parse', 'ssl', 'string', 'struct', 'subprocess', 'sysconfig', 'tempfile', 'textwrap', 'token', 'tokenize', 'traceback', 'typing', 'unittest', 'urllib', 'uuid', 'weakref', 'xml', 'zipfile', 'zlib']
python -c   1.17s user 0.06s system 99% cpu 1.225 total
```

Next candidate could be scipy which seems to be needed only at the `hdmf` level and only for sparse matrices...

<details>
<summary>here is the q&d patch</summary> 

```shell
$> diff -Naur ../hdmf-upstream/src/hdmf/common/sparse.py /home/yoh/proj/dandi/dandi-cli/venvs/dev3/lib/python3.8/site-packages/hdmf/common/sparse.py 
--- ../hdmf-upstream/src/hdmf/common/sparse.py	2020-01-07 12:54:32.995303465 -0500
+++ /home/yoh/proj/dandi/dandi-cli/venvs/dev3/lib/python3.8/site-packages/hdmf/common/sparse.py	2020-08-13 19:31:46.831436217 -0400
@@ -1,4 +1,3 @@
-import scipy.sparse as sps
 import numpy as np
 import h5py
 
@@ -11,7 +10,7 @@
 @register_class('CSRMatrix')
 class CSRMatrix(Container):
 
-    @docval({'name': 'data', 'type': (sps.csr_matrix, np.ndarray, h5py.Dataset),
+    @docval({'name': 'data', 'type': ("sps.csr_matrix", np.ndarray, h5py.Dataset),
              'doc': 'the data to use for this CSRMatrix or CSR data array.'
                     'If passing CSR data array, *indices*, *indptr*, and *shape* must also be provided'},
             {'name': 'indices', 'type': (np.ndarray, h5py.Dataset), 'doc': 'CSR index array', 'default': None},
@@ -19,6 +18,7 @@
             {'name': 'shape', 'type': (list, tuple, np.ndarray), 'doc': 'the shape of the matrix', 'default': None},
             {'name': 'name', 'type': str, 'doc': 'the name to use for this when storing', 'default': 'csr_matrix'})
     def __init__(self, **kwargs):
+        import scipy.sparse as sps
         call_docval_func(super().__init__, kwargs)
         data = getargs('data', kwargs)
         if isinstance(data, (np.ndarray, h5py.Dataset)):
```
</details>

which seems to drop additional 100ms from pynwb import time...

The main **problem** to address is the `@docval` types description.  I have not looked into either it is used only for docs (thus could be just replaced with a string), or needs actual type for type checking may be???

## How to test the behavior?

See all the snippets above

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
