### PR TITLE
Use HDMF 2.5.2

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,5 +1,5 @@
 # package dependencies and their minimum versions for installing PyNWB
-# the requirements here specify '==' for testing; setup.py replaces '==' with '>=', except HDMF has fixed requirements
+# the requirements here specify '==' for testing; setup.py replaces '==' with '>='
 h5py==2.9,<3  # support for setting attrs to lists of utf-8 added in 2.9
 hdmf==2.5.2,<3
 numpy==1.16,<1.21

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,7 @@
-# package dependencies and their minimum versions for installing PyNWB (note that HDMF has a range of requirements)
-# the requirements here specify '==' for testing; setup.py replaces '==' with '>='
+# package dependencies and their minimum versions for installing PyNWB
+# the requirements here specify '==' for testing; setup.py replaces '==' with '>=', except HDMF has fixed requirements
 h5py==2.9,<3  # support for setting attrs to lists of utf-8 added in 2.9
-hdmf==2.5.1,<3
+hdmf==2.5.1
 numpy==1.16,<1.21
 pandas==0.23,<2
 python-dateutil==2.7,<3

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,8 @@
 # package dependencies and their minimum versions for installing PyNWB
 # the requirements here specify '==' for testing; setup.py replaces '==' with '>=', except HDMF has fixed requirements
 h5py==2.9,<3  # support for setting attrs to lists of utf-8 added in 2.9
-hdmf==2.5.1
+hdmf==2.5.2,<3
 numpy==1.16,<1.21
 pandas==0.23,<2
 python-dateutil==2.7,<3
+setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 h5py==2.10.0
-hdmf==2.5.1
+hdmf==2.5.2
 numpy==1.18.5
 pandas==0.25.3
 python-dateutil==2.8.1
+setuptools==56.0.0

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ schema_dir = 'nwb-schema/core'
 
 with open('requirements-min.txt', 'r') as fp:
     # replace == with >= and remove trailing comments and spaces
-    reqs = [x.replace('==', '>=').split('#')[0].strip() for x in fp if not x.startswith('hdmf')]
+    reqs = [x.replace('==', '>=').split('#')[0].strip() for x in fp]
     reqs = [x for x in reqs if x]  # remove empty strings
 
 print(reqs)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ schema_dir = 'nwb-schema/core'
 
 with open('requirements-min.txt', 'r') as fp:
     # replace == with >= and remove trailing comments and spaces
-    reqs = [x.replace('==', '>=').split('#')[0].strip() for x in fp]
+    reqs = [x.replace('==', '>=').split('#')[0].strip() for x in fp if not x.startswith('hdmf')]
     reqs = [x for x in reqs if x]  # remove empty strings
 
 print(reqs)


### PR DESCRIPTION
Use just released HDMF 2.5.2, and also add setuptools as a requirement (see https://github.com/hdmf-dev/hdmf/pull/596)

## Checklist

- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR description clearly describes problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using `#XXX` notation where `XXX` is the issue number?
