### PR TITLE
[DOC] - Update docstring header sentences & some parameter descriptions

### DIFF
--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -22,7 +22,7 @@ class ElectrodeGroup(NWBContainer):
                      'device',
                      'position')
 
-    @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
+    @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode group'},
             {'name': 'description', 'type': str, 'doc': 'description of this electrode group'},
             {'name': 'location', 'type': str, 'doc': 'description of location of this electrode group'},
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record from this electrode group'},

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -14,9 +14,7 @@ from .device import Device
 
 @register_class('ElectrodeGroup', CORE_NAMESPACE)
 class ElectrodeGroup(NWBContainer):
-    """
-    Defines a related group of electrodes.
-    """
+    """Defines a related group of electrodes."""
 
     __nwbfields__ = ('name',
                      'description',

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -14,8 +14,7 @@ from .device import Device
 
 @register_class('ElectrodeGroup', CORE_NAMESPACE)
 class ElectrodeGroup(NWBContainer):
-    """
-    """
+    """Defines a related group of electrodes."""
 
     __nwbfields__ = ('name',
                      'description',

--- a/src/pynwb/ecephys.py
+++ b/src/pynwb/ecephys.py
@@ -14,7 +14,9 @@ from .device import Device
 
 @register_class('ElectrodeGroup', CORE_NAMESPACE)
 class ElectrodeGroup(NWBContainer):
-    """Defines a related group of electrodes."""
+    """
+    Defines a related group of electrodes.
+    """
 
     __nwbfields__ = ('name',
                      'description',

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -30,6 +30,7 @@ def _not_parent(arg):
 
 @register_class('LabMetaData', CORE_NAMESPACE)
 class LabMetaData(NWBContainer):
+    """Metadata about the lab that collected the data."""
 
     @docval({'name': 'name', 'type': str, 'doc': 'name of metadata'})
     def __init__(self, **kwargs):
@@ -38,6 +39,7 @@ class LabMetaData(NWBContainer):
 
 @register_class('Subject', CORE_NAMESPACE)
 class Subject(NWBContainer):
+    """Subject information and metadata."""
 
     __nwbfields__ = (
         'age',

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -30,9 +30,7 @@ def _not_parent(arg):
 
 @register_class('LabMetaData', CORE_NAMESPACE)
 class LabMetaData(NWBContainer):
-    """
-    Metadata about the lab that collected the data.
-    """
+    """Metadata about the lab that collected the data."""
 
     @docval({'name': 'name', 'type': str, 'doc': 'name of lab metadata'})
     def __init__(self, **kwargs):
@@ -41,9 +39,7 @@ class LabMetaData(NWBContainer):
 
 @register_class('Subject', CORE_NAMESPACE)
 class Subject(NWBContainer):
-    """
-    Subject information and metadata.
-    """
+    """Subject information and metadata."""
 
     __nwbfields__ = (
         'age',

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -30,7 +30,7 @@ def _not_parent(arg):
 
 @register_class('LabMetaData', CORE_NAMESPACE)
 class LabMetaData(NWBContainer):
-    """Metadata about the lab that collected the data."""
+    """Container for storing lab-specific meta-data"""
 
     @docval({'name': 'name', 'type': str, 'doc': 'name of lab metadata'})
     def __init__(self, **kwargs):

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -32,7 +32,7 @@ def _not_parent(arg):
 class LabMetaData(NWBContainer):
     """Metadata about the lab that collected the data."""
 
-    @docval({'name': 'name', 'type': str, 'doc': 'name of metadata'})
+    @docval({'name': 'name', 'type': str, 'doc': 'name of lab metadata'})
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -30,7 +30,9 @@ def _not_parent(arg):
 
 @register_class('LabMetaData', CORE_NAMESPACE)
 class LabMetaData(NWBContainer):
-    """Metadata about the lab that collected the data."""
+    """
+    Metadata about the lab that collected the data.
+    """
 
     @docval({'name': 'name', 'type': str, 'doc': 'name of lab metadata'})
     def __init__(self, **kwargs):
@@ -39,7 +41,9 @@ class LabMetaData(NWBContainer):
 
 @register_class('Subject', CORE_NAMESPACE)
 class Subject(NWBContainer):
-    """Subject information and metadata."""
+    """
+    Subject information and metadata.
+    """
 
     __nwbfields__ = (
         'age',

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -42,13 +42,12 @@ class IntracellularElectrode(NWBContainer):
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record from this electrode'},
             {'name': 'description', 'type': str,
-             'doc': 'Recording description, description of electrode (e.g.,  whole-cell, sharp, etc) '
-                    'COMMENT: Free-form text (can be from Methods)'},
+             'doc': 'Recording description, description of electrode (e.g.,  whole-cell, sharp, etc).'},
             {'name': 'slice', 'type': str, 'doc': 'Information about slice used for recording.', 'default': None},
             {'name': 'seal', 'type': str, 'doc': 'Information about seal used for recording.', 'default': None},
             {'name': 'location', 'type': str,
              'doc': 'Area, layer, comments on estimation, stereotaxis coordinates (if in vivo, etc).', 'default': None},
-            {'name': 'resistance', 'type': str, 'doc': 'Electrode resistance COMMENT: unit: Ohm.', 'default': None},
+            {'name': 'resistance', 'type': str, 'doc': 'Electrode resistance, unit: Ohm.', 'default': None},
             {'name': 'filtering', 'type': str, 'doc': 'Electrode specific filtering.', 'default': None},
             {'name': 'initial_access_resistance', 'type': str, 'doc': 'Initial access resistance.', 'default': None},
             {'name': 'cell_id', 'type': str, 'doc': 'Unique ID of cell.', 'default': None}

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -27,8 +27,7 @@ def ensure_unit(self, name, current_unit, unit, nwb_version):
 
 @register_class('IntracellularElectrode', CORE_NAMESPACE)
 class IntracellularElectrode(NWBContainer):
-    '''
-    '''
+    """Describes an intracellular electrode and associated metadata."""
 
     __nwbfields__ = ('cell_id',
                      'slice',

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -27,7 +27,9 @@ def ensure_unit(self, name, current_unit, unit, nwb_version):
 
 @register_class('IntracellularElectrode', CORE_NAMESPACE)
 class IntracellularElectrode(NWBContainer):
-    """Describes an intracellular electrode and associated metadata."""
+    """
+    Describes an intracellular electrode and associated metadata.
+    """
 
     __nwbfields__ = ('cell_id',
                      'slice',

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -27,9 +27,7 @@ def ensure_unit(self, name, current_unit, unit, nwb_version):
 
 @register_class('IntracellularElectrode', CORE_NAMESPACE)
 class IntracellularElectrode(NWBContainer):
-    """
-    Describes an intracellular electrode and associated metadata.
-    """
+    """Describes an intracellular electrode and associated metadata."""
 
     __nwbfields__ = ('cell_id',
                      'slice',

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -15,8 +15,8 @@ class OptogeneticStimulusSite(NWBContainer):
                      'excitation_lambda',
                      'location')
 
-    @docval({'name': 'name', 'type': str, 'doc': 'The name of this stimulus site'},
-            {'name': 'device', 'type': Device, 'doc': 'the device that was used'},
+    @docval({'name': 'name', 'type': str, 'doc': 'The name of this stimulus site.'},
+            {'name': 'device', 'type': Device, 'doc': 'The device that was used.'},
             {'name': 'description', 'type': str, 'doc': 'Description of site.'},
             {'name': 'excitation_lambda', 'type': 'float', 'doc': 'Excitation wavelength in nm.'},
             {'name': 'location', 'type': str, 'doc': 'Location of stimulation site.'})

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -8,9 +8,7 @@ from .device import Device
 
 @register_class('OptogeneticStimulusSite', CORE_NAMESPACE)
 class OptogeneticStimulusSite(NWBContainer):
-    """
-    Optogenetic stimulus site.
-    """
+    """Optogenetic stimulus site."""
 
     __nwbfields__ = ('device',
                      'description',

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -8,7 +8,9 @@ from .device import Device
 
 @register_class('OptogeneticStimulusSite', CORE_NAMESPACE)
 class OptogeneticStimulusSite(NWBContainer):
-    """Optogenetic stimulus site."""
+    """
+    Optogenetic stimulus site.
+    """
 
     __nwbfields__ = ('device',
                      'description',

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -8,8 +8,7 @@ from .device import Device
 
 @register_class('OptogeneticStimulusSite', CORE_NAMESPACE)
 class OptogeneticStimulusSite(NWBContainer):
-    '''
-    '''
+    """Optogenetic stimulus site."""
 
     __nwbfields__ = ('device',
                      'description',


### PR DESCRIPTION
This PR updates some docs, adding some docstring header sentences to those that were missing them, and for the same classes, doing minor updates to the parameter descriptions. 

## Motivation

For a few of the objects, there was no header description sentence in the docstring. This leads to this section being blank on the documentation site, and also, when pulling the docs from jupyter or similar, can be auto-filled from inherited objects reading, for example "A container that can contain other containers and has special functionality for printing." for those inherited from NWBContainer

## How to test the behavior?

There are no actual code changes here

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
