### PR TITLE
Add conversion factor to waveform columns

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/pynwb/nwb-schema"]
 	path = src/pynwb/nwb-schema
-	url = http://github.com/NeurodataWithoutBorders/nwb-schema.git
+	url = http://github.com/catalystneuro/nwb-schema.git@integrate_measurements

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/pynwb/nwb-schema"]
 	path = src/pynwb/nwb-schema
-	url = http://github.com/catalystneuro/nwb-schema.git@integrate_measurements
+	url = http://github.com/catalystneuro/nwb-schema.git

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ flake8-debugger==4.0.0
 flake8-print==4.0.0
 importlib-metadata==4.6.1
 tox==3.23.1
-hdmf @ git+https://github.com/catalystneuro/hdmf.git@add_measurement_vector_data

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,3 +7,4 @@ flake8-debugger==4.0.0
 flake8-print==4.0.0
 importlib-metadata==4.6.1
 tox==3.23.1
+hdmf @ git+https://github.com/catalystneuro/hdmf.git@add_measurement_vector_data

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # minimum versions of package dependencies for installing PyNWB
 h5py==2.10  # support for selection of datasets with list of indices added in 2.10
-hdmf==3.1.1
+hdmf @ git+https://github.com/catalystneuro/hdmf.git@add_measurement_vector_data
 numpy==1.16
 pandas==1.0.5
 python-dateutil==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
 h5py==3.3.0
-hdmf==3.1.1
+hdmf @ git+https://github.com/catalystneuro/hdmf.git@add_measurement_vector_data
 numpy==1.21.0
 pandas==1.3.0
 python-dateutil==2.8.1

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -78,10 +78,6 @@ class VectorDataMap(ObjectMapper):
                     return container.parent.waveform_rate
                 if spec.name == 'unit':
                     return container.parent.waveform_unit
-                if spec.name == 'conversion_factor':
-                    return container.parent.waveform_conversion
-                if spec.name == 'offset':
-                    return container.parent.waveform_offset
             if container.name == 'spike_times':
                 if spec.name == 'resolution':
                     return container.parent.resolution

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -78,6 +78,10 @@ class VectorDataMap(ObjectMapper):
                     return container.parent.waveform_rate
                 if spec.name == 'unit':
                     return container.parent.waveform_unit
+                if spec.name == 'conversion_factor':
+                    return container.parent.waveform_conversion
+                if spec.name == 'offset':
+                    return container.parent.waveform_offset
             if container.name == 'spike_times':
                 if spec.name == 'resolution':
                     return container.parent.resolution

--- a/src/pynwb/io/misc.py
+++ b/src/pynwb/io/misc.py
@@ -24,14 +24,6 @@ class UnitsMap(DynamicTableMap):
     def waveform_unit_carg(self, builder, manager):
         return self._get_waveform_stat(builder, 'unit')
 
-    @DynamicTableMap.constructor_arg('waveform_conversion')
-    def waveform_conversion_carg(self, builder, manager):
-        return self._get_waveform_stat(builder, 'conversion_factor')
-
-    @DynamicTableMap.constructor_arg('waveform_offset')
-    def waveform_offset_carg(self, builder, manager):
-        return self._get_waveform_stat(builder, 'offset')
-
     def _get_waveform_stat(self, builder, attribute):
         if 'waveform_mean' not in builder and 'waveform_sd' not in builder:
             return None

--- a/src/pynwb/io/misc.py
+++ b/src/pynwb/io/misc.py
@@ -24,6 +24,14 @@ class UnitsMap(DynamicTableMap):
     def waveform_unit_carg(self, builder, manager):
         return self._get_waveform_stat(builder, 'unit')
 
+    @DynamicTableMap.constructor_arg('waveform_conversion')
+    def waveform_conversion_carg(self, builder, manager):
+        return self._get_waveform_stat(builder, 'conversion_factor')
+
+    @DynamicTableMap.constructor_arg('waveform_offset')
+    def waveform_offset_carg(self, builder, manager):
+        return self._get_waveform_stat(builder, 'offset')
+
     def _get_waveform_stat(self, builder, attribute):
         if 'waveform_mean' not in builder and 'waveform_sd' not in builder:
             return None

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -164,9 +164,9 @@ class Units(DynamicTable):
             {'name': 'waveform_unit', 'type': str,
              'doc': 'Unit of measurement of the waveform means', 'default': 'volts'},
             {'name': 'waveform_conversion', 'type': float,
-             'doc': 'Scaling factor to apply to waveforms to convert them to waveform_unit', 'default': np.nan},
+             'doc': 'Scaling factor to apply to waveforms to convert them to waveform_unit', 'default': None},
             {'name': 'waveform_offset', 'type': float,
-             'doc': 'Offset to apply to waveforms after scaling them to waveform_units', 'default': np.nan},
+             'doc': 'Offset to apply to waveforms after scaling them to waveform_units', 'default': None},
             {'name': 'resolution', 'type': 'float',
              'doc': 'The smallest possible difference between two spike times', 'default': None}
             )

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -3,6 +3,7 @@ from collections.abc import Iterable
 import warnings
 from bisect import bisect_left, bisect_right
 
+# from hdmf.common.table import MeasurementData
 from hdmf.utils import docval, getargs, popargs, call_docval_func, get_docval
 
 from . import register_class, CORE_NAMESPACE
@@ -152,6 +153,7 @@ class Units(DynamicTable):
         {'name': 'waveform_mean', 'description': 'the spike waveform mean for each spike unit'},
         {'name': 'waveform_sd', 'description': 'the spike waveform standard deviation for each spike unit'},
         {'name': 'waveforms', 'description': waveforms_desc, 'index': 2}
+         # 'class': MeasurementData}
     )
 
     @docval({'name': 'name', 'type': str, 'doc': 'Name of this Units interface', 'default': 'Units'},
@@ -163,10 +165,6 @@ class Units(DynamicTable):
              'doc': 'Sampling rate of the waveform means', 'default': None},
             {'name': 'waveform_unit', 'type': str,
              'doc': 'Unit of measurement of the waveform means', 'default': 'volts'},
-            {'name': 'waveform_conversion', 'type': float,
-             'doc': 'Scaling factor to apply to waveforms to convert them to waveform_unit', 'default': None},
-            {'name': 'waveform_offset', 'type': float,
-             'doc': 'Offset to apply to waveforms after scaling them to waveform_units', 'default': None},
             {'name': 'resolution', 'type': 'float',
              'doc': 'The smallest possible difference between two spike times', 'default': None}
             )
@@ -179,8 +177,6 @@ class Units(DynamicTable):
         self.__electrode_table = getargs('electrode_table', kwargs)
         self.waveform_rate = getargs('waveform_rate', kwargs)
         self.waveform_unit = getargs('waveform_unit', kwargs)
-        self.waveform_conversion = getargs('waveform_conversion', kwargs)
-        self.waveform_offset = getargs('waveform_offset', kwargs)
         self.resolution = getargs('resolution', kwargs)
 
     @docval({'name': 'spike_times', 'type': 'array_data', 'doc': 'the spike times for each unit',
@@ -217,6 +213,8 @@ class Units(DynamicTable):
                         warnings.warn('Reference to electrode table that does not yet exist')
                 else:
                     elec_col.table = self.__electrode_table
+        if 'waveforms' in self:
+            self.waveform.units = self.waveform_unit
 
     @docval({'name': 'index', 'type': (int, list, tuple, np.ndarray),
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'},

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -202,8 +202,6 @@ class Units(DynamicTable):
         """
         Add a unit to this table
         """
-        # if 'waveforms' not in self:
-        #     self.add_column(name='waveforms', description=waveforms_desc, index=2, class=MeasurementData)
         super(Units, self).add_row(**kwargs)
         if 'electrodes' in self:
             elec_col = self['electrodes'].target

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -133,8 +133,6 @@ class Units(DynamicTable):
     __fields__ = (
         'waveform_rate',
         'waveform_unit',
-        'waveform_conversion',
-        'waveform_offset',
         'resolution'
     )
 

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable
 import warnings
 from bisect import bisect_left, bisect_right
 
-# from hdmf.common.table import MeasurementData
+from hdmf.common.table import MeasurementData
 from hdmf.utils import docval, getargs, popargs, call_docval_func, get_docval
 
 from . import register_class, CORE_NAMESPACE
@@ -152,8 +152,8 @@ class Units(DynamicTable):
         {'name': 'electrode_group', 'description': 'the electrode group that each spike unit came from'},
         {'name': 'waveform_mean', 'description': 'the spike waveform mean for each spike unit'},
         {'name': 'waveform_sd', 'description': 'the spike waveform standard deviation for each spike unit'},
-        {'name': 'waveforms', 'description': waveforms_desc, 'index': 2}
-         # 'class': MeasurementData}
+        {'name': 'waveforms', 'description': waveforms_desc, 'index': 2,
+         'class': MeasurementData, 'unit': 'volts', 'conversion': 1., 'offset': 0.}
     )
 
     @docval({'name': 'name', 'type': str, 'doc': 'Name of this Units interface', 'default': 'Units'},
@@ -202,6 +202,8 @@ class Units(DynamicTable):
         """
         Add a unit to this table
         """
+        # if 'waveforms' not in self:
+        #     self.add_column(name='waveforms', description=waveforms_desc, index=2, class=MeasurementData)
         super(Units, self).add_row(**kwargs)
         if 'electrodes' in self:
             elec_col = self['electrodes'].target
@@ -213,8 +215,6 @@ class Units(DynamicTable):
                         warnings.warn('Reference to electrode table that does not yet exist')
                 else:
                     elec_col.table = self.__electrode_table
-        if 'waveforms' in self:
-            self.waveform.units = self.waveform_unit
 
     @docval({'name': 'index', 'type': (int, list, tuple, np.ndarray),
              'doc': 'the index of the unit in unit_ids to retrieve spike times for'},

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -132,6 +132,8 @@ class Units(DynamicTable):
     __fields__ = (
         'waveform_rate',
         'waveform_unit',
+        'waveform_conversion',
+        'waveform_offset',
         'resolution'
     )
 
@@ -161,6 +163,10 @@ class Units(DynamicTable):
              'doc': 'Sampling rate of the waveform means', 'default': None},
             {'name': 'waveform_unit', 'type': str,
              'doc': 'Unit of measurement of the waveform means', 'default': 'volts'},
+            {'name': 'waveform_conversion', 'type': float,
+             'doc': 'Scaling factor to apply to waveforms to convert them to waveform_unit', 'default': np.nan},
+            {'name': 'waveform_offset', 'type': float,
+             'doc': 'Offset to apply to waveforms after scaling them to waveform_units', 'default': np.nan},
             {'name': 'resolution', 'type': 'float',
              'doc': 'The smallest possible difference between two spike times', 'default': None}
             )
@@ -173,6 +179,8 @@ class Units(DynamicTable):
         self.__electrode_table = getargs('electrode_table', kwargs)
         self.waveform_rate = getargs('waveform_rate', kwargs)
         self.waveform_unit = getargs('waveform_unit', kwargs)
+        self.waveform_conversion = getargs('waveform_conversion', kwargs)
+        self.waveform_offset = getargs('waveform_offset', kwargs)
         self.resolution = getargs('resolution', kwargs)
 
     @docval({'name': 'spike_times', 'type': 'array_data', 'doc': 'the spike times for each unit',

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -173,7 +173,7 @@ class UnitsTests(TestCase):
                     [1, 2, 3]   # spike 4
                 ]
             ]
-        ut.add_unit(waveforms=wf1)
+        ut.add_unit(waveforms=wf1, unit='volts', conversion=1., offset=0.)
         ut.add_unit(waveforms=wf2)
         self.assertEqual(ut.id.data, [0, 1])
         self.assertEqual(ut['waveforms'].target.data, [3, 6, 10, 14, 18])

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -180,6 +180,7 @@ class UnitsTests(TestCase):
         self.assertEqual(ut['waveforms'].data, [2, 5])
         self.assertListEqual(ut['waveforms'][0], wf1)
         self.assertListEqual(ut['waveforms'][1], wf2)
+        self.assertEqual(ut.waveforms.units, "volts")
 
     def test_get_spike_times(self):
         ut = Units()
@@ -250,25 +251,7 @@ class UnitsTests(TestCase):
         ut = Units(waveform_rate=waveform_rate)
         self.assertEqual(ut.waveform_rate, waveform_rate)
         self.assertEqual(ut.waveform_unit, 'volts')
-        self.assertIsNone(ut.waveform_conversion)
-        self.assertIsNone(ut.waveform_offset)
 
         waveform_unit = 'microvolts'
         ut = Units(waveform_unit=waveform_unit)
         self.assertEqual(ut.waveform_unit, waveform_unit)
-        self.assertIsNone(ut.waveform_conversion)
-        self.assertIsNone(ut.waveform_offset)
-
-        waveform_conversion = 0.195
-        ut = Units(waveform_conversion=waveform_conversion)
-        self.assertIsNone(ut.waveform_rate)
-        self.assertEqual(ut.waveform_unit, 'volts')
-        self.assertEqual(ut.waveform_conversion, waveform_conversion)
-        self.assertIsNone(ut.waveform_offset)
-
-        waveform_offset = 0.195 * 2**15
-        ut = Units(waveform_offset=waveform_offset)
-        self.assertIsNone(ut.waveform_rate)
-        self.assertEqual(ut.waveform_unit, 'volts')
-        self.assertIsNone(ut.waveform_conversion)
-        self.assertEqual(ut.waveform_offset, waveform_offset)

--- a/tests/unit/test_misc.py
+++ b/tests/unit/test_misc.py
@@ -246,6 +246,29 @@ class UnitsTests(TestCase):
         self.assertEqual(ut['electrode_group'][0], electrode_group)
 
     def test_waveform_attrs(self):
-        ut = Units(waveform_rate=40000.)
-        self.assertEqual(ut.waveform_rate, 40000.)
+        waveform_rate = 40000.
+        ut = Units(waveform_rate=waveform_rate)
+        self.assertEqual(ut.waveform_rate, waveform_rate)
         self.assertEqual(ut.waveform_unit, 'volts')
+        self.assertIsNone(ut.waveform_conversion)
+        self.assertIsNone(ut.waveform_offset)
+
+        waveform_unit = 'microvolts'
+        ut = Units(waveform_unit=waveform_unit)
+        self.assertEqual(ut.waveform_unit, waveform_unit)
+        self.assertIsNone(ut.waveform_conversion)
+        self.assertIsNone(ut.waveform_offset)
+
+        waveform_conversion = 0.195
+        ut = Units(waveform_conversion=waveform_conversion)
+        self.assertIsNone(ut.waveform_rate)
+        self.assertEqual(ut.waveform_unit, 'volts')
+        self.assertEqual(ut.waveform_conversion, waveform_conversion)
+        self.assertIsNone(ut.waveform_offset)
+
+        waveform_offset = 0.195 * 2**15
+        ut = Units(waveform_offset=waveform_offset)
+        self.assertIsNone(ut.waveform_rate)
+        self.assertEqual(ut.waveform_unit, 'volts')
+        self.assertIsNone(ut.waveform_conversion)
+        self.assertEqual(ut.waveform_offset, waveform_offset)


### PR DESCRIPTION
## Motivation
For large amounts of recording data, even adding waveform snippets to the columns of a `Units` table can be a significant task. One step towards reducing unnecessary data inflation is to add attributes for scaling factors similar to the behavior of other `TimeSeries`-like objects that allow the data to be stored in some minimal base type, while the conversion factor then scales it into the specified scientific units.

I've added these attributes and attempted to propagate them through the IO, mirroring the patterns established by the `waveform_rate` attribute.

Sister PR: https://github.com/NeurodataWithoutBorders/nwb-schema/pull/491

## How to test the behavior?
Behavior is showcased in the steps, identical to `waveform_rate`. What is currently untested in both cases is the default behavior of merely calling `nwbfile.add_unit()` the first time in a fresh NWBFile, which auto-generates a blank `Units` table. We should discuss how attributes of that table ought to be set in that situation (probably just be always being sure to define `nwbfile.Units = Units(**my_attributes)` before adding any actual units).

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
