### PR TITLE
Render large dataframes as images icephys tutorials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Documentation and tutorial enhancements:
 - Add copy button to code blocks @weiglszonja (#1460)
+- Enhance display of icephys pandas tutorial by using ``dataframe_image`` to render and display large tables as images. @oruebel (#1469)
 
 ## PyNWB 2.0.1 (March 16, 2022)
 

--- a/docs/gallery/domain/plot_icephys_pandas.py
+++ b/docs/gallery/domain/plot_icephys_pandas.py
@@ -44,7 +44,7 @@ pandas.set_option("display.max_colwidth", 30)
 pandas.set_option("display.max_rows", 10)
 pandas.set_option("display.max_columns", 6)
 pandas.set_option("display.colheader_justify", "right")
-dfi_fontsize = 8  # Fontsize to use when rendering with dataframe_image
+dfi_fontsize = 7  # Fontsize to use when rendering with dataframe_image
 
 
 #####################################################################

--- a/docs/gallery/domain/plot_icephys_pandas.py
+++ b/docs/gallery/domain/plot_icephys_pandas.py
@@ -27,21 +27,23 @@ tables and how to create an NWBFile for intracellular electrophysiology data.
 # Standard Python imports
 import numpy as np
 import pandas
+
+#####################################################################
+# Settings for improving rendering of tables in the online tutorial
 import dataframe_image
 import os
 # Get the path to the this tutorial
 try:
     tutorial_path = os.path.abspath(__file__)    # when running as a .py
 except NameError:
-    tutorial_path = os.path.abspath("__file__")  # When running as a script or as a jupyter notebook
+    tutorial_path = os.path.abspath("__file__")  # when running as a script or notebook
 # directory to save rendered dataframe images for display
 df_basedir = os.path.abspath(os.path.join(
     os.path.dirname(tutorial_path),
     "../../source/tutorials/domain/images/"))
-# for gallery tests only
-if not os.path.exists(df_basedir):
-    os.makedirs(df_basedir, exist_ok=True)
-
+# Create the image directory. This is necessary only for gallery tests on GitHub
+# but not for normal doc builds the output path already exists
+os.makedirs(df_basedir, exist_ok=True)
 # Set rendering options for tables
 pandas.set_option("display.max_colwidth", 30)
 pandas.set_option("display.max_rows", 10)

--- a/docs/gallery/domain/plot_icephys_pandas.py
+++ b/docs/gallery/domain/plot_icephys_pandas.py
@@ -28,12 +28,24 @@ tables and how to create an NWBFile for intracellular electrophysiology data.
 import numpy as np
 import pandas
 import dataframe_image
-df_basedir = "../../source/tutorials/domain/images/"  # directory to save rendered dataframe images for display
+import os
+# Get the path to the this tutorial
+try:
+    tutorial_path = os.path.abspath(__file__)    # when running as a .py
+except NameError:
+    tutorial_path = os.path.abspath("__file__")  # When running as a script or as a jupyter notebook
+# directory to save rendered dataframe images for display
+df_basedir = os.path.abspath(os.path.join(
+    os.path.dirname(tutorial_path),
+    "../../source/tutorials/domain/images/"))
 
-# Set pandas rendering option to avoid very wide tables in the html docs
+# Set rendering options for tables
 pandas.set_option("display.max_colwidth", 30)
 pandas.set_option("display.max_rows", 10)
 pandas.set_option("display.max_columns", 6)
+pandas.set_option("display.colheader_justify", "right")
+dfi_fontsize = 8  # Fontsize to use when rendering with dataframe_image
+
 
 #####################################################################
 # Example setup
@@ -178,8 +190,9 @@ ir_df = nwbfile.intracellular_recordings.to_dataframe(
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=ir_df,
-    filename=df_basedir + 'intracellular_recordings_dataframe.png',
-    table_conversion='matplotlib')
+    filename=os.path.join(df_basedir, 'intracellular_recordings_dataframe.png'),
+    table_conversion='matplotlib',
+    fontsize=dfi_fontsize)
 
 #####################################################################
 # .. image:: images/intracellular_recordings_dataframe.png
@@ -248,8 +261,9 @@ icephys_meta_df = to_hierarchical_dataframe(root_table)
 # save table as image to display in the docs
 dataframe_image.export(
     obj=icephys_meta_df,
-    filename=df_basedir + 'icephys_meta_dataframe.png',
-    table_conversion='matplotlib')
+    filename=os.path.join(df_basedir, 'icephys_meta_dataframe.png'),
+    table_conversion='matplotlib',
+    fontsize=dfi_fontsize)
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe.png
@@ -283,8 +297,9 @@ drid_icephys_meta_df = drop_id_columns(dataframe=icephys_meta_df, inplace=False)
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=drid_icephys_meta_df,
-    filename=df_basedir + 'icephys_meta_dataframe_drop_id.png',
-    table_conversion='matplotlib')
+    filename=os.path.join(df_basedir, 'icephys_meta_dataframe_drop_id.png'),
+    table_conversion='matplotlib',
+    fontsize=dfi_fontsize)
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe_drop_id.png
@@ -320,8 +335,9 @@ icephys_meta_df = pandas.concat([icephys_meta_df, stimulus_df], axis=1)
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=icephys_meta_df,
-    filename=df_basedir + 'icephys_meta_dataframe_expand_tsr.png',
-    table_conversion='matplotlib')
+    filename=os.path.join(df_basedir, 'icephys_meta_dataframe_expand_tsr.png'),
+    table_conversion='matplotlib',
+    fontsize=dfi_fontsize)
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe_expand_tsr.png
@@ -366,9 +382,10 @@ for field in ['neurodata_type', 'gain', 'rate', 'starting_time', 'object_id']:
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=icephys_meta_df,
-    filename=df_basedir + 'icephys_meta_dataframe_add_stimres.png',
+    filename=os.path.join(df_basedir, 'icephys_meta_dataframe_add_stimres.png'),
     table_conversion='matplotlib',
-    max_cols=10)
+    max_cols=10,
+    fontsize=dfi_fontsize)
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe_add_stimres.png
@@ -507,9 +524,10 @@ query_res_df = icephys_meta_df[
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=query_res_df,
-    filename=df_basedir + 'icephys_meta_query_result_dataframe.png',
+    filename=os.path.join(df_basedir, 'icephys_meta_query_result_dataframe.png'),
     table_conversion='matplotlib',
-    max_cols=10)
+    max_cols=10,
+    fontsize=dfi_fontsize)
 
 #####################################################################
 # .. image:: images/icephys_meta_query_result_dataframe.png

--- a/docs/gallery/domain/plot_icephys_pandas.py
+++ b/docs/gallery/domain/plot_icephys_pandas.py
@@ -176,7 +176,9 @@ ir_df = nwbfile.intracellular_recordings.to_dataframe(
 )
 
 # save the table as image to display in the docs
-dataframe_image.export(obj=ir_df, filename=df_basedir +'intracellular_recordings_dataframe.png')
+dataframe_image.export(
+    obj=ir_df,
+    filename=df_basedir + 'intracellular_recordings_dataframe.png')
 
 #####################################################################
 # .. image:: images/intracellular_recordings_dataframe.png
@@ -277,7 +279,7 @@ drid_icephys_meta_df = drop_id_columns(dataframe=icephys_meta_df, inplace=False)
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=drid_icephys_meta_df,
-    filename=df_basedir +'icephys_meta_dataframe_drop_id.png')
+    filename=df_basedir + 'icephys_meta_dataframe_drop_id.png')
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe_drop_id.png
@@ -313,7 +315,7 @@ icephys_meta_df = pandas.concat([icephys_meta_df, stimulus_df], axis=1)
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=icephys_meta_df,
-    filename=df_basedir +'icephys_meta_dataframe_expand_tsr.png')
+    filename=df_basedir + 'icephys_meta_dataframe_expand_tsr.png')
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe_expand_tsr.png
@@ -358,7 +360,7 @@ for field in ['neurodata_type', 'gain', 'rate', 'starting_time', 'object_id']:
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=icephys_meta_df,
-    filename=df_basedir +'icephys_meta_dataframe_add_stimres.png',
+    filename=df_basedir + 'icephys_meta_dataframe_add_stimres.png',
     max_cols=10)
 
 #####################################################################
@@ -498,7 +500,7 @@ query_res_df = icephys_meta_df[
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=query_res_df,
-    filename=df_basedir +'icephys_meta_query_result_dataframe.png',
+    filename=df_basedir + 'icephys_meta_query_result_dataframe.png',
     max_cols=10)
 
 #####################################################################
@@ -506,5 +508,3 @@ dataframe_image.export(
 #     :width: 100%
 #     :alt: icephys_meta_query_result_dataframe.png
 #     :align: center
-
-

--- a/docs/gallery/domain/plot_icephys_pandas.py
+++ b/docs/gallery/domain/plot_icephys_pandas.py
@@ -178,7 +178,8 @@ ir_df = nwbfile.intracellular_recordings.to_dataframe(
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=ir_df,
-    filename=df_basedir + 'intracellular_recordings_dataframe.png')
+    filename=df_basedir + 'intracellular_recordings_dataframe.png',
+    table_conversion='matplotlib')
 
 #####################################################################
 # .. image:: images/intracellular_recordings_dataframe.png
@@ -245,7 +246,10 @@ from hdmf.common.hierarchicaltable import to_hierarchical_dataframe
 icephys_meta_df = to_hierarchical_dataframe(root_table)
 
 # save table as image to display in the docs
-dataframe_image.export(icephys_meta_df, df_basedir + 'icephys_meta_dataframe.png')
+dataframe_image.export(
+    obj=icephys_meta_df,
+    filename=df_basedir + 'icephys_meta_dataframe.png',
+    table_conversion='matplotlib')
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe.png
@@ -279,7 +283,8 @@ drid_icephys_meta_df = drop_id_columns(dataframe=icephys_meta_df, inplace=False)
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=drid_icephys_meta_df,
-    filename=df_basedir + 'icephys_meta_dataframe_drop_id.png')
+    filename=df_basedir + 'icephys_meta_dataframe_drop_id.png',
+    table_conversion='matplotlib')
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe_drop_id.png
@@ -315,7 +320,8 @@ icephys_meta_df = pandas.concat([icephys_meta_df, stimulus_df], axis=1)
 # save the table as image to display in the docs
 dataframe_image.export(
     obj=icephys_meta_df,
-    filename=df_basedir + 'icephys_meta_dataframe_expand_tsr.png')
+    filename=df_basedir + 'icephys_meta_dataframe_expand_tsr.png',
+    table_conversion='matplotlib')
 
 #####################################################################
 # .. image:: images/icephys_meta_dataframe_expand_tsr.png
@@ -361,6 +367,7 @@ for field in ['neurodata_type', 'gain', 'rate', 'starting_time', 'object_id']:
 dataframe_image.export(
     obj=icephys_meta_df,
     filename=df_basedir + 'icephys_meta_dataframe_add_stimres.png',
+    table_conversion='matplotlib',
     max_cols=10)
 
 #####################################################################
@@ -501,6 +508,7 @@ query_res_df = icephys_meta_df[
 dataframe_image.export(
     obj=query_res_df,
     filename=df_basedir + 'icephys_meta_query_result_dataframe.png',
+    table_conversion='matplotlib',
     max_cols=10)
 
 #####################################################################

--- a/docs/gallery/domain/plot_icephys_pandas.py
+++ b/docs/gallery/domain/plot_icephys_pandas.py
@@ -10,6 +10,13 @@ intracellular electrophysiology experiments using the metadata tables
 from the :py:meth:`~pynwb.icephys` module. See the :ref:`icephys_tutorial_new`
 tutorial for an introduction to the intracellular electrophysiology metadata
 tables and how to create an NWBFile for intracellular electrophysiology data.
+
+.. note::
+
+    To enhance display of large pandas DataFrames, we save and render large tables
+    as images in this tutorial. Simply click on the rendered table to view the
+    full-size image.
+
 '''
 
 #####################################################################
@@ -20,6 +27,9 @@ tables and how to create an NWBFile for intracellular electrophysiology data.
 # Standard Python imports
 import numpy as np
 import pandas
+import dataframe_image
+df_basedir = "../../source/tutorials/domain/images/"  # directory to save rendered dataframe images for display
+
 # Set pandas rendering option to avoid very wide tables in the html docs
 pandas.set_option("display.max_colwidth", 30)
 pandas.set_option("display.max_rows", 10)
@@ -154,17 +164,25 @@ exp_cond_df.iloc[0]['repetitions']
 # ``electrodes``, ``stimuli``, and ``responses``. For convenience, the
 # :py:meth:`~pynwb.icephys.IntracellularRecordingsTable.to_dataframe` of the
 # :py:class:`~pynwb.icephys.IntracellularRecordingsTable` provides a few
-# additonal optional parameters to optionally ignore the ids of the category tables
+# additional optional parameters to ignore the ids of the category tables
 # (via ``ignore_category_ids=True``) or to convert the electrode, stimulus, and
 # response references to ObjectIds. For example:
 #
-
-nwbfile.intracellular_recordings.to_dataframe(
+ir_df = nwbfile.intracellular_recordings.to_dataframe(
     ignore_category_ids=True,
     electrode_refs_as_objectids=True,
     stimulus_refs_as_objectids=True,
     response_refs_as_objectids=True
 )
+
+# save the table as image to display in the docs
+dataframe_image.export(obj=ir_df, filename=df_basedir +'intracellular_recordings_dataframe.png')
+
+#####################################################################
+# .. image:: images/intracellular_recordings_dataframe.png
+#     :width: 100%
+#     :alt: intracellular_recordings_dataframe.png
+#     :align: center
 
 #####################################################################
 # Using indexed DataFrames
@@ -224,12 +242,14 @@ target_table[[0, 1]]
 from hdmf.common.hierarchicaltable import to_hierarchical_dataframe
 icephys_meta_df = to_hierarchical_dataframe(root_table)
 
-#####################################################################
-#
+# save table as image to display in the docs
+dataframe_image.export(icephys_meta_df, df_basedir + 'icephys_meta_dataframe.png')
 
-# To avoid a too wide display in the online docs we here only show 4 select rows of the
-# table and transpose the table to show the large MultiIndex as columns instead of rows
-icephys_meta_df.iloc[[0, 1, 18, 19]].transpose()
+#####################################################################
+# .. image:: images/icephys_meta_dataframe.png
+#     :width: 100%
+#     :alt: icephys_meta_dataframe.png
+#     :align: center
 
 #####################################################################
 # Depending on the analysis, it can be useful to further process our `DataFrame`_. Using the standard
@@ -252,7 +272,18 @@ icephys_meta_df.reset_index(inplace=True)
 flatten_column_index(dataframe=icephys_meta_df, max_levels=2, inplace=True)
 # Remove the id columns. By setting inplace=False allows us to visualize the result of this
 # action while keeping the id columns in our main icephys_meta_df table
-drop_id_columns(dataframe=icephys_meta_df, inplace=False)
+drid_icephys_meta_df = drop_id_columns(dataframe=icephys_meta_df, inplace=False)
+
+# save the table as image to display in the docs
+dataframe_image.export(
+    obj=drid_icephys_meta_df,
+    filename=df_basedir +'icephys_meta_dataframe_drop_id.png')
+
+#####################################################################
+# .. image:: images/icephys_meta_dataframe_drop_id.png
+#     :width: 100%
+#     :alt: icephys_meta_dataframe_drop_id.png
+#     :align: center
 
 #####################################################################
 # Useful additional data preparations
@@ -278,8 +309,17 @@ stimulus_df = pandas.DataFrame(
 # icephys_meta_df.drop(labels=[('stimuli', 'stimulus'), ], axis=1, inplace=True)
 # Add our expanded columns to the icephys_meta_df dataframe
 icephys_meta_df = pandas.concat([icephys_meta_df, stimulus_df], axis=1)
-# display the table for the HTML docs
-icephys_meta_df
+
+# save the table as image to display in the docs
+dataframe_image.export(
+    obj=icephys_meta_df,
+    filename=df_basedir +'icephys_meta_dataframe_expand_tsr.png')
+
+#####################################################################
+# .. image:: images/icephys_meta_dataframe_expand_tsr.png
+#     :width: 100%
+#     :alt: icephys_meta_dataframe_expand_tsr.png
+#     :align: center
 
 #####################################################################
 # We can then easily expand also the ``(responses, response)`` column in the same way
@@ -303,17 +343,29 @@ icephys_meta_df = pandas.concat([icephys_meta_df, response_df], axis=1)
 # Here we show a few examples.
 
 # Add a column with the name of the stimulus TimeSeries object.
-# Note: We use getattr here to easily deal with missing values, i.e., cases where no stimulus is present
+# Note: We use getattr here to easily deal with missing values,
+#       i.e., here the cases where no stimulus is present
 col = ('stimuli', 'name')
 icephys_meta_df[col] = [getattr(s, 'name', None)
                         for s in icephys_meta_df[('stimuli', 'timeseries')]]
 
-# Often we can easily do this in bulk-fashion by specifing the collection of fields of interest
+# Often we can easily do this in a bulk-fashion by specifying
+# the collection of fields of interest
 for field in ['neurodata_type', 'gain', 'rate', 'starting_time', 'object_id']:
     col = ('stimuli', field)
     icephys_meta_df[col] = [getattr(s, field, None)
                             for s in icephys_meta_df[('stimuli', 'timeseries')]]
-icephys_meta_df
+# save the table as image to display in the docs
+dataframe_image.export(
+    obj=icephys_meta_df,
+    filename=df_basedir +'icephys_meta_dataframe_add_stimres.png',
+    max_cols=10)
+
+#####################################################################
+# .. image:: images/icephys_meta_dataframe_add_stimres.png
+#     :width: 100%
+#     :alt: icephys_meta_dataframe_add_stimres.png
+#     :align: center
 
 #####################################################################
 # Naturally we can again do the same also for our response columns
@@ -404,7 +456,8 @@ for field in ['name', 'device', 'object_id']:
 
 # Get a response 'vcs_9' from the file
 response = nwbfile.get_acquisition('vcs_9')
-# Return all data related to that response, including the stimulus as part of ('stimuli', 'stimulus') column
+# Return all data related to that response, including the stimulus
+# as part of ('stimuli', 'stimulus') column
 icephys_meta_df[icephys_meta_df[('responses', 'object_id')] == response.object_id]
 
 
@@ -438,4 +491,20 @@ print(unique_stimulus_types)
 # Given a stimulus type, get all corresponding intracellular recordings
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-icephys_meta_df[icephys_meta_df[('sequential_recordings', 'stimulus_type')] == 'StimType_1']
+query_res_df = icephys_meta_df[
+    icephys_meta_df[('sequential_recordings', 'stimulus_type')] == 'StimType_1'
+]
+
+# save the table as image to display in the docs
+dataframe_image.export(
+    obj=query_res_df,
+    filename=df_basedir +'icephys_meta_query_result_dataframe.png',
+    max_cols=10)
+
+#####################################################################
+# .. image:: images/icephys_meta_query_result_dataframe.png
+#     :width: 100%
+#     :alt: icephys_meta_query_result_dataframe.png
+#     :align: center
+
+

--- a/docs/gallery/domain/plot_icephys_pandas.py
+++ b/docs/gallery/domain/plot_icephys_pandas.py
@@ -38,6 +38,9 @@ except NameError:
 df_basedir = os.path.abspath(os.path.join(
     os.path.dirname(tutorial_path),
     "../../source/tutorials/domain/images/"))
+# for gallery tests only
+if not os.path.exists(df_basedir):
+    os.makedirs(df_basedir, exist_ok=True)
 
 # Set rendering options for tables
 pandas.set_option("display.max_colwidth", 30)

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -7,3 +7,4 @@ allensdk>=2.11.0  # python 3.8 is not supported in allensdk<2.11
 MarkupSafe==2.0.1  # resolve incompatibility between jinja2 and markupsafe: https://github.com/AllenInstitute/AllenSDK/issues/2308
 Pillow
 sphinx-copybutton
+dataframe_image   # used to render large dataframe as image in the sphinx gallery to improve html display

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -8,3 +8,4 @@ MarkupSafe==2.0.1  # resolve incompatibility between jinja2 and markupsafe: http
 Pillow
 sphinx-copybutton
 dataframe_image   # used to render large dataframe as image in the sphinx gallery to improve html display
+lxml  # used by dataframe_image when using the matplotlib backend


### PR DESCRIPTION
## Motivation

Fix #1467

Rendering large dataframes in readthedocs is challenging due to the limited horizontal space and lack of horizontal scrolling. The display of some of the tables in the icephys tutorials was sub-optimal because of this, in particular when tables were transposed for display.

This PR uses the ``dataframe_image`` library to save large tables in the icephys tutorial as PNG images which are then displayed in the docs as regular images. 

**Advantages**
* Tables are resized to fit the page, rather than spill over horizontally over the page boundary
* Tables rendered this way also appear in the LaTeX/PDF version of the docs
* Users can click on the tables to view the full version
* Table rendered this way are still automatically updated with tutorials changes as they are generated dynamically as part of the docs

**Disadvantages**
* This adds ``dataframe_image`` as a dependency in ``requirements-doc.txt``
* ``dataframe_image`` relies on ``chrome`` so it needs to be installed as well for this to work
* Need to be careful for very large dataframes to avoid creating very large images, which can slow down generation and display of the docs
* Tables are rendered as PNG rather than as text in HTML so searching or selecting text from tables displayed this way is not possible

**Conclusion** Using ``dataframe_image`` for the purpose of the docs is useful when displaying a very large dataframe in HTML is a challenge. For dataframes that fit the ReadTheDocs layout, rendering the tables directly in HTML with pandas as usual is fine.

## How to test the behavior?

View the tutorial on readthedocs


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
