### PR TITLE
Add Python v3.10 to Bug Report Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,6 +63,7 @@ body:
         - 3.7
         - 3.8
         - 3.9
+        - 3.10
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Adds Python v3.10 to the selection box of the bug report form.