### PR TITLE
[BUG] - Fix update of epoch_tags store

### DIFF
--- a/src/pynwb/epoch.py
+++ b/src/pynwb/epoch.py
@@ -33,8 +33,10 @@ class TimeIntervals(DynamicTable):
 
     @docval({'name': 'start_time', 'type': 'float', 'doc': 'Start time of epoch, in seconds'},
             {'name': 'stop_time', 'type': 'float', 'doc': 'Stop time of epoch, in seconds'},
-            {'name': 'tags', 'type': (str, list, tuple), 'doc': 'user-defined tags used throughout time intervals',
-             'default': None},
+            {'name': 'tags', 'type': (str, list, tuple),
+             'doc': ('User-defined tags used throughout time intervals. If list or tuple each element is treated as '
+                     'a separate tag. If str, can be a single tag, or comma-separated entries that will be parsed '
+                     'into individual tags.'), 'default': None},
             {'name': 'timeseries', 'type': (list, tuple, TimeSeries), 'doc': 'the TimeSeries this epoch applies to',
              'default': None},
             allow_extra=True)

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -590,6 +590,7 @@ class NWBFile(MultiContainerInterface):
         self.__check_epochs()
         if kwargs['tags'] is not None:
             # If a str is passed into epoch_tags directly, it gets split into characters
+            #   This processing needs to match tags parsing in `epoch.TimeIntervals.add_interval`
             tmp = kwargs['tags']
             if isinstance(kwargs['tags'], str):
                 tmp = [s.strip() for s in kwargs['tags'].split(",") if not s.isspace()]

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -589,7 +589,11 @@ class NWBFile(MultiContainerInterface):
         """
         self.__check_epochs()
         if kwargs['tags'] is not None:
-            self.epoch_tags.update(kwargs['tags'])
+            # If a str is passed into epoch_tags directly, it gets split into characters
+            tmp = kwargs['tags']
+            if isinstance(kwargs['tags'], str):
+                tmp = [s.strip() for s in kwargs['tags'].split(",") if not s.isspace()]
+            self.epoch_tags.update(tmp)
         self.epochs.add_interval(**kwargs)
 
     def __check_electrodes(self):


### PR DESCRIPTION
## Motivation

This addresses #1449 

The way that `epoch_tags` was updated before didn't play well with strings, which should be a supported input. Since `epoch_tags` is a set, adding a string gets treated as an iterable, which then separates and adds each character. 

This PR fixes this section to check the types of the tags, and deal with them if they are a string. 

Note that the string processing line is a direct copy of `pynwb.epoch` line 47, to make sure strings are processed the same, and that epoch_tags properly supports the possible input of something like `'label1, label2'`. 

## How to test the behavior?

There is example code that shows the problem in #1449. I check that this same code when tested against this PR works as it should.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
