### PR TITLE
ENH: Ensure that sys.path has the current directory in setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
   be provided in place of ``data``. ``OpticalSeries.__init__`` now makes ``data`` optional. However, this has the
   side effect of moving the position of ``data`` to later in the argument list, which may break code that relies
   on positional arguments for ``OpticalSeries.__init__``. @rly (#1274)
+- Fixed `setup.py` not being able to import `versioneer` when installing in an embedded Python environment. @ikhramts (#1395)
 
 ## PyNWB 1.5.1 (May 24, 2021)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import sys
+
 from setuptools import setup, find_packages
+
+# Some Python installations don't add the current directory to path.
+if '' not in sys.path:
+    sys.path.insert(0, '')
 
 import versioneer
 


### PR DESCRIPTION
## Motivation

I tried to install the latest `dev` branch using `pip` in an [embedded Python](https://docs.python.org/3/using/windows.html#the-embeddable-package) on Windows, and got error `ModuleNotFoundError: No module named 'versioneer'` in `setup.py`.

This is a typical error with embedded Python because it does not add the current directory to `PYTHONPATH`. 

h5py [fixed this issue](https://github.com/h5py/h5py/commit/c27bc7bdb4e3da63b232e29d4f810e17b23ab037) two years ago by explicitly adding `''` to `sys.path` in `setup.py`.

This PR makes the same change here.

## How to test the behavior?

On Windows, using PowerShell

Before the change:

```
# Download and unzip embedded Python
> wget "https://www.python.org/ftp/python/3.9.6/python-3.9.6-embed-amd64.zip" -outfile "python.zip"
> Expand-Archive -Path python.zip -DestinationPath .\python

# Add site-packages to PYTHONPATH. 
# (Unfortunately we can't use this method to add the current dir)
> Add-Content -Path .\python\python39._pth -Value 'import site'

# Install PIP
> wget "https://bootstrap.pypa.io/get-pip.py" -outfile "get-pip.py"
> .\python\python.exe .\get-pip.py --no-warn-script-location
Collecting pip
  Using cached pip-21.2.4-py3-none-any.whl (1.6 MB)
Collecting setuptools
  Using cached setuptools-57.4.0-py3-none-any.whl (819 kB)
Collecting wheel
  Using cached wheel-0.37.0-py2.py3-none-any.whl (35 kB)
Installing collected packages: wheel, setuptools, pip
Successfully installed pip-21.2.4 setuptools-57.4.0 wheel-0.37.0

# Install PyNWB from the current dev branch:
> .\python\python.exe -m pip install https://github.com/NeurodataWithoutBorders/pynwb/archive/refs/heads/dev.zip --no-warn-script-location
Collecting https://github.com/NeurodataWithoutBorders/pynwb/archive/refs/heads/dev.zip
  Using cached https://github.com/NeurodataWithoutBorders/pynwb/archive/refs/heads/dev.zip
    ERROR: Command errored out with exit status 1:
     command: 'E:\Iouri_Temp\pynwb_test\python\python.exe' -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'C:\\Users\\ikhramts\\AppData\\Local\\Temp\\pip-req-build-jc0j42u3\\setup.py'"'"'; __file__='"'"'C:\\Users\\ikhramts\\AppData\\Local\\Temp\\pip-req-build-jc0j42u3\\setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base 'C:\Users\ikhramts\AppData\Local\Temp\pip-pip-egg-info-eliwd_ot'
         cwd: C:\Users\ikhramts\AppData\Local\Temp\pip-req-build-jc0j42u3\
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "C:\Users\ikhramts\AppData\Local\Temp\pip-req-build-jc0j42u3\setup.py", line 5, in <module>
        import versioneer
    ModuleNotFoundError: No module named 'versioneer'
    ----------------------------------------
WARNING: Discarding https://github.com/NeurodataWithoutBorders/pynwb/archive/refs/heads/dev.zip. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

After the change, everything installs correctly:

```
# ... Install Python, PIP ...

# Install PyNWB from the branch with the fix:
> .\python\python.exe -m pip install https://github.com/ikhramts/pynwb/archive/refs/heads/setup-py-add-current-dir.zip --no-warn-script-location
Collecting https://github.com/ikhramts/pynwb/archive/refs/heads/setup-py-add-current-dir.zip
  Using cached https://github.com/ikhramts/pynwb/archive/refs/heads/setup-py-add-current-dir.zip
Collecting h5py<4,>=2.9
  Using cached h5py-3.3.0-cp39-cp39-win_amd64.whl (2.8 MB)
Collecting hdmf<4,>=3.1.1
  Using cached hdmf-3.1.1-py3-none-any.whl (173 kB)
Collecting numpy<1.22,>=1.16
  Using cached numpy-1.21.1-cp39-cp39-win_amd64.whl (14.0 MB)
Collecting pandas<2,>=1.0.5
  Using cached pandas-1.3.1-cp39-cp39-win_amd64.whl (10.4 MB)
Collecting python-dateutil<3,>=2.7
  Using cached python_dateutil-2.8.2-py2.py3-none-any.whl (247 kB)
Requirement already satisfied: setuptools in e:\iouri_temp\pynwb_test\python\lib\site-packages (from pynwb==0+unknown) (57.4.0)
Collecting scipy<2,>=1.1
  Using cached scipy-1.7.1-cp39-cp39-win_amd64.whl (33.8 MB)
Collecting ruamel.yaml<1,>=0.16
  Using cached ruamel.yaml-0.17.10-py3-none-any.whl (108 kB)
Collecting jsonschema<4,>=2.6.0
  Using cached jsonschema-3.2.0-py2.py3-none-any.whl (56 kB)
Collecting attrs>=17.4.0
  Using cached attrs-21.2.0-py2.py3-none-any.whl (53 kB)
Collecting six>=1.11.0
  Using cached six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting pyrsistent>=0.14.0
  Using cached pyrsistent-0.18.0-cp39-cp39-win_amd64.whl (62 kB)
Collecting pytz>=2017.3
  Using cached pytz-2021.1-py2.py3-none-any.whl (510 kB)
Collecting ruamel.yaml.clib>=0.1.2
  Using cached ruamel.yaml.clib-0.2.6-cp39-cp39-win_amd64.whl (118 kB)
Building wheels for collected packages: pynwb
  Building wheel for pynwb (setup.py) ... done
  Created wheel for pynwb: filename=pynwb-0+unknown-py2.py3-none-any.whl size=85363 sha256=d112ae47203c387f8c11af8d9333aa0e5ee337357461c44af80814f812f22666
  Stored in directory: c:\users\ikhramts\appdata\local\pip\cache\wheels\60\fe\62\2f2fe5e57aa49bc503a5f1342ef997f95e989a538028df62ce
Successfully built pynwb
Installing collected packages: six, ruamel.yaml.clib, pytz, python-dateutil, pyrsistent, numpy, attrs, scipy, ruamel.yaml, pandas, jsonschema, h5py, hdmf, pynwb
Successfully installed attrs-21.2.0 h5py-3.3.0 hdmf-3.1.1 jsonschema-3.2.0 numpy-1.21.1 pandas-1.3.1 pynwb-0+unknown pyrsistent-0.18.0 python-dateutil-2.8.2 pytz-2021.1 ruamel.yaml-0.17.10 ruamel.yaml.clib-0.2.6 scipy-1.7.1 six-1.16.0
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
