### PR TITLE
Test validate script and function directly and add test to CI

### DIFF
--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -70,10 +70,18 @@ def main():
         if args.cached_namespace:
             catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace)
             ns_deps = NWBHDF5IO.load_namespaces(catalog, path)
-            s = set(ns_deps.keys())       # determine which namespaces are the most
-            for k in ns_deps:             # specific (i.e. extensions) and validate
-                s -= ns_deps[k].keys()    # against those
-            namespaces = list(sorted(s))
+            if args.ns:
+                if args.ns in ns_deps.keys():
+                    namespaces = [args.ns]
+                else:
+                    print("The namespace '{}' could not be found as only namespaces {} are cached.".format(
+                          args.ns, list(ns_deps.keys())), file=sys.stderr)
+                    sys.exit(1)
+            else:
+                s = set(ns_deps.keys())       # determine which namespaces are the most
+                for k in ns_deps:             # specific (i.e. extensions) and validate
+                    s -= ns_deps[k].keys()    # against those
+                namespaces = list(sorted(s))
             if len(namespaces) > 0:
                 tm = TypeMap(catalog)
                 manager = BuildManager(tm)
@@ -109,14 +117,14 @@ def main():
             if args.ns in namespaces:
                 namespaces = [args.ns]
             else:
-                print("The namespace {} could not be found in {} as only {} is present.".format(
+                print("The namespace '{}' could not be found in {} as only {} is present.".format(
                       args.ns, specloc, namespaces), file=sys.stderr)
                 ret = 1
                 continue
 
         with NWBHDF5IO(path, mode='r', manager=manager) as io:
             for ns in namespaces:
-                print("Validating {} against {} using namespace {}.".format(path, specloc, ns))
+                print("Validating {} against {} using namespace '{}'.".format(path, specloc, ns))
                 ret = ret or _validate_helper(io=io, namespace=ns)
 
     sys.exit(ret)

--- a/test.py
+++ b/test.py
@@ -214,7 +214,7 @@ def main():
     # Run unit tests for pynwb package
     if flags['pynwb'] in args.suites:
         run_test_suite("tests/unit", "pynwb unit tests", verbose=args.verbosity)
-        run_test_suite("tests/validate", "pynwb basic validate tests", verbose=args.verbosity)
+        run_test_suite("tests/validation", "pynwb basic validate tests", verbose=args.verbosity)
 
     # Run example tests
     if flags['example'] in args.suites:

--- a/test.py
+++ b/test.py
@@ -214,6 +214,7 @@ def main():
     # Run unit tests for pynwb package
     if flags['pynwb'] in args.suites:
         run_test_suite("tests/unit", "pynwb unit tests", verbose=args.verbosity)
+        run_test_suite("tests/validate", "pynwb basic validate tests", verbose=args.verbosity)
 
     # Run example tests
     if flags['example'] in args.suites:

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -35,11 +35,7 @@ class TestValidateScript(TestCase):
                                 capture_output=True)
 
         stderr_regex = re.compile(
-            r".*UserWarning: No cached namespaces found in tests/back_compat/1\.0\.2_nwbfile\.nwb\s*"
-            r"warnings.warn\(msg\)\s*"
-            r"The file tests/back_compat/1\.0\.2_nwbfile\.nwb has no cached namespace information\. "
-            r"Falling back to pynwb namespace information\.\s*"
-            r"The namespace 'notfound' could not be found in pynwb namespace information\.\s*"
+            r"The namespace 'notfound' could not be found as only namespaces \[\] are cached\."
         )
         self.assertRegex(result.stderr.decode('utf-8'), stderr_regex)
 
@@ -63,7 +59,7 @@ class TestValidateScript(TestCase):
                                 capture_output=True)
 
         stderr_regex = re.compile(
-            r"The namespace 'notfound' could not be found in cached namespace information\.\s*"
+            r"The namespace 'notfound' could not be found as only namespaces \['hdmf-common', 'core'\] are cached\."
         )
         self.assertRegex(result.stderr.decode('utf-8'), stderr_regex)
 


### PR DESCRIPTION
## Motivation

`tests/validation/test_validate.py` was not being called by any test scripts or CI. This PR adds `test_validate.py` to the `test.py` (under unit tests) and fixes it to work with the latest version of the PyNWB validator. 

Also update the validator script so that if a namespace is given and found in the cached namespace, the validator uses it properly. Previously, it was not possible to validate an NWB file against a namespace that is not the most restrictive among the cached namespaces.

## How to test the behavior?
```
python test.py
```

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
