### PR TITLE
Skip ros3 tests if internet or ros3 driver are not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug fixes:
 - Add `environment-ros3.yml` to `MANIFEST.in` for inclusion in source distributions. @rly (#1398)
 - Fix bad error check in ``IntracellularRecordingsTable.add_recording`` when adding ``IZeroClampSeries``. @oruebel (#1410)
+-  Skip ros3 tests if internet access or the ros3 driver are not available. @oruebel (#1414)
 
 ### Tutorial enhancements:
 - Updated the general tutorial to add documentation about the ``Images`` type. @bendichter (#1353)

--- a/tests/integration/ros3/test_ros3.py
+++ b/tests/integration/ros3/test_ros3.py
@@ -16,7 +16,7 @@ class TestRos3Streaming(TestCase):
             urllib.request.urlopen('https://dandiarchive.s3.amazonaws.com/ros3test.nwb', timeout=1)
         except urllib.request.URLError:
             self.skipTest("Internet access to DANDI failed. Skipping all Ros3 streaming tests.")
-        if'ros3' not in h5py.registered_drivers():
+        if 'ros3' not in h5py.registered_drivers():
             self.skipTest("ROS3 driver not installed. Skipping all Ros3 streaming tests.")
 
     def test_read(self):

--- a/tests/integration/ros3/test_ros3.py
+++ b/tests/integration/ros3/test_ros3.py
@@ -1,13 +1,26 @@
 from pynwb import NWBHDF5IO
 from pynwb.testing import TestCase
+import urllib.request
+import h5py
 
 
 class TestRos3Streaming(TestCase):
-    # requires h5py to be built with the ROS3 driver: conda install -c conda-forge h5py
+    """
+    Test file access using the HDF5 ros3 driver.
+
+    This test module requires h5py to be built with the ROS3 driver: conda install -c conda-forge h5py
+    """
+    def setUp(self):
+        # Skip ROS3 tests if internet is not available or the ROS3 driver is not installed
+        try:
+            urllib.request.urlopen('https://dandiarchive.s3.amazonaws.com/ros3test.nwb', timeout=1)
+        except urllib.request.URLError:
+            self.skipTest("Internet access to DANDI failed. Skipping all Ros3 streaming tests.")
+        if'ros3' not in h5py.registered_drivers():
+            self.skipTest("ROS3 driver not installed. Skipping all Ros3 streaming tests.")
 
     def test_read(self):
         s3_path = 'https://dandiarchive.s3.amazonaws.com/ros3test.nwb'
-
         with NWBHDF5IO(s3_path, mode='r', driver='ros3') as io:
             nwbfile = io.read()
             test_data = nwbfile.acquisition['ts_name'].data[:]


### PR DESCRIPTION
## Motivation

Fix #1412

Automatically skip ROS3 tests if internet is not available or if ROS3 is not installed 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
