### PR TITLE
Add copy button to code blocks 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Breaking changes:
 - Restrict `SpatialSeries.data` to have no more than 3 columns (#1455)
 
+### Documentation and tutorial enhancements:
+- Add copy button to code blocks @weiglszonja (#1460)
 
 ## PyNWB 2.0.1 (March 16, 2022)
 

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -17,3 +17,12 @@ dl.class em:not([class]):last-of-type::after {
 dl.class > dt:first-of-type {
     display: block !important;
 }
+
+button.copybtn {
+    height:25px;
+    width:25px;
+    opacity: 0.5;
+    padding: 0;
+    border: none;
+    background: none;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -54,7 +54,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinx.ext.extlinks',
-    'sphinx_gallery.gen_gallery'
+    'sphinx_gallery.gen_gallery',
+    'sphinx_copybutton',
 ]
 
 from sphinx_gallery.sorting import ExplicitOrder

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -6,3 +6,4 @@ sphinx-gallery
 allensdk>=2.11.0  # python 3.8 is not supported in allensdk<2.11
 MarkupSafe==2.0.1  # resolve incompatibility between jinja2 and markupsafe: https://github.com/AllenInstitute/AllenSDK/issues/2308
 Pillow
+sphinx-copybutton


### PR DESCRIPTION
## Motivation

Add copy button to code blocks in the documentation.
The button is customised to be always visible but faded (see below), it becomes fully visible when mouse is hovered over.

![button_demo](https://user-images.githubusercontent.com/24475788/164512456-b4f7d24a-24fb-4570-9c72-47cdc28841f3.gif)

resolves #1458

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
