### PR TITLE
Set language for code block to fix readthedocs

### DIFF
--- a/docs/source/extensions_tutorial/2_create_extension_spec_walkthrough.rst
+++ b/docs/source/extensions_tutorial/2_create_extension_spec_walkthrough.rst
@@ -11,7 +11,7 @@ generates a repository with the appropriate directory structure.
 After you finish the instructions `here <https://github.com/nwb-extensions/ndx-template#getting-started>`_,
 you should have a directory structure that looks like this
 
-.. code-block::
+.. code-block:: c
 
     ├── LICENSE.txt
     ├── MANIFEST.in


### PR DESCRIPTION
## Motivation

The code block with the file hierarchy created by the ndx-template does not render on readthedocs; see https://pynwb.readthedocs.io/en/dev/extensions_tutorial/2_create_extension_spec_walkthrough.html#using-ndx-template. The problem appears to be an issue with readthedocs where code blocks in sphinx that do not have a language specified don't seem to be rendered (even though they are rendered correctly in Git and offline sphinx).

## Checklist

- [N/A] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
