### PR TITLE
Fix link to the extension tutorial

### DIFF
--- a/docs/gallery/general/extensions.py
+++ b/docs/gallery/general/extensions.py
@@ -10,7 +10,7 @@ in PyNWB for creating  Neurodata Extensions (NDX).
 .. seealso::
 
     For a more in-depth, step-by-step guide on how to create, document, and publish NWB extensions, we highly
-    recommend visiting the :nwb_overview:`extension tutorial <extensions_tutorial/6_documenting_extension.html>`
+    recommend visiting the :nwb_overview:`extension tutorial <extensions_tutorial/extensions_tutorial_home.html>`
     on the :nwb_overview:`nwb overview <>` website.
 
 .. seealso::


### PR DESCRIPTION
## Motivation

In the extension tutorial the link to the corresponding guide on the nwb-overview page currently points to the subsection of the guide on documentation rather than the starting page of the guide. This PR just fixes this link.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
