### PR TITLE
Support explicit ordering of sphinx galleries 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## PyNWB 2.1.1 (Upcoming)
 
 ## Documentation and tutorial enhancements:
-- Support explicit ordering of sphinx gallery tutorials in the docs. @oruebel (#1504), @bdichter (#1495),
+- Support explicit ordering of sphinx gallery tutorials in the docs. @oruebel (#1504), @bdichter (#1495)
+- Add developer guide on how to create a new tutorial. @oruebel (#1504) 
 
 ## PyNWB 2.1.0 (July 6, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## PyNWB 2.1.1 (Upcoming)
+
+## Documentation and tutorial enhancements:
+- Support explicit ordering of sphinx gallery tutorials in the docs. @oruebel (#1504), @bdichter (#1495),
+
 ## PyNWB 2.1.0 (July 6, 2022)
 
 ### Breaking changes:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,17 +66,56 @@ from sphinx_gallery.sorting import ExampleTitleSortKey
 class CustomSphinxGallerySectionSortKey(ExampleTitleSortKey):
     """
     Define the key to be used to sort sphinx galleries sections
+
+    :param src_dir : The source directory.
+    :type srd_dir: str
     """
+    # Define a partial ordered list of galleries for all subsections. Galleries not
+    # listed here will be added in alphabetical order based on title after the
+    # explicitly listed galleries
+    GALLERY_ORDER = {
+        'general': ['file.py'],
+        # Sort domain-specific tutorials based on domain to group tutorials belonging to the same domain
+        'domain': ['ecephys.py',
+                   'ophys.py',
+                   'plot_icephys.py', 'plot_icephys_pandas.py', 'icephys.py',
+                   'plot_behavior.py',
+                   'brain_observatory.py'],
+        'advanced_io': []
+    }
+
     def __call__(self, filename):
         """
-        Return the key to be used for sorting the given sphinx gallery file.
+        Compute index to use for sorting galleries.
 
-        :param filename: Name of the sphinx gallery file
+        Return the explicit index of the gallery if defined as part of self.GALLERY_ORDER
+        and otherwise compute a score based on the title of the gallery to ensure galleries
+        are sorted alphabetically by default
         """
-        title = super().__call__(filename)
-        if title == "NWB File Basics":
-            return ''  # make this first
-        return title
+        import string
+        import math
+
+        # Get the ordered list of gallery files for the current source dir
+        explicit_order = self.GALLERY_ORDER.get(os.path.basename(self.src_dir), [])
+        # If the file is in the explicit order then return its index
+        if filename in explicit_order:
+            sort_index = explicit_order.index(filename)
+        # Else sort alphabetically based on the title by computing a corresponding
+        # floating point index based on the characters of the titles
+        else:
+            title = super().__call__(filename)
+            # map the characters of the title to a floating point number
+            # based on the numerical index of the individual lowercase characters
+            sort_index = len(explicit_order)  # all explicitly ordered galleries come first
+            for i, v in enumerate(title.lower()):
+                # get the index of the current character
+                curr_index = (string.ascii_lowercase.index(v)
+                              if v in string.ascii_lowercase
+                              else len(string.ascii_lowercase))
+                # shift the value based on its position in the title string and
+                # add it to the sort_index value
+                sort_index += curr_index / math.pow(10, ((i+1) * 2))
+        return sort_index
 
 
 sphinx_gallery_conf = {

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -45,6 +45,7 @@ breaking down the barriers to data sharing in neuroscience.
    software_process
    make_a_release
    make_roundtrip_test
+   make_a_tutorial
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/make_a_tutorial.rst
+++ b/docs/source/make_a_tutorial.rst
@@ -1,0 +1,58 @@
+======================
+How to Make a Tutorial
+======================
+
+Tutorials are define using `sphinx-gallery <https://sphinx-gallery.github.io/>`_.
+The sources of tutorials are stored in ``docs/gallery`` with each subfolder corresponding
+to a subsection in the tutorial gallery.
+
+
+Create a new tutorial
+---------------------
+
+1. Add a new python file to the appropriate subfolder of ``docs/gallery``.
+
+.. hint::
+
+   If you want the output of code cells to be rendered in the docs, then simply
+   include the prefix ``plot_`` as part of the name of tutorial file. Tutorials
+   without the prefix will render just the code cells and text.
+
+2. **Optional:** To specify an explicit position for your tutorial in the subsection of the
+   gallery, update the ``GALLERY_ORDER`` variable of the ``CustomSphinxGallerySectionSortKey``
+   class defined in ``docs/source/conf.py``. If you skip this step, the tutorial will
+   be added in alphabetical order.
+
+
+3. Check that the docs are building correctly and fix any errors
+
+.. code-block::
+
+   cd docs
+   make html
+
+4. View the docs to make sure your gallery renders correctly
+
+.. code-block::
+
+   open docs/_build/html/index.html
+
+5. Make a PR to request addition of your tutorial
+
+Create a new tutorial collection
+---------------------------------
+
+To add a section to the tutorial gallery
+
+1. Create a new folder in ``docs/gallery/<new-section>``
+
+2. Create a ``docs/gallery/<new-section>/README.txt`` file with the anchor name and title of the section, e.g.:
+
+.. code-block::
+
+    .. _my-new-tutorials:
+
+    My new tutorial section
+    -----------------------
+
+3. Add tutorials to the section by adding the tutorial files to the new folder


### PR DESCRIPTION
## Motivation

This PR was inspired by the recent PR https://github.com/NeurodataWithoutBorders/pynwb/pull/1495. This PR make the following changes:

*  Generalize the ``CustomSphinxGallerySectionSortKey`` to allow explicit ordering of galleries for any sections while still providing the default alphabetical sort for any galleries that are not explicitly listed. 
* Define explicit order for the domain-specific tutorials to group and sort tutorials based on domain, such that, e.g., all icephys tutorials appear together and tutorials appear in order of domain (ecephys, ophys, icephys).
* Add How-to guide with brief instructions on how to create a new tutorial

## How to test the behavior?

Build the docs

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
