### PR TITLE
Support updated Images, ImageReferences, IndexSeries types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
   change, the impact user codes should be minimal as this change primarily adds functionality while the overall
   behavior of the API is largely consistent with existing behavior. @oruebel, @rly (#1390)
 
+# Enhancements
+- Added support for NWB 2.5.0.
+  - Added support for updated ``IndexSeries`` type, new ``order_of_images`` field in ``Images``, and new neurodata_type
+    ``ImageReferences``. @rly (#1483)
+
 ### Documentation and tutorial enhancements:
 - Added tutorial on annotating data via ``TimeIntervals``. @oruebel (#1390)
 - Add copy button to code blocks @weiglszonja (#1460)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## PyNWB 2.1.0 (Upcoming)
 
 ### Breaking changes:
-- Restrict `SpatialSeries.data` to have no more than 3 columns (#1455)
+- Raise a warning if `SpatialSeries.data` has more than 3 columns (#1455, #1480)
 - Updated ``TimeIntervals`` to use the new  ``TimeSeriesReferenceVectorData`` type. This does not alter the overall
   structure of ``TimeIntervals`` in a major way aside from changing the value of the ``neurodata_type`` attribute of the
   ``TimeIntervals.timeseries`` column from ``VectorData`` to ``TimeSeriesReferenceVectorData``. This change facilitates

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -301,6 +301,24 @@ class Image(NWBData):
         self.description = kwargs['description']
 
 
+@register_class('ImageReferences', CORE_NAMESPACE)
+class ImageReferences(NWBData):
+    """
+    Ordered dataset of references to Image objects.
+    """
+    __nwbfields__ = ('data', )
+
+    @docval({'name': 'name', 'type': str, 'doc': 'The name of this ImageReferences object.'},
+            {'name': 'data', 'type': 'array_data', 'doc': 'The images in order.'},)
+    def __init__(self, **kwargs):
+        # NOTE we do not use the docval shape validator here because it will recognize a list of P MxN images as
+        # having shape (P, M, N)
+        # check type and dimensionality
+        for image in kwargs['data']:
+            assert isinstance(image, Image), "Images used in ImageReferences must have type Image, not %s" % type(image)
+        super().__init__(**kwargs)
+
+
 @register_class('Images', CORE_NAMESPACE)
 class Images(MultiContainerInterface):
     """An collection of images with an optional way to specify the order of the images
@@ -309,7 +327,7 @@ class Images(MultiContainerInterface):
     """
 
     __nwbfields__ = ('description',
-                     {'name': 'order_of_images', 'child': True})
+                     {'name': 'order_of_images', 'child': True, 'required_name': 'order_of_images'})
 
     __clsconf__ = {
         'attr': 'images',
@@ -322,7 +340,7 @@ class Images(MultiContainerInterface):
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this set of images'},
             {'name': 'images', 'type': 'array_data', 'doc': 'image objects', 'default': None},
             {'name': 'description', 'type': str, 'doc': 'description of images', 'default': 'no description'},
-            {'name': 'order_of_images', 'type': VectorData,
+            {'name': 'order_of_images', 'type': 'ImageReferences',
              'doc': 'Ordered dataset of references to Image objects stored in the parent group.', 'default': None},)
     def __init__(self, **kwargs):
         name, description, images, order_of_images = popargs('name', 'description', 'images', 'order_of_images', kwargs)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -105,15 +105,21 @@ class TimeSeries(NWBDataInterface):
     DEFAULT_DATA = np.ndarray(shape=(0, ), dtype=np.uint8)
     DEFAULT_UNIT = 'unknown'
 
+    DEFAULT_RESOLUTION = -1.0
+    DEFAULT_CONVERSION = 1.0
+    DEFAULT_OFFSET = 0.0
+
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this TimeSeries dataset'},  # required
             {'name': 'data', 'type': ('array_data', 'data', 'TimeSeries'),
              'doc': ('The data values. The first dimension must be time. '
                      'Can also store binary data, e.g., image frames')},
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)'},
             {'name': 'resolution', 'type': 'float',
-             'doc': 'The smallest meaningful difference (in specified unit) between values in data', 'default': -1.0},
+             'doc': 'The smallest meaningful difference (in specified unit) between values in data',
+             'default': DEFAULT_RESOLUTION},
             {'name': 'conversion', 'type': 'float',
-             'doc': 'Scalar to multiply each element in data to convert it to the specified unit', 'default': 1.0},
+             'doc': 'Scalar to multiply each element in data to convert it to the specified unit',
+             'default': DEFAULT_CONVERSION},
             {
                 'name': 'offset',
                 'type': 'float',
@@ -121,7 +127,7 @@ class TimeSeries(NWBDataInterface):
                     "Scalar to add to each element in the data scaled by 'conversion' to finish converting it to the "
                     "specified unit."
                     ),
-                'default': 0.0
+                'default': DEFAULT_OFFSET
             },
             {'name': 'timestamps', 'type': ('array_data', 'data', 'TimeSeries'), 'shape': (None,),
              'doc': 'Timestamps for samples stored in data', 'default': None},
@@ -297,8 +303,13 @@ class Image(NWBData):
 
 @register_class('Images', CORE_NAMESPACE)
 class Images(MultiContainerInterface):
+    """An collection of images with an optional way to specify the order of the images
+    using the "order_of_images" dataset. An order must be specified if the images are
+    referenced by index, e.g., from an IndexSeries.
+    """
 
-    __nwbfields__ = ('description',)
+    __nwbfields__ = ('description',
+                     {'name': 'order_of_images', 'child': True})
 
     __clsconf__ = {
         'attr': 'images',
@@ -310,12 +321,15 @@ class Images(MultiContainerInterface):
 
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this set of images'},
             {'name': 'images', 'type': 'array_data', 'doc': 'image objects', 'default': None},
-            {'name': 'description', 'type': str, 'doc': 'description of images', 'default': 'no description'})
+            {'name': 'description', 'type': str, 'doc': 'description of images', 'default': 'no description'},
+            {'name': 'order_of_images', 'type': VectorData,
+             'doc': 'Ordered dataset of references to Image objects stored in the parent group.', 'default': None},)
     def __init__(self, **kwargs):
-        name, description, images = popargs('name', 'description', 'images', kwargs)
+        name, description, images, order_of_images = popargs('name', 'description', 'images', 'order_of_images', kwargs)
         super(Images, self).__init__(name, **kwargs)
         self.description = description
         self.images = images
+        self.order_of_images = order_of_images
 
 
 class TimeSeriesReference(NamedTuple):

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -43,7 +43,8 @@ class SpatialSeries(TimeSeries):
         allowed_data_shapes = ((None, ), (None, 1), (None, 2), (None, 3))
         data_shape = get_data_shape(data)
         if not any(self._validate_data_shape(data_shape, a) for a in allowed_data_shapes):
-            warnings.warn("SpatialSeries '%s' has data shape %s which is not compliant with NWB 2.5 and greater." %
+            warnings.warn("SpatialSeries '%s' has data shape %s which is not compliant with NWB 2.5 and greater. "
+                          "The second dimension should have length <= 3 to represent at most x, y, z." %
                           (name, str(data_shape)))
 
         self.reference_frame = reference_frame

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -1,4 +1,6 @@
-from hdmf.utils import docval, popargs, get_docval
+import warnings
+
+from hdmf.utils import docval, popargs, get_docval, get_data_shape
 
 from . import register_class, CORE_NAMESPACE
 from .core import MultiContainerInterface
@@ -21,9 +23,7 @@ class SpatialSeries(TimeSeries):
     __nwbfields__ = ('reference_frame',)
 
     @docval(*get_docval(TimeSeries.__init__, 'name'),  # required
-            {'name': 'data', 'type': ('array_data', 'data', TimeSeries), 'shape': (
-                    (None, ), (None, 1), (None, 2), (None, 3)
-            ),  # required
+            {'name': 'data', 'type': ('array_data', 'data', TimeSeries), 'shape': ((None, ), (None, None)),  # required
              'doc': ('The data values. Can be 1D or 2D. The first dimension must be time. If 2D, there can be 1, 2, '
                      'or 3 columns, which represent x, y, and z.')},
             {'name': 'reference_frame', 'type': str,   # required
@@ -38,7 +38,24 @@ class SpatialSeries(TimeSeries):
         """
         name, data, reference_frame, unit = popargs('name', 'data', 'reference_frame', 'unit', kwargs)
         super(SpatialSeries, self).__init__(name, data, unit, **kwargs)
+
+        # NWB 2.5 restricts length of second dimension to be <= 3
+        allowed_data_shapes = ((None, ), (None, 1), (None, 2), (None, 3))
+        data_shape = get_data_shape(data)
+        if not any(self._validate_data_shape(data_shape, a) for a in allowed_data_shapes):
+            warnings.warn("SpatialSeries '%s' has data shape %s which is not compliant with NWB 2.5 and greater." %
+                          (name, str(data_shape)))
+
         self.reference_frame = reference_frame
+
+    @staticmethod
+    def _validate_data_shape(valshape, argshape):
+        if not len(valshape) == len(argshape):
+            return False
+        for a, b in zip(valshape, argshape):
+            if b not in (a, None):
+                return False
+        return True
 
 
 @register_class('BehavioralEpochs', CORE_NAMESPACE)

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -123,21 +123,22 @@ class IndexSeries(TimeSeries):
             *get_docval(TimeSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
                         'comments', 'description', 'control', 'control_description', 'offset'))
     def __init__(self, **kwargs):
-        indexed_timeseries = popargs('indexed_timeseries', kwargs)
+        indexed_timeseries, indexed_images = popargs('indexed_timeseries', 'indexed_images', kwargs)
         if kwargs['unit'] and kwargs['unit'] != 'N/A':
             msg = ("The 'unit' field of IndexSeries is fixed to the value 'N/A' starting in NWB 2.5. Passing "
                    "a different value for 'unit' will raise an error in PyNWB 3.0.")
             warnings.warn(msg, PendingDeprecationWarning)
-        if not kwargs['indexed_timeseries'] and not kwargs['indexed_images']:
+        if not indexed_timeseries and not indexed_images:
             msg = "Either indexed_timeseries or indexed_images must be provided when creating an IndexSeries."
             raise ValueError(msg)
-        if kwargs['indexed_timeseries']:
+        if indexed_timeseries:
             msg = ("The indexed_timeseries field of IndexSeries is discouraged and will be deprecated in "
                    "a future version of NWB. Use the indexed_images field instead.")
             warnings.warn(msg, PendingDeprecationWarning)
         kwargs['unit'] = 'N/A'  # fixed value starting in NWB 2.5
         super(IndexSeries, self).__init__(**kwargs)
         self.indexed_timeseries = indexed_timeseries
+        self.indexed_images = indexed_images
         if kwargs['conversion'] and kwargs['conversion'] != self.DEFAULT_CONVERSION:
             warnings.warn("The conversion attribute is not used by IndexSeries.")
         if kwargs['resolution'] and kwargs['resolution'] != self.DEFAULT_RESOLUTION:

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -5,7 +5,7 @@ from collections.abc import Iterable
 from hdmf.utils import docval, getargs, popargs, call_docval_func, get_docval
 
 from . import register_class, CORE_NAMESPACE
-from .base import TimeSeries, Image
+from .base import TimeSeries, Image, Images
 from .device import Device
 
 
@@ -115,13 +115,35 @@ class IndexSeries(TimeSeries):
             'doc': ('The data values. Must be 1D, where the first dimension must be time (frame)')},
             *get_docval(TimeSeries.__init__, 'unit'),  # required
             {'name': 'indexed_timeseries', 'type': TimeSeries,  # required
-             'doc': 'HDF5 link to TimeSeries containing images that are indexed.'},
+             'doc': 'Link to TimeSeries containing images that are indexed.', 'default': None},
+            {'name': 'indexed_images', 'type': Images,  # required
+             'doc': ("Link to Images object containing an ordered set of images that are indexed. The Images object "
+                     "must contain a 'ordered_images' dataset specifying the order of the images in the Images type."),
+             'default': None},
             *get_docval(TimeSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
                         'comments', 'description', 'control', 'control_description', 'offset'))
     def __init__(self, **kwargs):
         indexed_timeseries = popargs('indexed_timeseries', kwargs)
+        if kwargs['unit'] and kwargs['unit'] != 'N/A':
+            msg = ("The 'unit' field of IndexSeries is fixed to the value 'N/A' starting in NWB 2.5. Passing "
+                   "a different value for 'unit' will raise an error in PyNWB 3.0.")
+            warnings.warn(msg, PendingDeprecationWarning)
+        if not kwargs['indexed_timeseries'] and not kwargs['indexed_images']:
+            msg = "Either indexed_timeseries or indexed_images must be provided when creating an IndexSeries."
+            raise ValueError(msg)
+        if kwargs['indexed_timeseries']:
+            msg = ("The indexed_timeseries field of IndexSeries is discouraged and will be deprecated in "
+                   "a future version of NWB. Use the indexed_images field instead.")
+            warnings.warn(msg, PendingDeprecationWarning)
+        kwargs['unit'] = 'N/A'  # fixed value starting in NWB 2.5
         super(IndexSeries, self).__init__(**kwargs)
         self.indexed_timeseries = indexed_timeseries
+        if kwargs['conversion'] and kwargs['conversion'] != self.DEFAULT_CONVERSION:
+            warnings.warn("The conversion attribute is not used by IndexSeries.")
+        if kwargs['resolution'] and kwargs['resolution'] != self.DEFAULT_RESOLUTION:
+            warnings.warn("The resolution attribute is not used by IndexSeries.")
+        if kwargs['offset'] and kwargs['offset'] != self.DEFAULT_OFFSET:
+            warnings.warn("The offset attribute is not used by IndexSeries.")
 
 
 @register_class('ImageMaskSeries', CORE_NAMESPACE)

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -34,9 +34,9 @@ class NWBDataMap(NWBBaseTypeMapper):
     def carg_name(self, builder, manager):
         return builder.name
 
-    @ObjectMapper.constructor_arg('data')
-    def carg_data(self, builder, manager):
-        return builder.data
+    # @ObjectMapper.constructor_arg('data')
+    # def carg_data(self, builder, manager):
+    #     return builder.data
 
 
 @register_map(ScratchData)

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -30,6 +30,7 @@ class NWBFileMap(ObjectMapper):
         self.unmap(stimulus_spec.get_group('templates'))
         self.map_spec('stimulus', stimulus_spec.get_group('presentation').get_neurodata_type('TimeSeries'))
         self.map_spec('stimulus_template', stimulus_spec.get_group('templates').get_neurodata_type('TimeSeries'))
+        self.map_spec('stimulus_template', stimulus_spec.get_group('templates').get_neurodata_type('Images'))
 
         intervals_spec = self.spec.get_group('intervals')
         self.unmap(intervals_spec)

--- a/tests/integration/hdf5/test_base.py
+++ b/tests/integration/hdf5/test_base.py
@@ -2,10 +2,8 @@ import numpy as np
 from datetime import datetime
 from dateutil.tz import tzlocal
 
-from hdmf.common import VectorData
-
 from pynwb import TimeSeries, NWBFile, NWBHDF5IO
-from pynwb.base import Images, Image
+from pynwb.base import Images, Image, ImageReferences
 from pynwb.testing import AcquisitionH5IOMixin, TestCase, remove_test_file
 
 
@@ -55,7 +53,7 @@ class TestImagesIO(AcquisitionH5IOMixin, TestCase):
         """ Return the test Images to read/write """
         image1 = Image(name='test_image', data=np.ones((10, 10)))
         image2 = Image(name='test_image2', data=np.ones((10, 10)))
-        order_of_images = VectorData(name='order_of_images', description='test', data=[image2, image1])
-        images = Images(name='images_name', images=[image1, image2], order_of_images=order_of_images)
+        image_references = ImageReferences(name='order_of_images', data=[image2, image1])
+        images = Images(name='images_name', images=[image1, image2], order_of_images=image_references)
 
         return images

--- a/tests/integration/hdf5/test_base.py
+++ b/tests/integration/hdf5/test_base.py
@@ -2,7 +2,10 @@ import numpy as np
 from datetime import datetime
 from dateutil.tz import tzlocal
 
+from hdmf.common import VectorData
+
 from pynwb import TimeSeries, NWBFile, NWBHDF5IO
+from pynwb.base import Images, Image
 from pynwb.testing import AcquisitionH5IOMixin, TestCase, remove_test_file
 
 
@@ -44,3 +47,15 @@ class TestTimeSeriesLinking(TestCase):
         tsa = nwbfile.acquisition['a']
         tsb = nwbfile.acquisition['b']
         self.assertIs(tsa.timestamps, tsb.timestamps)
+
+
+class TestImagesIO(AcquisitionH5IOMixin, TestCase):
+
+    def setUpContainer(self):
+        """ Return the test Images to read/write """
+        image1 = Image(name='test_image', data=np.ones((10, 10)))
+        image2 = Image(name='test_image2', data=np.ones((10, 10)))
+        order_of_images = VectorData(name='order_of_images', description='test', data=[image2, image1])
+        images = Images(name='images_name', images=[image1, image2], order_of_images=order_of_images)
+
+        return images

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -2,6 +2,8 @@ import warnings
 
 import numpy as np
 
+from hdmf.common import VectorData
+
 from pynwb.base import ProcessingModule, TimeSeries, Images, Image, TimeSeriesReferenceVectorData, TimeSeriesReference
 from pynwb.testing import TestCase
 from hdmf.data_utils import DataChunkIterator
@@ -246,9 +248,13 @@ class TestImage(TestCase):
 class TestImages(TestCase):
 
     def test_images(self):
-        image = Image(name='test_image', data=np.ones((10, 10)))
+        image1 = Image(name='test_image', data=np.ones((10, 10)))
         image2 = Image(name='test_image2', data=np.ones((10, 10)))
-        Images(name='images_name', images=[image, image2])
+        order_of_images = VectorData(name='order_of_images', description='test', data=[image2, image1])
+        images = Images(name='images_name', images=[image1, image2], order_of_images=order_of_images)
+
+        self.assertIs(images.order_of_images[0], image2)
+        self.assertIs(images.order_of_images[1], image1)
 
 
 class TestTimeSeriesReferenceVectorData(TestCase):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -2,9 +2,8 @@ import warnings
 
 import numpy as np
 
-from hdmf.common import VectorData
-
-from pynwb.base import ProcessingModule, TimeSeries, Images, Image, TimeSeriesReferenceVectorData, TimeSeriesReference
+from pynwb.base import (ProcessingModule, TimeSeries, Images, Image, TimeSeriesReferenceVectorData,
+                        TimeSeriesReference, ImageReferences)
 from pynwb.testing import TestCase
 from hdmf.data_utils import DataChunkIterator
 from hdmf.backends.hdf5 import H5DataIO
@@ -250,8 +249,8 @@ class TestImages(TestCase):
     def test_images(self):
         image1 = Image(name='test_image', data=np.ones((10, 10)))
         image2 = Image(name='test_image2', data=np.ones((10, 10)))
-        order_of_images = VectorData(name='order_of_images', description='test', data=[image2, image1])
-        images = Images(name='images_name', images=[image1, image2], order_of_images=order_of_images)
+        image_references = ImageReferences(name='order_of_images', data=[image2, image1])
+        images = Images(name='images_name', images=[image1, image2], order_of_images=image_references)
 
         self.assertIs(images.order_of_images[0], image2)
         self.assertIs(images.order_of_images[1], image1)

--- a/tests/unit/test_behavior.py
+++ b/tests/unit/test_behavior.py
@@ -20,7 +20,8 @@ class SpatialSeriesConstructor(TestCase):
         self.assertEqual(sS.unit, 'degrees')
 
     def test_gt_3_cols(self):
-        msg = "SpatialSeries 'test_sS' has data shape (5, 4) which is not compliant with NWB 2.5 and greater."
+        msg = ("SpatialSeries 'test_sS' has data shape (5, 4) which is not compliant with NWB 2.5 and greater."
+               "The second dimension should have length <= 3 to represent at most x, y, z.")
         with self.assertWarnsWith(UserWarning, msg):
             SpatialSeries("test_sS", np.ones((5, 4)), "reference_frame", "meters", rate=30.)
 

--- a/tests/unit/test_behavior.py
+++ b/tests/unit/test_behavior.py
@@ -20,7 +20,7 @@ class SpatialSeriesConstructor(TestCase):
         self.assertEqual(sS.unit, 'degrees')
 
     def test_gt_3_cols(self):
-        msg = ("SpatialSeries 'test_sS' has data shape (5, 4) which is not compliant with NWB 2.5 and greater."
+        msg = ("SpatialSeries 'test_sS' has data shape (5, 4) which is not compliant with NWB 2.5 and greater. "
                "The second dimension should have length <= 3 to represent at most x, y, z.")
         with self.assertWarnsWith(UserWarning, msg):
             SpatialSeries("test_sS", np.ones((5, 4)), "reference_frame", "meters", rate=30.)

--- a/tests/unit/test_behavior.py
+++ b/tests/unit/test_behavior.py
@@ -20,14 +20,9 @@ class SpatialSeriesConstructor(TestCase):
         self.assertEqual(sS.unit, 'degrees')
 
     def test_gt_3_cols(self):
-        with self.assertRaises(ValueError) as error:
+        msg = "SpatialSeries 'test_sS' has data shape (5, 4) which is not compliant with NWB 2.5 and greater."
+        with self.assertWarnsWith(UserWarning, msg):
             SpatialSeries("test_sS", np.ones((5, 4)), "reference_frame", "meters", rate=30.)
-
-        self.assertEqual(
-            "SpatialSeries.__init__: incorrect shape for 'data' (got '(5, 4)', expected "
-            "'((None,), (None, 1), (None, 2), (None, 3))')",
-            str(error.exception)
-        )
 
 
 class BehavioralEpochsConstructor(TestCase):

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -132,8 +132,6 @@ class IndexSeriesConstructor(TestCase):
         self.assertIs(iS.indexed_timeseries, ts)
 
 
-
-
 class ImageMaskSeriesConstructor(TestCase):
 
     def test_init(self):

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pynwb import TimeSeries
+from pynwb.base import Image, Images, ImageReferences
 from pynwb.device import Device
 from pynwb.image import ImageSeries, IndexSeries, ImageMaskSeries, OpticalSeries, GrayscaleImage, RGBImage, RGBAImage
 from pynwb.testing import TestCase
@@ -76,22 +77,61 @@ class ImageSeriesConstructor(TestCase):
 class IndexSeriesConstructor(TestCase):
 
     def test_init(self):
+        image1 = Image(name='test_image', data=np.ones((10, 10)))
+        image2 = Image(name='test_image2', data=np.ones((10, 10)))
+        image_references = ImageReferences(name='order_of_images', data=[image2, image1])
+        images = Images(name='images_name', images=[image1, image2], order_of_images=image_references)
+
+        iS = IndexSeries(
+            name='test_iS',
+            data=[1, 2, 3],
+            unit='N/A',
+            indexed_images=images,
+            timestamps=[0.1, 0.2, 0.3]
+        )
+        self.assertEqual(iS.name, 'test_iS')
+        self.assertEqual(iS.unit, 'N/A')
+        self.assertIs(iS.indexed_images, images)
+
+    def test_init_bad_unit(self):
         ts = TimeSeries(
             name='test_ts',
             data=[1, 2, 3],
             unit='unit',
             timestamps=[0.1, 0.2, 0.3]
         )
-        iS = IndexSeries(
-            name='test_iS',
+        msg = ("The 'unit' field of IndexSeries is fixed to the value 'N/A' starting in NWB 2.5. Passing "
+               "a different value for 'unit' will raise an error in PyNWB 3.0.")
+        with self.assertWarnsWith(PendingDeprecationWarning, msg):
+            iS = IndexSeries(
+                name='test_iS',
+                data=[1, 2, 3],
+                unit='na',
+                indexed_timeseries=ts,
+                timestamps=[0.1, 0.2, 0.3]
+            )
+        self.assertEqual(iS.unit, 'N/A')
+
+    def test_init_indexed_ts(self):
+        ts = TimeSeries(
+            name='test_ts',
             data=[1, 2, 3],
-            unit='N/A',
-            indexed_timeseries=ts,
+            unit='unit',
             timestamps=[0.1, 0.2, 0.3]
         )
-        self.assertEqual(iS.name, 'test_iS')
-        self.assertEqual(iS.unit, 'N/A')
+        msg = ("The indexed_timeseries field of IndexSeries is discouraged and will be deprecated in "
+               "a future version of NWB. Use the indexed_images field instead.")
+        with self.assertWarnsWith(PendingDeprecationWarning, msg):
+            iS = IndexSeries(
+                name='test_iS',
+                data=[1, 2, 3],
+                unit='N/A',
+                indexed_timeseries=ts,
+                timestamps=[0.1, 0.2, 0.3]
+            )
         self.assertIs(iS.indexed_timeseries, ts)
+
+
 
 
 class ImageMaskSeriesConstructor(TestCase):


### PR DESCRIPTION
## Motivation

NWB 2.5 will introduce changes to Images and IndexSeries and it introduces a new neurodata type ImageReferences.
See https://github.com/NeurodataWithoutBorders/nwb-schema/blob/dev/docs/format/source/format_release_notes.rst

This PR adds support for these schema changes.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
