### PR TITLE
Enh/ `ImageSeries`: add checks when `external_file` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
   from s3 that is an alternative to ros3. This required relaxing of `NWBHDF5IO` input validation. The `path`
   arg is not needed if `file` is provided. `mode` now has a default value of "r". 
   @bendichter (#1499)
+- Added a method to `NWBMixin` that only raises an error when a check is violated on instance creation,
+  otherwise throws a warning when reading from a file. The new checks in `ImageSeries` when `external_file` 
+  is provided is used with this method to ensure that that files with invalid data can be read, but prohibits
+  the user from creating new instances when these checks are violated. @weiglszonja (#1516)
 
 ## PyNWB 2.1.0 (July 6, 2022)
 

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # minimum versions of package dependencies for installing PyNWB
 h5py==2.10  # support for selection of datasets with list of indices added in 2.10
-hdmf==3.3.2
+hdmf==3.3.4
 numpy==1.16
 pandas==1.0.5
 python-dateutil==2.7

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # minimum versions of package dependencies for installing PyNWB
 h5py==2.10  # support for selection of datasets with list of indices added in 2.10
-hdmf==3.3.4
+hdmf==3.4.0
 numpy==1.16
 pandas==1.0.5
 python-dateutil==2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
 h5py==3.6.0
-hdmf==3.3.4
+hdmf== 3.4.0
 numpy==1.21.5  # note that numpy 1.22 dropped python 3.7 support
 pandas==1.3.5  # note that pandas 1.4 dropped python 3.7 support
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
 h5py==3.6.0
-hdmf==3.3.2
+hdmf==3.3.4
 numpy==1.21.5  # note that numpy 1.22 dropped python 3.7 support
 pandas==1.3.5  # note that pandas 1.4 dropped python 3.7 support
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
 h5py==3.6.0
-hdmf== 3.4.0
+hdmf==3.4.0
 numpy==1.21.5  # note that numpy 1.22 dropped python 3.7 support
 pandas==1.3.5  # note that pandas 1.4 dropped python 3.7 support
 python-dateutil==2.8.2

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -32,6 +32,19 @@ class NWBMixin(AbstractContainer):
         neurodata_type = kwargs['neurodata_type']
         return super().get_ancestor(data_type=neurodata_type)
 
+    def _error_on_new_warn_on_construct(self, error_msg: str):
+        """
+        Raise an error when a check is violated on instance creation.
+        To ensure backwards compatibility, this method throws a warning
+        instead of raising an error when reading from a file, ensuring that
+        files with invalid data can be read.
+        """
+        if error_msg is None:
+            return
+        if not self._in_construct_mode:
+            raise ValueError(error_msg)
+        warn(error_msg)
+
 
 @register_class('NWBContainer', CORE_NAMESPACE)
 class NWBContainer(NWBMixin, Container):

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -37,7 +37,8 @@ class NWBMixin(AbstractContainer):
         Raise an error when a check is violated on instance creation.
         To ensure backwards compatibility, this method throws a warning
         instead of raising an error when reading from a file, ensuring that
-        files with invalid data can be read.
+        files with invalid data can be read. If error_msg is set to None
+        the function will simply return without further action.
         """
         if error_msg is None:
             return

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -51,8 +51,8 @@ class ImageSeries(TimeSeries):
              'doc': 'Path or URL to one or more external file(s). Field only present if format=external. '
                     'Either external_file or data must be specified (not None), but not both.', 'default': None},
             {'name': 'starting_frame', 'type': Iterable,
-             'doc': 'Each entry is a frame number that corresponds to the first frame of each file in external_file. '
-                    'This serves as an index to what frames each file contains.', 'default': None},
+             'doc': 'Each entry is a frame number that corresponds to the first frame of each file '
+                    'listed in external_file within the full ImageSeries.', 'default': None},
             {'name': 'bits_per_pixel', 'type': int, 'doc': 'DEPRECATED: Number of bits per image pixel',
              'default': None},
             {'name': 'dimension', 'type': Iterable,

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -84,8 +84,8 @@ class ImageSeries(TimeSeries):
                 args_to_set['starting_frame'] = [0]
         if external_file_shape != starting_frame_shape:
             warnings.warn(
-                "%s '%s': The number of frame indices in 'starting_frame' should have the same length as 'external_file'."
-                % (self.__class__.__name__, name)
+                "%s '%s': The number of frame indices in 'starting_frame' should have the same length "
+                "as 'external_file'." % (self.__class__.__name__, name)
             )
 
         super().__init__(**kwargs)

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -77,8 +77,13 @@ class ImageSeries(TimeSeries):
         if unit is None:
             kwargs['unit'] = ImageSeries.DEFAULT_UNIT
 
-        if args_to_set['external_file'] is not None and args_to_set['starting_frame'] is None:
-            args_to_set['starting_frame'] = [0] if len(args_to_set['external_file']) == 1 else None
+        if (
+            args_to_set["external_file"] is not None
+            and args_to_set["starting_frame"] is None
+        ):
+            args_to_set["starting_frame"] = (
+                [0] if len(args_to_set["external_file"]) == 1 else None
+            )
 
         super().__init__(**kwargs)
 
@@ -97,12 +102,13 @@ class ImageSeries(TimeSeries):
                 "Setting a default value for 'format' is deprecated and will be changed "
                 "to raising a ValueError in the next release."
                 % (self.__class__.__name__, self.name),
-                DeprecationWarning
+                DeprecationWarning,
             )
 
         if not self._check_external_file_format():
             raise ValueError(
-                "%s '%s': Format must be 'external' when external_file is specified." % (self.__class__.__name__, name)
+                "%s '%s': Format must be 'external' when external_file is specified."
+                % (self.__class__.__name__, name)
             )
 
         if not self._check_external_file_data():
@@ -114,7 +120,8 @@ class ImageSeries(TimeSeries):
         if not self._check_image_series_dimension():
             warnings.warn(
                 "%s '%s': Length of data does not match length of timestamps. Your data may be transposed. "
-                "Time should be on the 0th dimension" % (self.__class__.__name__, self.name)
+                "Time should be on the 0th dimension"
+                % (self.__class__.__name__, self.name)
             )
 
     def _check_external_file_starting_frame_length(self):
@@ -132,11 +139,11 @@ class ImageSeries(TimeSeries):
         Change the format to 'external' when external_file is specified.
         """
         if (
-                self.data.shape[0] == 0 and
-                self.external_file is not None and
-                self.format is None
+            self.data.shape[0] == 0
+            and self.external_file is not None
+            and self.format is None
         ):
-            self.format = 'external'
+            self.format = "external"
             return True
 
         return False

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -96,7 +96,7 @@ class ImageSeries(TimeSeries):
         if not self._check_external_file_starting_frame_length():
             msg = ("%s '%s': The number of frame indices in 'starting_frame' should have "
                    "the same length as 'external_file'." % (self.__class__.__name__, name))
-            self._raise_error_when_check_is_violated(error_msg=msg)
+            self._error_on_new_warn_on_construct(error_msg=msg)
 
         if self._change_external_file_format():
             warnings.warn(
@@ -112,14 +112,14 @@ class ImageSeries(TimeSeries):
                 "%s '%s': Format must be 'external' when external_file is specified."
                 % (self.__class__.__name__, name)
             )
-            self._raise_error_when_check_is_violated(error_msg=msg)
+            self._error_on_new_warn_on_construct(error_msg=msg)
 
         if not self._check_external_file_data():
             msg = (
                 "%s '%s': Either external_file or data must be specified (not None), but not both."
                 % (self.__class__.__name__, name)
             )
-            self._raise_error_when_check_is_violated(error_msg=msg)
+            self._error_on_new_warn_on_construct(error_msg=msg)
 
         if not self._check_image_series_dimension():
             warnings.warn(
@@ -127,19 +127,6 @@ class ImageSeries(TimeSeries):
                 "Time should be on the 0th dimension"
                 % (self.__class__.__name__, self.name)
             )
-
-    def _raise_error_when_check_is_violated(self, error_msg):
-        """
-        Raise an error when a check is violated on instance creation.
-        To ensure backwards compatibility, this method throws a warning
-        instead of raising an error when reading from a file, ensuring that
-        files with invalid data can be read.
-        """
-        if error_msg is None:
-            return
-        if not self._in_construct_mode:
-            raise ValueError(error_msg)
-        warnings.warn(error_msg)
 
     def _check_external_file_starting_frame_length(self):
         """

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -115,6 +115,8 @@ class ImageSeries(TimeSeries):
         """
         Check that the number of frame indices in 'starting_frame' matches the number of files in 'external_file'.
         """
+        if self.external_file is None:
+            return True
         external_file_shape = get_data_shape(self.external_file)
         starting_frame_shape = get_data_shape(self.starting_frame)
         return external_file_shape == starting_frame_shape

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -107,7 +107,8 @@ class ImageSeries(TimeSeries):
 
         if not self._check_external_file_data():
             raise ValueError(
-                "%s '%s': Either external_file or data must be specified (not None), but not both." % (self.__class__.__name__, name)
+                "%s '%s': Either external_file or data must be specified (not None), but not both."
+                % (self.__class__.__name__, name)
             )
 
         if not self._check_image_series_dimension():

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -82,7 +82,7 @@ class ImageSeries(TimeSeries):
         if external_file_shape is not None and starting_frame_shape is None:
             if len(external_file_shape) == 1:
                 args_to_set['starting_frame'] = [0]
-        if external_file_shape != starting_frame_shape:
+        if external_file_shape != get_data_shape(args_to_set['starting_frame']):
             warnings.warn(
                 "%s '%s': The number of frame indices in 'starting_frame' should have the same length "
                 "as 'external_file'." % (self.__class__.__name__, name)

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -79,8 +79,6 @@ class ImageSeries(TimeSeries):
 
         if args_to_set['external_file'] is not None and args_to_set['starting_frame'] is None:
             args_to_set['starting_frame'] = [0] if len(args_to_set['external_file']) == 1 else None
-        if args_to_set['external_file'] is not None and args_to_set['format'] is None:
-            args_to_set['format'] = 'external'
 
         super().__init__(**kwargs)
 
@@ -91,6 +89,15 @@ class ImageSeries(TimeSeries):
             raise ValueError(
                 "%s '%s': The number of frame indices in 'starting_frame' should have the same length "
                 "as 'external_file'." % (self.__class__.__name__, name)
+            )
+
+        if data is None and self._change_external_file_format():
+            warnings.warn(
+                "%s '%s': The value for 'format' has been changed to 'external'. "
+                "Setting a default value for 'format' is deprecated and will be changed "
+                "to raising a ValueError in the next release."
+                % (self.__class__.__name__, self.name),
+                DeprecationWarning
             )
 
         if not self._check_external_file_format():
@@ -111,6 +118,16 @@ class ImageSeries(TimeSeries):
         external_file_shape = get_data_shape(self.external_file)
         starting_frame_shape = get_data_shape(self.starting_frame)
         return external_file_shape == starting_frame_shape
+
+    def _change_external_file_format(self):
+        """
+        Change the format to 'external' when external_file is specified.
+        """
+        if self.external_file is not None and self.format is None:
+            self.format = 'external'
+            return True
+
+        return False
 
     def _check_external_file_format(self):
         """

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -105,6 +105,11 @@ class ImageSeries(TimeSeries):
                 "%s '%s': Format must be 'external' when external_file is specified." % (self.__class__.__name__, name)
             )
 
+        if not self._check_external_file_data():
+            raise ValueError(
+                "%s '%s': Either external_file or data must be specified (not None), but not both." % (self.__class__.__name__, name)
+            )
+
         if not self._check_image_series_dimension():
             warnings.warn(
                 "%s '%s': Length of data does not match length of timestamps. Your data may be transposed. "
@@ -139,6 +144,15 @@ class ImageSeries(TimeSeries):
             return True
 
         return self.format == "external"
+
+    def _check_external_file_data(self):
+        """
+        Check that data is an empty array when external_file is specified.
+        """
+        if self.external_file is None:
+            return True
+
+        return self.data.shape[0] == 0
 
     def _check_time_series_dimension(self):
         """Override _check_time_series_dimension to do nothing.

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -102,16 +102,16 @@ class ImageSeries(TimeSeries):
                 DeprecationWarning,
             )
 
-        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_starting_frame_length())
-        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_format())
-        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_data())
-
         if not self._check_image_series_dimension():
             warnings.warn(
                 "%s '%s': Length of data does not match length of timestamps. Your data may be transposed. "
                 "Time should be on the 0th dimension"
                 % (self.__class__.__name__, self.name)
             )
+
+        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_starting_frame_length())
+        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_format())
+        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_data())
 
     def _check_external_file_starting_frame_length(self):
         """

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -44,9 +44,8 @@ class ImageSeries(TimeSeries):
              'doc': 'Path or URL to one or more external file(s). Field only present if format=external. '
                     'Either external_file or data must be specified (not None), but not both.', 'default': None},
             {'name': 'starting_frame', 'type': Iterable,
-             'doc': 'Each entry is the frame number in the corresponding external_file variable. '
-                    'This serves as an index to what frames each file contains. If external_file is not '
-                    'provided, then this value will be None', 'default': [0]},
+             'doc': 'Each entry is a frame number that corresponds to the first frame of each file in external_file. '
+                    'This serves as an index to what frames each file contains.', 'default': None},
             {'name': 'bits_per_pixel', 'type': int, 'doc': 'DEPRECATED: Number of bits per image pixel',
              'default': None},
             {'name': 'dimension', 'type': Iterable,

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -117,20 +117,6 @@ class ImageSeries(TimeSeries):
         )
         self._error_on_new_warn_on_construct(error_msg=self._check_external_file_data())
 
-    def _check_external_file_starting_frame_length(self):
-        """
-        Check that the number of frame indices in 'starting_frame' matches the number of files in 'external_file'.
-        """
-        if self.external_file is None:
-            return
-        if get_data_shape(self.external_file) == get_data_shape(self.starting_frame):
-            return
-
-        return (
-            "%s '%s': The number of frame indices in 'starting_frame' should have "
-            "the same length as 'external_file'." % (self.__class__.__name__, self.name)
-        )
-
     def _change_external_file_format(self):
         """
         Change the format to 'external' when external_file is specified.
@@ -144,6 +130,38 @@ class ImageSeries(TimeSeries):
             return True
 
         return False
+
+    def _check_time_series_dimension(self):
+        """Override _check_time_series_dimension to do nothing.
+        The _check_image_series_dimension method will be called instead.
+        """
+        return True
+
+    def _check_image_series_dimension(self):
+        """Check that the 0th dimension of data equals the length of timestamps, when applicable.
+
+        ImageSeries objects can have an external file instead of data stored. The external file cannot be
+        queried for the number of frames it contains, so this check will return True when an external file
+        is provided. Otherwise, this function calls the parent class' _check_time_series_dimension method.
+        """
+        if self.external_file is not None:
+            return True
+        return super()._check_time_series_dimension()
+
+    def _check_external_file_starting_frame_length(self):
+        """
+        Check that the number of frame indices in 'starting_frame' matches
+        the number of files in 'external_file'.
+        """
+        if self.external_file is None:
+            return
+        if get_data_shape(self.external_file) == get_data_shape(self.starting_frame):
+            return
+
+        return (
+            "%s '%s': The number of frame indices in 'starting_frame' should have "
+            "the same length as 'external_file'." % (self.__class__.__name__, self.name)
+        )
 
     def _check_external_file_format(self):
         """
@@ -172,23 +190,6 @@ class ImageSeries(TimeSeries):
             "%s '%s': Either external_file or data must be specified (not None), but not both."
             % (self.__class__.__name__, self.name)
         )
-
-    def _check_time_series_dimension(self):
-        """Override _check_time_series_dimension to do nothing.
-        The _check_image_series_dimension method will be called instead.
-        """
-        return True
-
-    def _check_image_series_dimension(self):
-        """Check that the 0th dimension of data equals the length of timestamps, when applicable.
-
-        ImageSeries objects can have an external file instead of data stored. The external file cannot be
-        queried for the number of frames it contains, so this check will return True when an external file
-        is provided. Otherwise, this function calls the parent class' _check_time_series_dimension method.
-        """
-        if self.external_file is not None:
-            return True
-        return super()._check_time_series_dimension()
 
     @property
     def bits_per_pixel(self):

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -71,22 +71,24 @@ class ImageSeries(TimeSeries):
         if args_to_set['external_file'] is None and data is None:
             raise ValueError("Must supply either external_file or data to %s '%s'."
                              % (self.__class__.__name__, name))
-        if args_to_set['external_file'] is not None:
-            args_to_set['starting_frame'] = [0] if len(args_to_set['external_file']) == 1 else args_to_set['starting_frame']
-        if get_data_shape(args_to_set['external_file']) != get_data_shape(args_to_set['starting_frame']):
-            warnings.warn(
-                "%s '%s': The number of frame indices in 'starting_frame' should have the same length as 'external_file'."
-                             % (self.__class__.__name__, name))
         # data and unit are required in TimeSeries, but allowed to be None here, so handle this specially
         if data is None:
             kwargs['data'] = ImageSeries.DEFAULT_DATA
         if unit is None:
             kwargs['unit'] = ImageSeries.DEFAULT_UNIT
 
+        external_file_shape = get_data_shape(args_to_set['external_file'])
+        starting_frame_shape = get_data_shape(args_to_set['starting_frame'])
+        if external_file_shape is not None and starting_frame_shape is None:
+            if len(external_file_shape) == 1:
+                args_to_set['starting_frame'] = [0]
+        if external_file_shape != starting_frame_shape:
+            warnings.warn(
+                "%s '%s': The number of frame indices in 'starting_frame' should have the same length as 'external_file'."
+                             % (self.__class__.__name__, name))
+
         super().__init__(**kwargs)
 
-        if args_to_set["external_file"] is None:
-            args_to_set["starting_frame"] = None  # overwrite starting_frame
         for key, val in args_to_set.items():
             setattr(self, key, val)
 

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -2,7 +2,14 @@ import warnings
 import numpy as np
 from collections.abc import Iterable
 
-from hdmf.utils import docval, getargs, popargs, popargs_to_dict, get_docval
+from hdmf.utils import (
+    docval,
+    getargs,
+    popargs,
+    popargs_to_dict,
+    get_docval,
+    get_data_shape,
+)
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries, Image, Images
@@ -64,7 +71,11 @@ class ImageSeries(TimeSeries):
         if args_to_set['external_file'] is None and data is None:
             raise ValueError("Must supply either external_file or data to %s '%s'."
                              % (self.__class__.__name__, name))
-
+        if args_to_set['external_file'] is not None:
+            args_to_set['starting_frame'] = [0] if len(args_to_set['external_file']) == 1 else args_to_set['starting_frame']
+        if get_data_shape(args_to_set['external_file']) != get_data_shape(args_to_set['starting_frame']):
+            raise ValueError("%s '%s': The number of frame indices in 'starting_frame' must have the same length as 'external_file'."
+                             % (self.__class__.__name__, name))
         # data and unit are required in TimeSeries, but allowed to be None here, so handle this specially
         if data is None:
             kwargs['data'] = ImageSeries.DEFAULT_DATA

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -79,6 +79,8 @@ class ImageSeries(TimeSeries):
 
         if args_to_set['external_file'] is not None and args_to_set['starting_frame'] is None:
             args_to_set['starting_frame'] = [0] if len(args_to_set['external_file']) == 1 else None
+        if args_to_set['external_file'] is not None and args_to_set['format'] is None:
+            args_to_set['format'] = 'external'
 
         super().__init__(**kwargs)
 
@@ -89,6 +91,11 @@ class ImageSeries(TimeSeries):
             raise ValueError(
                 "%s '%s': The number of frame indices in 'starting_frame' should have the same length "
                 "as 'external_file'." % (self.__class__.__name__, name)
+            )
+
+        if not self._check_external_file_format():
+            raise ValueError(
+                "%s '%s': Format must be 'external' when external_file is specified." % (self.__class__.__name__, name)
             )
 
         if not self._check_image_series_dimension():
@@ -104,6 +111,15 @@ class ImageSeries(TimeSeries):
         external_file_shape = get_data_shape(self.external_file)
         starting_frame_shape = get_data_shape(self.starting_frame)
         return external_file_shape == starting_frame_shape
+
+    def _check_external_file_format(self):
+        """
+        Check that format is 'external' when external_file is specified.
+        """
+        if self.external_file is None:
+            return True
+
+        return self.format == "external"
 
     def _check_time_series_dimension(self):
         """Override _check_time_series_dimension to do nothing.

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -74,7 +74,8 @@ class ImageSeries(TimeSeries):
         if args_to_set['external_file'] is not None:
             args_to_set['starting_frame'] = [0] if len(args_to_set['external_file']) == 1 else args_to_set['starting_frame']
         if get_data_shape(args_to_set['external_file']) != get_data_shape(args_to_set['starting_frame']):
-            raise ValueError("%s '%s': The number of frame indices in 'starting_frame' must have the same length as 'external_file'."
+            warnings.warn(
+                "%s '%s': The number of frame indices in 'starting_frame' should have the same length as 'external_file'."
                              % (self.__class__.__name__, name))
         # data and unit are required in TimeSeries, but allowed to be None here, so handle this specially
         if data is None:

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -83,7 +83,7 @@ class ImageSeries(TimeSeries):
             if len(external_file_shape) == 1:
                 args_to_set['starting_frame'] = [0]
         if external_file_shape != get_data_shape(args_to_set['starting_frame']):
-            warnings.warn(
+            raise ValueError(
                 "%s '%s': The number of frame indices in 'starting_frame' should have the same length "
                 "as 'external_file'." % (self.__class__.__name__, name)
             )

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -141,7 +141,7 @@ class ImageSeries(TimeSeries):
         Change the format to 'external' when external_file is specified.
         """
         if (
-            self.data.shape[0] == 0
+            get_data_shape(self.data)[0] == 0
             and self.external_file is not None
             and self.format is None
         ):

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -79,6 +79,7 @@ class ImageSeries(TimeSeries):
         if unit is None:
             kwargs['unit'] = ImageSeries.DEFAULT_UNIT
 
+        # If a single external_file is given then set starting_frame  to [0] for backward compatibility 
         if (
             args_to_set["external_file"] is not None
             and args_to_set["starting_frame"] is None
@@ -128,9 +129,14 @@ class ImageSeries(TimeSeries):
             )
 
     def _raise_error_when_check_is_violated(self, error_msg):
-        """Raise an error when a check is violated on instance creation.
+        """
+        Raise an error when a check is violated on instance creation.
         To ensure backwards compatibility, this method throws a warning
-        instead of raising an error when reading from a file."""
+        instead of raising an error when reading from a file, ensuring that
+        files with invalid data can be read.
+        """
+        if error_msg is None:
+            return
         if not self._in_construct_mode:
             raise ValueError(error_msg)
         warnings.warn(error_msg)

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -109,8 +109,12 @@ class ImageSeries(TimeSeries):
                 % (self.__class__.__name__, self.name)
             )
 
-        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_starting_frame_length())
-        self._error_on_new_warn_on_construct(error_msg=self._check_external_file_format())
+        self._error_on_new_warn_on_construct(
+            error_msg=self._check_external_file_starting_frame_length()
+        )
+        self._error_on_new_warn_on_construct(
+            error_msg=self._check_external_file_format()
+        )
         self._error_on_new_warn_on_construct(error_msg=self._check_external_file_data())
 
     def _check_external_file_starting_frame_length(self):
@@ -122,8 +126,10 @@ class ImageSeries(TimeSeries):
         if get_data_shape(self.external_file) == get_data_shape(self.starting_frame):
             return
 
-        return ("%s '%s': The number of frame indices in 'starting_frame' should have "
-                "the same length as 'external_file'." % (self.__class__.__name__, self.name))
+        return (
+            "%s '%s': The number of frame indices in 'starting_frame' should have "
+            "the same length as 'external_file'." % (self.__class__.__name__, self.name)
+        )
 
     def _change_external_file_format(self):
         """
@@ -148,8 +154,10 @@ class ImageSeries(TimeSeries):
         if self.format == "external":
             return
 
-        return ("%s '%s': Format must be 'external' when external_file is specified."
-                % (self.__class__.__name__, self.name))
+        return "%s '%s': Format must be 'external' when external_file is specified." % (
+            self.__class__.__name__,
+            self.name,
+        )
 
     def _check_external_file_data(self):
         """
@@ -160,8 +168,10 @@ class ImageSeries(TimeSeries):
         if get_data_shape(self.data)[0] == 0:
             return
 
-        return ("%s '%s': Either external_file or data must be specified (not None), but not both."
-                % (self.__class__.__name__, self.name))
+        return (
+            "%s '%s': Either external_file or data must be specified (not None), but not both."
+            % (self.__class__.__name__, self.name)
+        )
 
     def _check_time_series_dimension(self):
         """Override _check_time_series_dimension to do nothing.

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -95,12 +95,7 @@ class ImageSeries(TimeSeries):
         if not self._check_external_file_starting_frame_length():
             msg = ("%s '%s': The number of frame indices in 'starting_frame' should have "
                    "the same length as 'external_file'." % (self.__class__.__name__, name))
-
-            # Raise an error when user creates the instance
-            if not self._in_construct_mode:
-                raise ValueError(msg)
-            # For back compatibility, raise a warning when loading from file
-            warnings.warn(msg)
+            self._raise_error_when_check_is_violated(error_msg=msg)
 
         if self._change_external_file_format():
             warnings.warn(
@@ -112,16 +107,18 @@ class ImageSeries(TimeSeries):
             )
 
         if not self._check_external_file_format():
-            raise ValueError(
+            msg = (
                 "%s '%s': Format must be 'external' when external_file is specified."
                 % (self.__class__.__name__, name)
             )
+            self._raise_error_when_check_is_violated(error_msg=msg)
 
         if not self._check_external_file_data():
-            raise ValueError(
+            msg = (
                 "%s '%s': Either external_file or data must be specified (not None), but not both."
                 % (self.__class__.__name__, name)
             )
+            self._raise_error_when_check_is_violated(error_msg=msg)
 
         if not self._check_image_series_dimension():
             warnings.warn(
@@ -129,6 +126,14 @@ class ImageSeries(TimeSeries):
                 "Time should be on the 0th dimension"
                 % (self.__class__.__name__, self.name)
             )
+
+    def _raise_error_when_check_is_violated(self, error_msg):
+        """Raise an error when a check is violated on instance creation.
+        To ensure backwards compatibility, this method throws a warning
+        instead of raising an error when reading from a file."""
+        if not self._in_construct_mode:
+            raise ValueError(error_msg)
+        warnings.warn(error_msg)
 
     def _check_external_file_starting_frame_length(self):
         """

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -85,7 +85,8 @@ class ImageSeries(TimeSeries):
         if external_file_shape != starting_frame_shape:
             warnings.warn(
                 "%s '%s': The number of frame indices in 'starting_frame' should have the same length as 'external_file'."
-                             % (self.__class__.__name__, name))
+                % (self.__class__.__name__, name)
+            )
 
         super().__init__(**kwargs)
 

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -91,7 +91,7 @@ class ImageSeries(TimeSeries):
                 "as 'external_file'." % (self.__class__.__name__, name)
             )
 
-        if data is None and self._change_external_file_format():
+        if self._change_external_file_format():
             warnings.warn(
                 "%s '%s': The value for 'format' has been changed to 'external'. "
                 "Setting a default value for 'format' is deprecated and will be changed "
@@ -131,7 +131,11 @@ class ImageSeries(TimeSeries):
         """
         Change the format to 'external' when external_file is specified.
         """
-        if self.external_file is not None and self.format is None:
+        if (
+                self.data.shape[0] == 0 and
+                self.external_file is not None and
+                self.format is None
+        ):
             self.format = 'external'
             return True
 

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -93,10 +93,14 @@ class ImageSeries(TimeSeries):
             setattr(self, key, val)
 
         if not self._check_external_file_starting_frame_length():
-            raise ValueError(
-                "%s '%s': The number of frame indices in 'starting_frame' should have the same length "
-                "as 'external_file'." % (self.__class__.__name__, name)
-            )
+            msg = ("%s '%s': The number of frame indices in 'starting_frame' should have "
+                   "the same length as 'external_file'." % (self.__class__.__name__, name))
+
+            # Raise an error when user creates the instance
+            if not self._in_construct_mode:
+                raise ValueError(msg)
+            # For back compatibility, raise a warning when loading from file
+            warnings.warn(msg)
 
         if self._change_external_file_format():
             warnings.warn(

--- a/tests/back_compat/test_read.py
+++ b/tests/back_compat/test_read.py
@@ -75,16 +75,14 @@ class TestReadOldVersions(TestCase):
     def test_read_imageseries_no_data_warns_when_checks_are_violated(self):
         """Test that warnings are raised when an ImageSeries is read that was created
         incorrectly."""
-        f = Path(__file__).parent / '1.5.1_imageseries_no_data.nwb'
+        f = Path(__file__).parent / "1.5.1_imageseries_no_data.nwb"
         with warnings.catch_warnings(record=True) as warnings_on_read:
-            with NWBHDF5IO(str(f), 'r') as io:
+            with NWBHDF5IO(str(f), "r") as io:
                 io.read()
                 warning_msgs = [warning.message.args[0] for warning in warnings_on_read]
                 self.assertEqual(len(warning_msgs), 2)
                 self.assertTrue(
-                    all(
-                        msg in warning_msgs for msg in self.image_series_warnings[1:]
-                    )
+                    all(msg in warning_msgs for msg in self.image_series_warnings[1:])
                 )
                 assert self.image_series_warnings[0] not in warning_msgs
 
@@ -98,15 +96,12 @@ class TestReadOldVersions(TestCase):
     def test_read_imageseries_no_unit_warns_when_checks_are_violated(self):
         """Test that warnings are raised when an ImageSeries is read that was created
         incorrectly."""
-        f = Path(__file__).parent / '1.5.1_imageseries_no_unit.nwb'
+        f = Path(__file__).parent / "1.5.1_imageseries_no_unit.nwb"
         with warnings.catch_warnings(record=True) as warnings_on_read:
-            with NWBHDF5IO(str(f), 'r') as io:
+            with NWBHDF5IO(str(f), "r") as io:
                 io.read()
                 warning_msgs = [warning.message.args[0] for warning in warnings_on_read]
                 self.assertEqual(len(warning_msgs), 3)
                 self.assertTrue(
-                    all(
-                        msg in warning_msgs for msg in self.image_series_warnings
-                    )
+                    all(msg in warning_msgs for msg in self.image_series_warnings)
                 )
-

--- a/tests/back_compat/test_read.py
+++ b/tests/back_compat/test_read.py
@@ -20,6 +20,17 @@ class TestReadOldVersions(TestCase):
                                "- expected an array of shape '[None]', got non-array data 'one publication'")],
     }
 
+    @classmethod
+    def setUpClass(cls):
+        cls.image_series_warnings = [
+            "ImageSeries 'test_imageseries': Either external_file or data must be "
+            "specified (not None), but not both.",
+            "ImageSeries 'test_imageseries': The number of frame indices in "
+            "'starting_frame' should have the same length as 'external_file'.",
+            "ImageSeries 'test_imageseries': Format must be 'external' when "
+            "external_file is specified.",
+        ]
+
     def test_read(self):
         """Test reading and validating all NWB files in the same folder as this file.
 
@@ -61,9 +72,41 @@ class TestReadOldVersions(TestCase):
             read_nwbfile = io.read()
             np.testing.assert_array_equal(read_nwbfile.acquisition['test_imageseries'].data, ImageSeries.DEFAULT_DATA)
 
+    def test_read_imageseries_no_data_warns_when_checks_are_violated(self):
+        """Test that warnings are raised when an ImageSeries is read that was created
+        incorrectly."""
+        f = Path(__file__).parent / '1.5.1_imageseries_no_data.nwb'
+        with warnings.catch_warnings(record=True) as warnings_on_read:
+            with NWBHDF5IO(str(f), 'r') as io:
+                io.read()
+                warning_msgs = [warning.message.args[0] for warning in warnings_on_read]
+                self.assertEqual(len(warning_msgs), 2)
+                self.assertTrue(
+                    all(
+                        msg in warning_msgs for msg in self.image_series_warnings[1:]
+                    )
+                )
+                assert self.image_series_warnings[0] not in warning_msgs
+
     def test_read_imageseries_no_unit(self):
         """Test that an ImageSeries written without unit is read with unit set to the default value."""
         f = Path(__file__).parent / '1.5.1_imageseries_no_unit.nwb'
         with NWBHDF5IO(str(f), 'r') as io:
             read_nwbfile = io.read()
             self.assertEqual(read_nwbfile.acquisition['test_imageseries'].unit, ImageSeries.DEFAULT_UNIT)
+
+    def test_read_imageseries_no_unit_warns_when_checks_are_violated(self):
+        """Test that warnings are raised when an ImageSeries is read that was created
+        incorrectly."""
+        f = Path(__file__).parent / '1.5.1_imageseries_no_unit.nwb'
+        with warnings.catch_warnings(record=True) as warnings_on_read:
+            with NWBHDF5IO(str(f), 'r') as io:
+                io.read()
+                warning_msgs = [warning.message.args[0] for warning in warnings_on_read]
+                self.assertEqual(len(warning_msgs), 3)
+                self.assertTrue(
+                    all(
+                        msg in warning_msgs for msg in self.image_series_warnings
+                    )
+                )
+

--- a/tests/integration/hdf5/test_image.py
+++ b/tests/integration/hdf5/test_image.py
@@ -12,7 +12,6 @@ class TestImageSeriesIO(AcquisitionH5IOMixin, TestCase):
         self.dev1 = Device('dev1')
         iS = ImageSeries(
             name='test_iS',
-            data=np.ones((3, 3, 3)),
             unit='unit',
             external_file=['external_file'],
             starting_frame=[0],

--- a/tests/integration/hdf5/test_image.py
+++ b/tests/integration/hdf5/test_image.py
@@ -15,8 +15,8 @@ class TestImageSeriesIO(AcquisitionH5IOMixin, TestCase):
             data=np.ones((3, 3, 3)),
             unit='unit',
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=[1., 2., 3.],
             device=self.dev1,
         )

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -179,8 +179,8 @@ class TestPlaneSegmentationIO(NWBH5IOMixin, TestCase):
             name='test_iS',
             dimension=[2],
             external_file=['images.tiff'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=ts
         )
 
@@ -248,8 +248,8 @@ class MaskIO(TestPlaneSegmentationIO, metaclass=ABCMeta):
             name='test_iS',
             dimension=[2],
             external_file=['images.tiff'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=ts
         )
         self.device = Device(name='dev1')
@@ -346,8 +346,8 @@ class TestCorrectedImageStackIO(AcquisitionH5IOMixin, TestCase):
             data=data,
             unit='unit',
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=timestamps
         )
         self.original_is = ImageSeries(
@@ -355,8 +355,8 @@ class TestCorrectedImageStackIO(AcquisitionH5IOMixin, TestCase):
             data=data,
             unit='unit',
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=timestamps
         )
         tstamps = [1., 2., 3.]

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -338,12 +338,10 @@ class TestCorrectedImageStackIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """Return the test CorrectedImageStack to read/write."""
-        data = np.ones((2, 2, 2)),
         timestamps = [1., 2.]
 
         corrected_is = ImageSeries(
             name='corrected',
-            data=data,
             unit='unit',
             external_file=['external_file'],
             starting_frame=[0],
@@ -352,7 +350,6 @@ class TestCorrectedImageStackIO(AcquisitionH5IOMixin, TestCase):
         )
         self.original_is = ImageSeries(
             name='original_is',
-            data=data,
             unit='unit',
             external_file=['external_file'],
             starting_frame=[0],

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -171,6 +171,35 @@ class ImageSeriesConstructor(TestCase):
             self.assertEqual(w, [])
         self.assertEqual(iS.starting_frame, [0])
 
+    def test_external_file_with_incorrect_format(self):
+        """Test that ValueError is raised when external_file is provided but
+        the format is not 'external'."""
+        msg = (
+            "ImageSeries 'test_iS': Format must be 'external' when external_file is specified."
+        )
+        with self.assertRaisesWith(ValueError, msg):
+            ImageSeries(
+                name="test_iS",
+                external_file=["external_file"],
+                format="raw",
+                unit="n.a.",
+                starting_frame=[0],
+                rate=0.2,
+            )
+
+    def test_external_file_default_format(self):
+        """Test that format is set to 'external' if not provided, when external_file is provided."""
+        with warnings.catch_warnings(record=True) as w:
+            iS = ImageSeries(
+                name="test_iS",
+                external_file=["external_file", "external_file2"],
+                unit="n.a.",
+                starting_frame=[0, 10],
+                rate=0.2,
+            )
+            self.assertEqual(w, [])
+        self.assertEqual(iS.format, "external")
+
 
 class IndexSeriesConstructor(TestCase):
 
@@ -234,7 +263,7 @@ class ImageMaskSeriesConstructor(TestCase):
 
     def test_init(self):
         iS = ImageSeries(name='test_iS', data=np.ones((2, 2, 2)), unit='unit',
-                         external_file=['external_file'], starting_frame=[0], format='tiff',
+                         external_file=['external_file'], starting_frame=[0], format='external',
                          timestamps=[1., .2])
 
         ims = ImageMaskSeries(name='test_ims', data=np.ones((2, 2, 2)), unit='unit',

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -117,6 +117,32 @@ class ImageSeriesConstructor(TestCase):
             )
             self.assertEqual(w, [])
 
+    def test_external_files_no_starting_frame(self):
+        """Test that an assertion error is raised when the length of starting_frame
+         is not the same as the length of external_file."""
+        msg = "ImageSeries 'test_iS': The number of frame indices in 'starting_frame' must have the same length as 'external_file'."
+        with self.assertRaisesWith(ValueError, msg):
+            ImageSeries(
+                name='test_iS',
+                external_file=['external_file', 'external_file2'],
+                format='external',
+                unit='n.a.',
+                starting_frame=None,
+                rate=0.2,
+            )
+
+    def test_external_files_no_starting_frame(self):
+        """Test that an assertion error is not raised when external_file has a length of 1."""
+        iS = ImageSeries(
+            name='test_iS',
+            external_file=['external_file'],
+            format='external',
+            unit='n.a.',
+            starting_frame=None,
+            rate=0.2,
+        )
+
+        assert iS.starting_frame == [0]
 
 class IndexSeriesConstructor(TestCase):
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -117,21 +117,24 @@ class ImageSeriesConstructor(TestCase):
             )
             self.assertEqual(w, [])
 
-    def test_external_files_no_starting_frame(self):
+    def test_external_files_starting_frame_warning(self):
         """Test that a warning is raised when the length of starting_frame
          is not the same as the length of external_file."""
-        msg = "ImageSeries 'test_iS': The number of frame indices in 'starting_frame' must have the same length as 'external_file'."
-        with self.assertWarnsWith(ValueError, msg):
-            ImageSeries(
-                name='test_iS',
-                external_file=['external_file', 'external_file2'],
-                format='external',
-                unit='n.a.',
-                starting_frame=None,
-                rate=0.2,
-            )
+        for starting_frame in [None, [0], [1, 2, 3]]:
+            with self.subTest():
+                msg = "ImageSeries 'test_iS': The number of frame indices in " \
+                      "'starting_frame' should have the same length as 'external_file'."
+                with self.assertWarnsWith(UserWarning, msg):
+                    ImageSeries(
+                        name='test_iS',
+                        external_file=['external_file', 'external_file2'],
+                        format='external',
+                        unit='n.a.',
+                        starting_frame=starting_frame,
+                        rate=0.2,
+                    )
 
-    def test_external_files_no_starting_frame(self):
+    def test_external_file_default_starting_frame(self):
         """Test that starting_frame is set to [0] if not provided, when external_file is has length 1."""
         iS = ImageSeries(
             name='test_iS',
@@ -142,7 +145,8 @@ class ImageSeriesConstructor(TestCase):
             rate=0.2,
         )
 
-        assert iS.starting_frame == [0]
+        self.assertEqual(iS.starting_frame, [0])
+
 
 class IndexSeriesConstructor(TestCase):
 

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -118,10 +118,10 @@ class ImageSeriesConstructor(TestCase):
             self.assertEqual(w, [])
 
     def test_external_files_no_starting_frame(self):
-        """Test that an assertion error is raised when the length of starting_frame
+        """Test that a warning is raised when the length of starting_frame
          is not the same as the length of external_file."""
         msg = "ImageSeries 'test_iS': The number of frame indices in 'starting_frame' must have the same length as 'external_file'."
-        with self.assertRaisesWith(ValueError, msg):
+        with self.assertWarnsWith(ValueError, msg):
             ImageSeries(
                 name='test_iS',
                 external_file=['external_file', 'external_file2'],
@@ -132,7 +132,7 @@ class ImageSeriesConstructor(TestCase):
             )
 
     def test_external_files_no_starting_frame(self):
-        """Test that an assertion error is not raised when external_file has a length of 1."""
+        """Test that starting_frame is set to [0] if not provided, when external_file is has length 1."""
         iS = ImageSeries(
             name='test_iS',
             external_file=['external_file'],

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -26,16 +26,16 @@ class ImageSeriesConstructor(TestCase):
             data=np.ones((3, 3, 3)),
             unit='unit',
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=[1., 2., 3.],
             device=dev,
         )
         self.assertEqual(iS.name, 'test_iS')
         self.assertEqual(iS.unit, 'unit')
         self.assertEqual(iS.external_file, ['external_file'])
-        self.assertEqual(iS.starting_frame, [1, 2, 3])
-        self.assertEqual(iS.format, 'tiff')
+        self.assertEqual(iS.starting_frame, [0])
+        self.assertEqual(iS.format, 'external')
         self.assertIs(iS.device, dev)
         # self.assertEqual(iS.bits_per_pixel, np.nan)
 
@@ -95,7 +95,6 @@ class ImageSeriesConstructor(TestCase):
                 name='test_iS',
                 data=np.ones((3, 3, 3)),
                 unit='Frames',
-                starting_frame=[0],
                 timestamps=[1, 2, 3, 4]
             )
 
@@ -125,8 +124,8 @@ class ImageSeriesConstructor(TestCase):
             )
             self.assertEqual(w, [])
 
-    def test_external_files_starting_frame_warning(self):
-        """Test that a warning is raised when the length of starting_frame
+    def test_external_file_with_incorrect_starting_frame(self):
+        """Test that ValueError is raised when the length of starting_frame
         is not the same as the length of external_file."""
         for starting_frame in [None, [0], [1, 2, 3]]:
             with self.subTest():
@@ -144,7 +143,21 @@ class ImageSeriesConstructor(TestCase):
                         rate=0.2,
                     )
 
-    def test_external_file_default_starting_frame(self):
+    def test_external_file_with_correct_starting_frame(self):
+        """Test that ValueError is not raised when the length of starting_frame
+        is the same as the length of external_file."""
+        with warnings.catch_warnings(record=True) as w:
+            ImageSeries(
+                name="test_iS",
+                external_file=["external_file", "external_file2", "external_file3"],
+                format="external",
+                unit="n.a.",
+                starting_frame=[0, 15, 30],
+                rate=0.2,
+            )
+            self.assertEqual(w, [])
+
+    def test_external_file_with_default_starting_frame(self):
         """Test that starting_frame is set to [0] if not provided, when external_file is has length 1."""
         with warnings.catch_warnings(record=True) as w:
             iS = ImageSeries(
@@ -221,18 +234,18 @@ class ImageMaskSeriesConstructor(TestCase):
 
     def test_init(self):
         iS = ImageSeries(name='test_iS', data=np.ones((2, 2, 2)), unit='unit',
-                         external_file=['external_file'], starting_frame=[1, 2, 3], format='tiff',
+                         external_file=['external_file'], starting_frame=[0], format='tiff',
                          timestamps=[1., .2])
 
         ims = ImageMaskSeries(name='test_ims', data=np.ones((2, 2, 2)), unit='unit',
-                              masked_imageseries=iS, external_file=['external_file'], starting_frame=[1, 2, 3],
-                              format='tiff', timestamps=[1., 2.])
+                              masked_imageseries=iS, external_file=['external_file'], starting_frame=[0],
+                              format='external', timestamps=[1., 2.])
         self.assertEqual(ims.name, 'test_ims')
         self.assertEqual(ims.unit, 'unit')
         self.assertIs(ims.masked_imageseries, iS)
         self.assertEqual(ims.external_file, ['external_file'])
-        self.assertEqual(ims.starting_frame, [1, 2, 3])
-        self.assertEqual(ims.format, 'tiff')
+        self.assertEqual(ims.starting_frame, [0])
+        self.assertEqual(ims.format, 'external')
 
 
 class OpticalSeriesConstructor(TestCase):
@@ -240,15 +253,15 @@ class OpticalSeriesConstructor(TestCase):
     def test_init(self):
         ts = OpticalSeries(name='test_ts', data=np.ones((2, 2, 2)), unit='unit', distance=1.0,
                            field_of_view=[4, 5], orientation='orientation', external_file=['external_file'],
-                           starting_frame=[1, 2, 3], format='tiff', timestamps=[1., 2.])
+                           starting_frame=[0], format='external', timestamps=[1., 2.])
         self.assertEqual(ts.name, 'test_ts')
         self.assertEqual(ts.unit, 'unit')
         self.assertEqual(ts.distance, 1.0)
         self.assertEqual(ts.field_of_view, [4, 5])
         self.assertEqual(ts.orientation, 'orientation')
         self.assertEqual(ts.external_file, ['external_file'])
-        self.assertEqual(ts.starting_frame, [1, 2, 3])
-        self.assertEqual(ts.format, 'tiff')
+        self.assertEqual(ts.starting_frame, [0])
+        self.assertEqual(ts.format, 'external')
 
 
 class TestImageSubtypes(TestCase):

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -134,7 +134,7 @@ class ImageSeriesConstructor(TestCase):
                     "ImageSeries 'test_iS': The number of frame indices in "
                     "'starting_frame' should have the same length as 'external_file'."
                 )
-                with self.assertWarnsWith(UserWarning, msg):
+                with self.assertRaisesWith(ValueError, msg):
                     ImageSeries(
                         name="test_iS",
                         external_file=["external_file", "external_file2"],

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -5,7 +5,15 @@ import numpy as np
 from pynwb import TimeSeries
 from pynwb.base import Image, Images, ImageReferences
 from pynwb.device import Device
-from pynwb.image import ImageSeries, IndexSeries, ImageMaskSeries, OpticalSeries, GrayscaleImage, RGBImage, RGBAImage
+from pynwb.image import (
+    ImageSeries,
+    IndexSeries,
+    ImageMaskSeries,
+    OpticalSeries,
+    GrayscaleImage,
+    RGBImage,
+    RGBAImage,
+)
 from pynwb.testing import TestCase
 
 
@@ -119,32 +127,35 @@ class ImageSeriesConstructor(TestCase):
 
     def test_external_files_starting_frame_warning(self):
         """Test that a warning is raised when the length of starting_frame
-         is not the same as the length of external_file."""
+        is not the same as the length of external_file."""
         for starting_frame in [None, [0], [1, 2, 3]]:
             with self.subTest():
-                msg = "ImageSeries 'test_iS': The number of frame indices in " \
-                      "'starting_frame' should have the same length as 'external_file'."
+                msg = (
+                    "ImageSeries 'test_iS': The number of frame indices in "
+                    "'starting_frame' should have the same length as 'external_file'."
+                )
                 with self.assertWarnsWith(UserWarning, msg):
                     ImageSeries(
-                        name='test_iS',
-                        external_file=['external_file', 'external_file2'],
-                        format='external',
-                        unit='n.a.',
+                        name="test_iS",
+                        external_file=["external_file", "external_file2"],
+                        format="external",
+                        unit="n.a.",
                         starting_frame=starting_frame,
                         rate=0.2,
                     )
 
     def test_external_file_default_starting_frame(self):
         """Test that starting_frame is set to [0] if not provided, when external_file is has length 1."""
-        iS = ImageSeries(
-            name='test_iS',
-            external_file=['external_file'],
-            format='external',
-            unit='n.a.',
-            starting_frame=None,
-            rate=0.2,
-        )
-
+        with warnings.catch_warnings(record=True) as w:
+            iS = ImageSeries(
+                name="test_iS",
+                external_file=["external_file"],
+                format="external",
+                unit="n.a.",
+                starting_frame=None,
+                rate=0.2,
+            )
+            self.assertEqual(w, [])
         self.assertEqual(iS.starting_frame, [0])
 
 

--- a/tests/unit/test_ophys.py
+++ b/tests/unit/test_ophys.py
@@ -48,8 +48,8 @@ def create_plane_segmentation():
         data=np.ones((2, 2, 2)),
         unit='unit',
         external_file=['external_file'],
-        starting_frame=[1, 2, 3],
-        format='tiff',
+        starting_frame=[0],
+        format='external',
         timestamps=[1., 2.]
     )
 
@@ -184,8 +184,8 @@ class TwoPhotonSeriesConstructor(TestCase):
             pmt_gain=1.0,
             scan_line_rate=2.0,
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=list()
         )
         self.assertEqual(tPS.name, 'test_tPS')
@@ -195,8 +195,8 @@ class TwoPhotonSeriesConstructor(TestCase):
         self.assertEqual(tPS.pmt_gain, 1.0)
         self.assertEqual(tPS.scan_line_rate, 2.0)
         self.assertEqual(tPS.external_file, ['external_file'])
-        self.assertEqual(tPS.starting_frame, [1, 2, 3])
-        self.assertEqual(tPS.format, 'tiff')
+        self.assertEqual(tPS.starting_frame, [0])
+        self.assertEqual(tPS.format, 'external')
         self.assertIsNone(tPS.dimension)
 
 
@@ -246,8 +246,8 @@ class CorrectedImageStackConstructor(TestCase):
             data=np.ones((2, 2, 2)),
             unit='unit',
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=[1., 2.]
         )
         is2 = ImageSeries(
@@ -255,8 +255,8 @@ class CorrectedImageStackConstructor(TestCase):
             data=np.ones((2, 2, 2)),
             unit='unit',
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=[1., 2.]
         )
         tstamps = np.arange(1.0, 100.0, 0.1, dtype=np.float64)
@@ -394,8 +394,8 @@ class PlaneSegmentationConstructor(TestCase):
             data=np.ones((2, 2, 2)),
             unit='unit',
             external_file=['external_file'],
-            starting_frame=[1, 2, 3],
-            format='tiff',
+            starting_frame=[0],
+            format='external',
             timestamps=[1., 2.]
         )
 

--- a/tests/unit/test_ophys.py
+++ b/tests/unit/test_ophys.py
@@ -45,7 +45,6 @@ def create_plane_segmentation():
 
     iSS = ImageSeries(
         name='test_iS',
-        data=np.ones((2, 2, 2)),
         unit='unit',
         external_file=['external_file'],
         starting_frame=[0],
@@ -243,7 +242,6 @@ class CorrectedImageStackConstructor(TestCase):
     def test_init(self):
         is1 = ImageSeries(
             name='corrected',
-            data=np.ones((2, 2, 2)),
             unit='unit',
             external_file=['external_file'],
             starting_frame=[0],
@@ -252,7 +250,6 @@ class CorrectedImageStackConstructor(TestCase):
         )
         is2 = ImageSeries(
             name='is2',
-            data=np.ones((2, 2, 2)),
             unit='unit',
             external_file=['external_file'],
             starting_frame=[0],
@@ -391,7 +388,6 @@ class PlaneSegmentationConstructor(TestCase):
     def set_up_dependencies(self):
         iSS = ImageSeries(
             name='test_iS',
-            data=np.ones((2, 2, 2)),
             unit='unit',
             external_file=['external_file'],
             starting_frame=[0],


### PR DESCRIPTION
## Motivation

This PR is a continuation of the issue described in #1510 by raising a `ValueError` when `starting_frame` does not have the same length as `external_file`. 

- Added a method to `NWBMixin` that only raises an error when a check is violated on instance creation,
  otherwise throws a warning when reading from a file. 

The new checks is used with this method to ensure that that files with invalid data can be read, but prohibits the user from creating new instances when these checks are violated. 

New checks:
- The length of `starting_frame` must match the length of `external_file` when `external_file` is specified
- Format must be `'external'` when `external_file` is specified
- `data` must be empty array when `external_file` is specified
`ValueError` is raised when a check is violated on instance creation,
but only warns when file is read from disk.

Default values:
- `starting_frame` is `[0]` when `external_file` has a length of 1
- `format` is `'external'` when format was originally None and `external_file` is specified (`DeprecationWarning` is raised)

          

Fix #1510 

## How to test the behavior?

Unittests are added in `tests/unit/test_image.py`

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
