### PR TITLE
Update image types docval to add more clarity to dimension order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@
 ### Bug fixes:
 - Add `environment-ros3.yml` to `MANIFEST.in` for inclusion in source distributions. @rly (#1398)
 - Fix bad error check in ``IntracellularRecordingsTable.add_recording`` when adding ``IZeroClampSeries``. @oruebel (#1410)
--  Skip ros3 tests if internet access or the ros3 driver are not available. @oruebel (#1414)
+- Skip ros3 tests if internet access or the ros3 driver are not available. @oruebel (#1414)
 
 ### Tutorial enhancements:
 - Updated the general tutorial to add documentation about the ``Images`` type. @bendichter (#1353)
+
+### Minor improvements:
+- Improve constructor docstrings for Image types. @weiglszonja (#1418)
+
 
 ## PyNWB 2.0.0 (August 13, 2021)
 

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -193,7 +193,8 @@ class OpticalSeries(ImageSeries):
 class GrayscaleImage(Image):
 
     @docval(*get_docval(Image.__init__, 'name'),
-            {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'Data of image. Must be 2D',
+            {'name': 'data', 'type': ('array_data', 'data'),
+             'doc': 'Data of grayscale image. Must be 2D where the dimensions represent x and y.',
              'shape': (None, None)},
             *get_docval(Image.__init__, 'resolution', 'description'))
     def __init__(self, **kwargs):
@@ -205,7 +206,8 @@ class RGBImage(Image):
 
     @docval(*get_docval(Image.__init__, 'name'),
             {'name': 'data', 'type': ('array_data', 'data'),
-             'doc': 'Data of image. Must be 3D where the third dimension has length 3 and represents the RGB value',
+             'doc': 'Data of color image. Must be 3D where the first and second dimensions represent x and y. '
+                    'The third dimension has length 3 and represents the RGB value.',
              'shape': (None, None, 3)},
             *get_docval(Image.__init__, 'resolution', 'description'))
     def __init__(self, **kwargs):
@@ -217,7 +219,8 @@ class RGBAImage(Image):
 
     @docval(*get_docval(Image.__init__, 'name'),
             {'name': 'data', 'type': ('array_data', 'data'),
-             'doc': 'Data of image. Must be 3D where the third dimension has length 4 and represents the RGBA value',
+             'doc': 'Data of color image with transparency. Must be 3D where the first and second dimensions '
+                    'represent x and y. The third dimension has length 4 and represents the RGBA value.',
              'shape': (None, None, 4)},
             *get_docval(Image.__init__, 'resolution', 'description'))
     def __init__(self, **kwargs):


### PR DESCRIPTION
## Motivation

Add more clarity to dimension order for image types
NeurodataWithoutBorders/nwb-jupyter-widgets/issues/193

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
