### PR TITLE
Set default neurodata_type_inc for NWBGroupSpec, NWBDatasetSpec

### DIFF
--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -12,6 +12,10 @@ def __swap_inc_def(cls, default_nd_type_inc=None):
     args = get_docval(cls.__init__)
     clsname = 'NWB%s' % cls.__name__
     ret = list()
+    # do not set default neurodata_type_inc for base hdmf-common types that should not have data_type_inc
+    for arg in args:
+        if arg['name'] == 'Container' or arg['name'] == 'Data':
+            default_nd_type_inc = None
     for arg in args:
         if arg['name'] == 'data_type_def':
             ret.append({'name': 'neurodata_type_def', 'type': str,

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -137,8 +137,7 @@ class NWBDatasetSpec(BaseStorageOverride, DatasetSpec):
     def __init__(self, **kwargs):
         kwargs = self._translate_kwargs(kwargs)
         # set data_type_inc to NWBData only if it is not specified and the type is not an HDMF base type
-        if (kwargs['data_type_inc'] is None and kwargs['data_type_def'] is not None and
-                kwargs['data_type_def'] != 'Data'):
+        if kwargs['data_type_inc'] is None and kwargs['data_type_def'] not in (None, 'Data'):
             kwargs['data_type_inc'] = 'NWBData'
         super(NWBDatasetSpec, self).__init__(**kwargs)
 

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -155,6 +155,8 @@ class NWBGroupSpec(BaseStorageOverride, GroupSpec):
     def __init__(self, **kwargs):
         kwargs = self._translate_kwargs(kwargs)
         # set data_type_inc to NWBData only if it is not specified and the type is not an HDMF base type
+        # NOTE: CSRMatrix in hdmf-common-schema does not have a data_type_inc but should not inherit from
+        # NWBContainer. This will be fixed in hdmf-common-schema 1.2.1.
         if kwargs['data_type_inc'] is None and kwargs['data_type_def'] not in (None, 'Container', 'CSRMatrix'):
             kwargs['data_type_inc'] = 'NWBContainer'
         super(NWBGroupSpec, self).__init__(**kwargs)

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -156,8 +156,7 @@ class NWBGroupSpec(BaseStorageOverride, GroupSpec):
     def __init__(self, **kwargs):
         kwargs = self._translate_kwargs(kwargs)
         # set data_type_inc to NWBData only if it is not specified and the type is not an HDMF base type
-        if (kwargs['data_type_inc'] is None and kwargs['data_type_def'] is not None
-                and kwargs['data_type_def'] != 'Container' and kwargs['data_type_def'] != 'CSRMatrix'):
+        if kwargs['data_type_inc'] is None and kwargs['data_type_def'] not in (None, 'Container', 'CSRMatrix'):
             kwargs['data_type_inc'] = 'NWBContainer'
         super(NWBGroupSpec, self).__init__(**kwargs)
 

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -137,7 +137,8 @@ class NWBDatasetSpec(BaseStorageOverride, DatasetSpec):
     def __init__(self, **kwargs):
         kwargs = self._translate_kwargs(kwargs)
         # set data_type_inc to NWBData only if it is not specified and the type is not an HDMF base type
-        if kwargs['data_type_inc'] is None and kwargs['data_type_def'] != 'Data':
+        if (kwargs['data_type_inc'] is None and kwargs['data_type_def'] is not None and
+                kwargs['data_type_def'] != 'Data'):
             kwargs['data_type_inc'] = 'NWBData'
         super(NWBDatasetSpec, self).__init__(**kwargs)
 
@@ -155,8 +156,8 @@ class NWBGroupSpec(BaseStorageOverride, GroupSpec):
     def __init__(self, **kwargs):
         kwargs = self._translate_kwargs(kwargs)
         # set data_type_inc to NWBData only if it is not specified and the type is not an HDMF base type
-        if (kwargs['data_type_inc'] is None and kwargs['data_type_def'] != 'Container' and
-                kwargs['data_type_def'] != 'CSRMatrix'):
+        if (kwargs['data_type_inc'] is None and kwargs['data_type_def'] is not None
+                and kwargs['data_type_def'] != 'Container' and kwargs['data_type_def'] != 'CSRMatrix'):
             kwargs['data_type_inc'] = 'NWBContainer'
         super(NWBGroupSpec, self).__init__(**kwargs)
 

--- a/src/pynwb/spec.py
+++ b/src/pynwb/spec.py
@@ -1,14 +1,14 @@
 from copy import copy, deepcopy
 
-from hdmf.spec import LinkSpec, GroupSpec, DatasetSpec, SpecNamespace,\
-                       NamespaceBuilder, AttributeSpec, DtypeSpec, RefSpec
+from hdmf.spec import (LinkSpec, GroupSpec, DatasetSpec, SpecNamespace, NamespaceBuilder, AttributeSpec, DtypeSpec,
+                       RefSpec)
 from hdmf.spec.write import export_spec  # noqa: F401
 from hdmf.utils import docval, get_docval, call_docval_func
 
 from . import CORE_NAMESPACE
 
 
-def __swap_inc_def(cls):
+def __swap_inc_def(cls, default_nd_type_inc=None):
     args = get_docval(cls.__init__)
     clsname = 'NWB%s' % cls.__name__
     ret = list()
@@ -18,7 +18,7 @@ def __swap_inc_def(cls):
                         'doc': 'the NWB data type this spec defines', 'default': None})
         elif arg['name'] == 'data_type_inc':
             ret.append({'name': 'neurodata_type_inc', 'type': (clsname, str),
-                        'doc': 'the NWB data type this spec includes', 'default': None})
+                        'doc': 'the NWB data type this spec includes', 'default': default_nd_type_inc})
         else:
             ret.append(copy(arg))
     return ret
@@ -29,7 +29,7 @@ _ref_docval = __swap_inc_def(RefSpec)
 
 class NWBRefSpec(RefSpec):
 
-    @docval(*_ref_docval)
+    @docval(*deepcopy(_ref_docval))
     def __init__(self, **kwargs):
         call_docval_func(super(NWBRefSpec, self).__init__, kwargs)
 
@@ -39,7 +39,7 @@ _attr_docval = __swap_inc_def(AttributeSpec)
 
 class NWBAttributeSpec(AttributeSpec):
 
-    @docval(*_attr_docval)
+    @docval(*deepcopy(_attr_docval))
     def __init__(self, **kwargs):
         call_docval_func(super(NWBAttributeSpec, self).__init__, kwargs)
 
@@ -49,7 +49,7 @@ _link_docval = __swap_inc_def(LinkSpec)
 
 class NWBLinkSpec(LinkSpec):
 
-    @docval(*_link_docval)
+    @docval(*deepcopy(_link_docval))
     def __init__(self, **kwargs):
         call_docval_func(super(NWBLinkSpec, self).__init__, kwargs)
 
@@ -119,30 +119,30 @@ _dtype_docval = __swap_inc_def(DtypeSpec)
 
 class NWBDtypeSpec(DtypeSpec):
 
-    @docval(*_dtype_docval)
+    @docval(*deepcopy(_dtype_docval))
     def __init__(self, **kwargs):
         call_docval_func(super(NWBDtypeSpec, self).__init__, kwargs)
 
 
-_dataset_docval = __swap_inc_def(DatasetSpec)
+_dataset_docval = __swap_inc_def(DatasetSpec, 'NWBData')
 
 
 class NWBDatasetSpec(BaseStorageOverride, DatasetSpec):
-    ''' The Spec class to use for NWB specifications '''
+    ''' The Spec class to use for NWB dataset specifications '''
 
-    @docval(*_dataset_docval)
+    @docval(*deepcopy(_dataset_docval))
     def __init__(self, **kwargs):
         args, kwargs = self._translate_kwargs(kwargs)
         super(NWBDatasetSpec, self).__init__(*args, **kwargs)
 
 
-_group_docval = __swap_inc_def(GroupSpec)
+_group_docval = __swap_inc_def(GroupSpec, 'NWBContainer')
 
 
 class NWBGroupSpec(BaseStorageOverride, GroupSpec):
-    ''' The Spec class to use for NWB specifications '''
+    ''' The Spec class to use for NWB group specifications '''
 
-    @docval(*_group_docval)
+    @docval(*deepcopy(_group_docval))
     def __init__(self, **kwargs):
         args, kwargs = self._translate_kwargs(kwargs)
         super(NWBGroupSpec, self).__init__(*args, **kwargs)
@@ -153,9 +153,7 @@ class NWBGroupSpec(BaseStorageOverride, GroupSpec):
 
     @docval({'name': 'neurodata_type', 'type': str, 'doc': 'the neurodata_type to retrieve'})
     def get_neurodata_type(self, **kwargs):
-        '''
-        Get a specification by "data_type"
-        '''
+        ''' Get a specification by "neurodata_type" '''
         return super(NWBGroupSpec, self).get_data_type(kwargs['neurodata_type'])
 
     @docval(*deepcopy(_group_docval))


### PR DESCRIPTION
## Motivation

When creating a `NWBGroupSpec` or `NWBDatasetSpec`, the default values for `neurodata_type_inc` should be `NWBContainer` and `NWBData` respectively so that the new neurodata_types work nicely with the rest of the PyNWB API which often assumes that neurodata_types are of one of those classes (or are DynamicTables). 

See comments in #1294 

This PR also adds a call to `deepcopy` on some docval arguments to make sure that one call to e.g., `NWBAttributeSpec.__init__()` does not change the default values for a later call `NWBAttributeSpec.__init__()` (e.g., if `default=list()`).

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
