### PR TITLE
added a driver option to allow for ros3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 ### New features:
 - `NWBFile.add_scratch(...)` and `ScratchData.__init__(...)` now accept scalar data in addition to the currently
   accepted types. @rly (#1309)
-- Use HDMF 2.3.0. See the [HDMF 2.3.0 release notes](https://github.com/hdmf-dev/hdmf/releases/tag/2.3.0) for details.
 - Support `pathlib.Path` paths when opening files with `NWBHDF5IO`. @dsleiter (#1314)
+- Use HDMF 2.4.0. See the [HDMF 2.4.0 release notes](https://github.com/hdmf-dev/hdmf/releases/tag/2.4.0) for details.
+- Support `driver='ros3'` in `NWBHDF5IO` for streaming NWB files directly from s3. @bendichter (#1331)
 
 ## PyNWB 1.4.0 (August 12, 2020)
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # these minimum requirements specify '==' for testing; setup.py replaces '==' with '>='
 h5py==2.9  # support for setting attrs to lists of utf-8 added in 2.9
-hdmf==2.3,<3
+hdmf==2.4
 numpy==1.16
 pandas==0.23
 python-dateutil==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 h5py==2.10.0
-hdmf==2.3.0
+hdmf==2.4.0
 numpy==1.18.5
 pandas==0.25.3
 python-dateutil==2.8.1

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -214,10 +214,11 @@ class NWBHDF5IO(_HDF5IO):
              'default': None},
             {'name': 'file', 'type': h5py.File, 'doc': 'a pre-existing h5py.File object', 'default': None},
             {'name': 'comm', 'type': "Intracomm", 'doc': 'the MPI communicator to use for parallel I/O',
-             'default': None})
+             'default': None},
+            {'name': 'driver', 'type': str, 'doc': 'driver for h5py to use when opening HDF5 file', 'default': None})
     def __init__(self, **kwargs):
-        path, mode, manager, extensions, load_namespaces, file_obj, comm =\
-            popargs('path', 'mode', 'manager', 'extensions', 'load_namespaces', 'file', 'comm', kwargs)
+        path, mode, manager, extensions, load_namespaces, file_obj, comm, driver =\
+            popargs('path', 'mode', 'manager', 'extensions', 'load_namespaces', 'file', 'comm', 'driver', kwargs)
         if load_namespaces:
             if manager is not None:
                 warn("loading namespaces from file - ignoring 'manager'")
@@ -228,7 +229,7 @@ class NWBHDF5IO(_HDF5IO):
                 raise ValueError("cannot load namespaces from file when writing to it")
 
             tm = get_type_map()
-            super(NWBHDF5IO, self).load_namespaces(tm, path, file=file_obj)
+            super(NWBHDF5IO, self).load_namespaces(tm, path, file=file_obj, driver=driver)
             manager = BuildManager(tm)
 
             # XXX: Leaving this here in case we want to revert to this strategy for
@@ -244,7 +245,7 @@ class NWBHDF5IO(_HDF5IO):
                 manager = get_manager(extensions=extensions)
             elif manager is None:
                 manager = get_manager()
-        super(NWBHDF5IO, self).__init__(path, manager=manager, mode=mode, file=file_obj, comm=comm)
+        super(NWBHDF5IO, self).__init__(path, manager=manager, mode=mode, file=file_obj, comm=comm, driver=driver)
 
     @docval({'name': 'src_io', 'type': HDMFIO, 'doc': 'the HDMFIO object for reading the data to export'},
             {'name': 'nwbfile', 'type': 'NWBFile',


### PR DESCRIPTION
## Motivation

added a driver option to allow for ros3

paired with https://github.com/hdmf-dev/hdmf/pull/506

## How to test the behavior?
```python
from pynwb import NWBHDF5IO

path = 'https://dandiarchive.s3.amazonaws.com/girder-assetstore/fa/00/fa00ee6896e54ea1a6b49fd970fd0210?versionId=Oqi5Wx00EabrDXBgiumsr0e11IYBD75T'

io = NWBHDF5IO(path, mode='r', load_namespaces=True, driver='ros3')
nwb = io.read()
```

## Checklist

- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR description clearly describes problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
