### PR TITLE
Add useful imports for users from HDMF

### DIFF
--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -273,6 +273,8 @@ from . import ogen  # noqa: F401,E402
 from . import ophys  # noqa: F401,E402
 from . import retinotopy  # noqa: F401,E402
 from . import legacy  # noqa: F401,E402
+from hdmf.data_utils import DataChunkIterator  # noqa: F401,E402
+from hdmf.backends.hdf5 import H5DataIO  # noqa: F401,E402
 
 from ._version import get_versions  # noqa: E402
 __version__ = get_versions()['version']


### PR DESCRIPTION
## Motivation

Users may wish to use `DataChunkIterator` and `H5DataIO` without having to explicitly call `import hdmf`. See https://github.com/NeurodataWithoutBorders/pynwb/issues/1285#issuecomment-680140368 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
