### PR TITLE
[DOC] - Fix spelling in documentation

### DIFF
--- a/docs/gallery/domain/brain_observatory.py
+++ b/docs/gallery/domain/brain_observatory.py
@@ -6,7 +6,7 @@ Create an nwb file from Allen Brain Observatory data.
 """
 
 ########################################
-# This example demostrates the basic functionality of several parts of the pynwb write API, centered around the optical
+# This example demonstrates the basic functionality of several parts of the pynwb write API, centered around the optical
 # physiology submodule (pynwb.ophys). We will use the allensdk as a read API, while leveraging the pynwb data model and
 # write api to transform and write the data back to disk.
 #
@@ -84,7 +84,7 @@ for stimulus in stimulus_list:
     nwbfile.add_stimulus(image_index)
 
 ########################################
-# 3) Besides the two-photon calcium image stack, the running speed of the animal was also recordered in this experiment.
+# 3) Besides the two-photon calcium image stack, the running speed of the animal was also recorded in this experiment.
 # We can store this data as a TimeSeries, in the acquisition portion of the file.
 
 running_speed = TimeSeries(
@@ -115,7 +115,7 @@ for _, row in epoch_table.iterrows():
 
 ########################################
 # 5) In the brain observatory, a two-photon microscope is used to acquire images of the calcium activity of neurons
-# expressing a fluorescent protien indicator.  Essentially the microscope captures picture (30 times a second) at a
+# expressing a fluorescent protein indicator.  Essentially the microscope captures picture (30 times a second) at a
 # single depth in the visual cortex (the imaging plane).  Let's use pynwb to store the metadata associated with this
 # hardware and experimental setup:
 optical_channel = OpticalChannel(
@@ -142,10 +142,10 @@ imaging_plane = nwbfile.create_imaging_plane(
 )
 
 ########################################
-# The Allen Insitute does not include the raw imaging signal, as this data would make the file too large. Instead, these
-# data are  preprocessed, and a dF/F flourescence signal extracted for each region-of-interest (ROI). To store the chain
+# The Allen Institute does not include the raw imaging signal, as this data would make the file too large. Instead, these
+# data are  preprocessed, and a dF/F fluorescence signal extracted for each region-of-interest (ROI). To store the chain
 # of computations necessary to describe this data processing pipeline, pynwb provides a "processing module" with
-# interfaces that simplify and standarize the process of adding the steps in this provenance chain to the file:
+# interfaces that simplify and standardize the process of adding the steps in this provenance chain to the file:
 ophys_module = nwbfile.create_processing_module(
     name='ophys_module',
     description='Processing module for 2P calcium responses',

--- a/docs/gallery/domain/ecephys.py
+++ b/docs/gallery/domain/ecephys.py
@@ -94,7 +94,7 @@ for idx in [1, 2, 3, 4]:
 # top-level :py:class:`~pynwb.misc.Units` table.
 #
 # In addition to the *data* and *timestamps* fields inherited
-# from :py:class:`~pynwb.base.TimeSeries` class, these two classs will require metadata about the elctrodes
+# from :py:class:`~pynwb.base.TimeSeries` class, these two classes will require metadata about the electrodes
 # from which *data* was generated. This is done by providing an :py:class:`~pynwb.core.DynamicTableRegion`,
 # which you can create using the :py:class:`~pynwb.file.NWBFile.create_electrode_table_region`
 #

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -230,7 +230,7 @@ rrs_rois = rrs.rois
 # .. [#] You can also store dF/F data using the :py:class:`~pynwb.ophys.DfOverF` class.
 #
 # .. [#] Neurodata sets can be *very* large, so individual components of the dataset are only loaded into memory when
-#    you requst them. This functionality is only possible if closing of the :py:class:`~pynwb.NWBHDF5IO`
+#    you request them. This functionality is only possible if closing of the :py:class:`~pynwb.NWBHDF5IO`
 #    object is handled by the user.
 #
 # .. [#] If you added more than one :py:class:`~pynwb.ophys.RoiResponseSeries`, you will need to

--- a/docs/gallery/general/advanced_hdf5_io.py
+++ b/docs/gallery/general/advanced_hdf5_io.py
@@ -123,7 +123,7 @@ nwbfile.add_acquisition(test_ts)
 # Chunking will be automatically enabled by h5py when compression and other I/O filters are enabled.
 #
 # To use compression, we can wrap our dataset using :py:class:`~hdmf.backends.hdf5.h5_utils.H5DataIO` and
-# define the approbriate opions:
+# define the appropriate options:
 
 wrapped_data = H5DataIO(data=data,
                         compression='gzip',              # <---- Use GZip
@@ -195,7 +195,7 @@ for k, v in nwbfile.acquisition.items():
 #   name=test_chunked_timeseries, chunks=(250, 5), compression=None, maxshape=(None, 10)
 #   name=test_gzipped_timeseries, chunks=(250, 5), compression=gzip, maxshape=(1000, 10)
 #
-# As we can see, the datasets have been chunked and compressed correctly. Alos, as expected, chunking
+# As we can see, the datasets have been chunked and compressed correctly. Also, as expected, chunking
 # was automatically enabled for the compressed datasets.
 
 

--- a/docs/gallery/general/extensions.py
+++ b/docs/gallery/general/extensions.py
@@ -242,7 +242,7 @@ nwbfile = io.read()
 # -----------------------------------------------------
 # It is sometimes the case that we need a group to hold zero-or-more or
 # one-or-more of the same object. Here we show how to create an extension that
-# defines a group (`PotatoSack`) that holds multiple objects (`Potatoes`) and
+# defines a group (`PotatoSack`) that holds multiple objects (`Potato`) and
 # then how to use the new data types. First, we use `pynwb` to define the new
 # data types.
 

--- a/docs/gallery/general/extensions.py
+++ b/docs/gallery/general/extensions.py
@@ -145,7 +145,7 @@ AutoTetrodeSeries = get_class('TetrodeSeries', 'mylab')
 #
 #     When defining your own :py:class:`~pynwb.core.NWBContainer`, the subclass name does not need to be the same
 #     as the extension type name. However, it is encouraged to keep class and extension names the same for the
-#     purposes of readibility.
+#     purposes of readability.
 
 ####################
 # .. _caching_extension:
@@ -242,7 +242,7 @@ nwbfile = io.read()
 # -----------------------------------------------------
 # It is sometimes the case that we need a group to hold zero-or-more or
 # one-or-more of the same object. Here we show how to create an extension that
-# defines a group (`PotatoSack`) that holds multiple objects (`Pototo` es) and
+# defines a group (`PotatoSack`) that holds multiple objects (`Potatoes`) and
 # then how to use the new data types. First, we use `pynwb` to define the new
 # data types.
 
@@ -356,7 +356,7 @@ io.close()
 #
 # Here we show how to create extensions by creating a data class for a
 # cortical surface mesh. This data type is particularly important for ECoG data, we need to know where each electrode is
-# with respect to the gyri and sucli. Surface mesh objects contain two types of data:
+# with respect to the gyri and sulci. Surface mesh objects contain two types of data:
 #
 # 1. `vertices`, which is an (n, 3) matrix of floats that represents points in 3D space
 #

--- a/docs/gallery/general/file.py
+++ b/docs/gallery/general/file.py
@@ -301,7 +301,7 @@ nwbfile.processing['behavior'].add(position)
 #
 # Epochs can be added to an NWB file using the method :py:meth:`~pynwb.file.NWBFile.add_epoch`.
 # The first and second arguments are the start time and stop times, respectively.
-# The third argument is one or more tags for labelling the epoch, and the fifth argument is a
+# The third argument is one or more tags for labeling the epoch, and the fifth argument is a
 # list of all the :py:class:`~pynwb.base.TimeSeries` that the epoch applies
 # to.
 

--- a/docs/gallery/general/iterative_write.py
+++ b/docs/gallery/general/iterative_write.py
@@ -88,9 +88,9 @@ writing large arrays without loading all data into memory and streaming data wri
 # .. tip::
 #
 #    Currently the HDF5 I/O backend of PyNWB (:py:class:`~hdmf.backends.hdf5.h5tools.HDF5IO`,
-#    :py:class:`~pynwb.NWBHDF5IO`) processes itertive data writes one-dataset-at-a-time. This means, that
+#    :py:class:`~pynwb.NWBHDF5IO`) processes iterative data writes one-dataset-at-a-time. This means, that
 #    while you may have an arbitrary number of iterative data writes, the write is performed in order.
-#    In the future we may use a queing process to enable the simultaneous processing of multiple iterative writes at
+#    In the future we may use a queuing process to enable the simultaneous processing of multiple iterative writes at
 #    the same time.
 #
 # Preparations:
@@ -98,7 +98,7 @@ writing large arrays without loading all data into memory and streaming data wri
 #
 # The data write in our examples really does not change. We, therefore, here create a
 # simple helper function first to write a simple NWBFile containing a single timeseries to
-# avoid repition of the same code and to allow us to focus on the important parts of this tutorial.
+# avoid repetition of the same code and to allow us to focus on the important parts of this tutorial.
 
 from datetime import datetime
 from dateutil.tz import tzlocal
@@ -305,7 +305,7 @@ data = SparseMatrixIterator(shape=(xsize, ysize),
                             chunk_shape=chunk_shape)
 
 #####################
-# In order to also enable compression and other advanced HDF5 dataset I/O featurs we can then also
+# In order to also enable compression and other advanced HDF5 dataset I/O features we can then also
 # wrap our data via :py:class:`~hdmf.backends.hdf5.h5_utils.H5DataIO`.
 from hdmf.backends.hdf5.h5_utils import H5DataIO
 matrix2 = SparseMatrixIterator(shape=(xsize, ysize),

--- a/docs/gallery/general/linking_data.py
+++ b/docs/gallery/general/linking_data.py
@@ -222,7 +222,7 @@ timeseries_2 = nwbfile2.get_acquisition('test_timeseries2')
 ####################
 # Step 2: Add the container to another NWBFile
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-# To intergrate both :py:meth:`~pynwb.base.TimeSeries` into a single file we simply create a new
+# To integrate both :py:meth:`~pynwb.base.TimeSeries` into a single file we simply create a new
 # :py:meth:`~pynwb.file.NWBFile` and our existing :py:meth:`~pynwb.base.TimeSeries` to it. PyNWB's
 # :py:class:`~pynwb.NWBHDF5IO` backend then automatically detects that the TimeSeries have already
 # been written to another file and will create external links for us.

--- a/docs/source/building_api.rst
+++ b/docs/source/building_api.rst
@@ -2,7 +2,7 @@ Building API classes
 ====================
 
 After you have written an extension, you will need a Pythonic way to interact with the data model. To do this,
-you will need to write some classes that represent the data you defined in your specificiation extensions.
+you will need to write some classes that represent the data you defined in your specification extensions.
 The :py:mod:`pynwb.core` module has various tools to make it easier to write classes that behave like
 the rest of the PyNWB API.
 
@@ -19,7 +19,7 @@ from your extension, you can tell PyNWB which *neurodata_type* it represents usi
 :py:func:`~pynwb.register_class`. This class can be called on its own, or used as a class decorator. The
 first argument should be the *neurodata_type* and the second argument should be the *namespace* name.
 
-The following example demonstrates how to register a class as the Python class reprsentation of the
+The following example demonstrates how to register a class as the Python class representation of the
 *neurodata_type* "MyContainer" from the *namespace* "my_ns".
 
 .. code-block:: python
@@ -88,7 +88,7 @@ subclasses :py:class:`~pynwb.core.NWBData` you can still use ``__nwbfields__``. 
 :py:func:`~hdmf.utils.docval`-like dictionaries.
 
 The following example demonstrates how to define a table with the columns ``foo`` and ``bar`` that are of type
-str and int, respectively. We also register the class as the reppresentation of the *neurodata_type* "MyTable"
+str and int, respectively. We also register the class as the representation of the *neurodata_type* "MyTable"
 from the *namespace* "my_ns".
 
 .. code-block:: python

--- a/docs/source/extensions.rst
+++ b/docs/source/extensions.rst
@@ -299,7 +299,7 @@ class for reading and writing, you will need to implement and register a custom
 .. tip::
 
     ObjectMappers allow you to customize how objects in the spec are mapped to attributes of your NWBContainer in
-    Python. This is useful, e.g., in cases where you want ot customize the default mapping. For example in
+    Python. This is useful, e.g., in cases where you want to customize the default mapping. For example in
     TimeSeries the attribute ``unit`` which is defined on the dataset ``data`` (i.e., ``data.unit``) would
     by default be mapped to the attribute ``data_unit`` on :py:class:`~pynwb.base.TimeSeries`. The ObjectMapper
     :py:class:`~pynwb.io.base.TimeSeriesMap` then changes this mapping to map ``data.unit`` to the attribute ``unit``

--- a/docs/source/make_roundtrip_test.rst
+++ b/docs/source/make_roundtrip_test.rst
@@ -68,7 +68,7 @@ The next thing is to tell the ``TestMapRoundTrip`` how to add the container to a
 argument--the :py:class:`~pynwb.file.NWBFile` instance that will be used to write your container.
 
 This method is required because different container types are allowed in different parts of an NWBFile. This method is
-also where you can add additonial containers that your container of interest depends on. For example, for the
+also where you can add additional containers that your container of interest depends on. For example, for the
 :py:class:`~pynwb.ecephys.ElectricalSeries` roundtrip test, ``addContainer`` handles adding the
 :py:class:`~pynwb.ecephys.ElectrodeGroup`, :py:class:`~pynwb.file.ElectrodeTable`, and
 :py:class:`~pynwb.device.Device` dependencies.

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -40,9 +40,9 @@ class SpatialSeries(TimeSeries):
 @register_class('BehavioralEpochs', CORE_NAMESPACE)
 class BehavioralEpochs(MultiContainerInterface):
     """
-    TimeSeries for storing behavoioral epochs. The objective of this and the other two Behavioral
+    TimeSeries for storing behavioral epochs. The objective of this and the other two Behavioral
     interfaces (e.g. BehavioralEvents and BehavioralTimeSeries) is to provide generic hooks for
-    software tools/scripts. This allows a tool/script to take the output one specific interface (e.g.,
+    software tools/scripts. This allows a tool/script to take the output of one specific interface (e.g.,
     UnitTimes) and plot that data relative to another data modality (e.g., behavioral events) without
     having to define all possible modalities in advance. Declaring one of these interfaces means that
     one or more TimeSeries of the specified type is published. These TimeSeries should reside in a
@@ -79,7 +79,7 @@ class BehavioralEvents(MultiContainerInterface):
 @register_class('BehavioralTimeSeries', CORE_NAMESPACE)
 class BehavioralTimeSeries(MultiContainerInterface):
     """
-    TimeSeries for storing Behavoioral time series data. See description of BehavioralEpochs for
+    TimeSeries for storing Behavioral time series data. See description of BehavioralEpochs for
     more details.
     """
 


### PR DESCRIPTION
This PR does a sweep of spelling and small phrasing fixes, mostly on the documentation site, and some small fixes in in-code documentation (in `behavior.py`).  

## Motivation

I've been exploring the documentation, and noticed there are quite a few spelling issues, so this fixes the ones I found from a quick scan through.  

## How to test the behavior?

Doc fixes only, so no tests needed. 

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
