### PR TITLE
Added test for to_hierarchical_dataframe for the icephys tables 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug fixes:
 - Add `environment-ros3.yml` to `MANIFEST.in` for inclusion in source distributions. @rly (#1398)
+- Update HDMF minimum version to `3.1.2` to fix bug when converting the icephys metadata tables via `to_hierarchical_dataframe` when the tables contain indexed columns and add corresponding unit tests. @oruebel (#1404)
 
 ## PyNWB 2.0.0 (August 13, 2021)
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # minimum versions of package dependencies for installing PyNWB
 h5py==2.10  # support for selection of datasets with list of indices added in 2.10
-hdmf==3.1.1
+hdmf==3.1.2
 numpy==1.16
 pandas==1.0.5
 python-dateutil==2.7


### PR DESCRIPTION
This PR is in response to https://github.com/hdmf-dev/hdmf/issues/665 which identified an issue where conversion of the icephys metadata tables to a hierarchical dataframe fails if a table contains a VectorIndex column. This PR adds corresponding tests in PyNWB to make sure this case is tests here. A corresponding PR on HDMF will follow as well to fix this issue. 

## How to test the behavior?

From https://github.com/hdmf-dev/hdmf/issues/665
```
from pynwb.testing import create_icephys_testfile
from hdmf.common.hierarchicaltable import to_hierarchical_dataframe
nwbfile = create_icephys_testfile()
nwbfile.icephys_experimental_conditions.add_column('newcol', 'abc', data = [1,2,3], index = [2,3])
to_hierarchical_dataframe(nwbfile.icephys_experimental_conditions)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
