### PR TITLE
Add environment-ros3.yml to MANIFEST.in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## PyNWB 2.0.1 (Upcoming)
 
 ### Bug fixes:
-- Add `environment-ros3.yml` to `MANIFEST.in` for inclusion in source distributions. @rly
+- Add `environment-ros3.yml` to `MANIFEST.in` for inclusion in source distributions. @rly (#1398)
 
 ## PyNWB 2.0.0 (August 13, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## PyNWB 2.0.1 (Upcoming)
+
+### Bug fixes:
+- Add `environment-ros3.yml` to `MANIFEST.in` for inclusion in source distributions. @rly
+
 ## PyNWB 2.0.0 (August 13, 2021)
 
 ### Breaking changes:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include license.txt Legal.txt versioneer.py src/pynwb/_version.py src/pynwb/_due.py
-include requirements.txt requirements-dev.txt requirements-doc.txt requirements-min.txt
+include requirements.txt requirements-dev.txt requirements-doc.txt requirements-min.txt environment-ros3.yml
 include test.py tox.ini
 
 graft tests


### PR DESCRIPTION
## Motivation

`environment-ros3.yml` was added in PyNWB 2.0 but not added to `MANIFEST.in`. It should be added so that it can be included in source distributions alongside the requirements files.

This file is currently used only by CI processes, but `conda` users may wish to use it to set up a working ROS3-compatible conda environment.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
