### PR TITLE
[DOC] - Update docval doctypes for those that render weird on docsite

### DIFF
--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -247,7 +247,7 @@ class NWBHDF5IO(_HDF5IO):
 
     @docval({'name': 'src_io', 'type': HDMFIO,
              'doc': 'the HDMFIO object (such as NWBHDF5IO) that was used to read the data to export'},
-            {'name': 'nwbfile', 'type': 'NWBFile',
+            {'name': 'nwbfile', 'type': NWBFile,
              'doc': 'the NWBFile object to export. If None, then the entire contents of src_io will be exported',
              'default': None},
             {'name': 'write_args', 'type': dict, 'doc': 'arguments to pass to :py:meth:`write_builder`',

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -247,7 +247,7 @@ class NWBHDF5IO(_HDF5IO):
 
     @docval({'name': 'src_io', 'type': HDMFIO,
              'doc': 'the HDMFIO object (such as NWBHDF5IO) that was used to read the data to export'},
-            {'name': 'nwbfile', 'type': NWBFile,
+            {'name': 'nwbfile', 'type': 'NWBFile',
              'doc': 'the NWBFile object to export. If None, then the entire contents of src_io will be exported',
              'default': None},
             {'name': 'write_args', 'type': dict, 'doc': 'arguments to pass to :py:meth:`write_builder`',

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -108,15 +108,15 @@ class TimeSeries(NWBDataInterface):
              'doc': ('The data values. The first dimension must be time. '
                      'Can also store binary data, e.g., image frames')},
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)'},
-            {'name': 'resolution', 'type': 'float',
+            {'name': 'resolution', 'type': float,
              'doc': 'The smallest meaningful difference (in specified unit) between values in data',
              'default': DEFAULT_RESOLUTION},
-            {'name': 'conversion', 'type': 'float',
+            {'name': 'conversion', 'type': float,
              'doc': 'Scalar to multiply each element in data to convert it to the specified unit',
              'default': DEFAULT_CONVERSION},
             {
                 'name': 'offset',
-                'type': 'float',
+                'type': float,
                 'doc': (
                     "Scalar to add to each element in the data scaled by 'conversion' to finish converting it to the "
                     "specified unit."
@@ -125,8 +125,8 @@ class TimeSeries(NWBDataInterface):
             },
             {'name': 'timestamps', 'type': ('array_data', 'data', 'TimeSeries'), 'shape': (None,),
              'doc': 'Timestamps for samples stored in data', 'default': None},
-            {'name': 'starting_time', 'type': 'float', 'doc': 'The timestamp of the first sample', 'default': None},
-            {'name': 'rate', 'type': 'float', 'doc': 'Sampling rate in Hz', 'default': None},
+            {'name': 'starting_time', 'type': float, 'doc': 'The timestamp of the first sample', 'default': None},
+            {'name': 'rate', 'type': float, 'doc': 'Sampling rate in Hz', 'default': None},
 
             {'name': 'comments', 'type': str, 'doc': 'Human-readable comments about this TimeSeries dataset',
              'default': 'no comments'},
@@ -293,7 +293,7 @@ class Image(NWBData):
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this image'},
             {'name': 'data', 'type': ('array_data', 'data'), 'doc': 'data of image. Dimensions: x, y [, r,g,b[,a]]',
              'shape': ((None, None), (None, None, 3), (None, None, 4))},
-            {'name': 'resolution', 'type': 'float', 'doc': 'pixels / cm', 'default': None},
+            {'name': 'resolution', 'type': float, 'doc': 'pixels / cm', 'default': None},
             {'name': 'description', 'type': str, 'doc': 'description of image', 'default': None})
     def __init__(self, **kwargs):
         args_to_set = popargs_to_dict(("resolution", "description"), kwargs)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -342,7 +342,7 @@ class Images(MultiContainerInterface):
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this set of images'},
             {'name': 'images', 'type': 'array_data', 'doc': 'image objects', 'default': None},
             {'name': 'description', 'type': str, 'doc': 'description of images', 'default': 'no description'},
-            {'name': 'order_of_images', 'type': 'ImageReferences',
+            {'name': 'order_of_images', 'type': ImageReferences,
              'doc': 'Ordered dataset of references to Image objects stored in the parent group.', 'default': None},)
     def __init__(self, **kwargs):
 

--- a/src/pynwb/epoch.py
+++ b/src/pynwb/epoch.py
@@ -31,8 +31,8 @@ class TimeIntervals(DynamicTable):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-    @docval({'name': 'start_time', 'type': 'float', 'doc': 'Start time of epoch, in seconds'},
-            {'name': 'stop_time', 'type': 'float', 'doc': 'Stop time of epoch, in seconds'},
+    @docval({'name': 'start_time', 'type': float, 'doc': 'Start time of epoch, in seconds'},
+            {'name': 'stop_time', 'type': float, 'doc': 'Stop time of epoch, in seconds'},
             {'name': 'tags', 'type': (str, list, tuple), 'doc': 'user-defined tags used throughout time intervals',
              'default': None},
             {'name': 'timeseries', 'type': (list, tuple, TimeSeries), 'doc': 'the TimeSeries this epoch applies to',

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -607,11 +607,11 @@ class NWBFile(MultiContainerInterface):
         self.__check_electrodes()
         self.electrodes.add_column(**kwargs)
 
-    @docval({'name': 'x', 'type': 'float', 'doc': 'the x coordinate of the position (+x is posterior)',
+    @docval({'name': 'x', 'type': float, 'doc': 'the x coordinate of the position (+x is posterior)',
              'default': None},
-            {'name': 'y', 'type': 'float', 'doc': 'the y coordinate of the position (+y is inferior)', 'default': None},
-            {'name': 'z', 'type': 'float', 'doc': 'the z coordinate of the position (+z is right)', 'default': None},
-            {'name': 'imp', 'type': 'float', 'doc': 'the impedance of the electrode, in ohms', 'default': None},
+            {'name': 'y', 'type': float, 'doc': 'the y coordinate of the position (+y is inferior)', 'default': None},
+            {'name': 'z', 'type': float, 'doc': 'the z coordinate of the position (+z is right)', 'default': None},
+            {'name': 'imp', 'type': float, 'doc': 'the impedance of the electrode, in ohms', 'default': None},
             {'name': 'location', 'type': str,
              'doc': 'the location of electrode within the subject e.g. brain region. Required.',
              'default': None},
@@ -622,9 +622,9 @@ class NWBFile(MultiContainerInterface):
              'doc': 'the ElectrodeGroup object to add to this NWBFile. Required.',
              'default': None},
             {'name': 'id', 'type': int, 'doc': 'a unique identifier for the electrode', 'default': None},
-            {'name': 'rel_x', 'type': 'float', 'doc': 'the x coordinate within the electrode group', 'default': None},
-            {'name': 'rel_y', 'type': 'float', 'doc': 'the y coordinate within the electrode group', 'default': None},
-            {'name': 'rel_z', 'type': 'float', 'doc': 'the z coordinate within the electrode group', 'default': None},
+            {'name': 'rel_x', 'type': float, 'doc': 'the x coordinate within the electrode group', 'default': None},
+            {'name': 'rel_y', 'type': float, 'doc': 'the y coordinate within the electrode group', 'default': None},
+            {'name': 'rel_z', 'type': float, 'doc': 'the z coordinate within the electrode group', 'default': None},
             {'name': 'reference', 'type': str, 'doc': 'Description of the reference electrode and/or reference scheme\
                 used for this  electrode, e.g.,"stainless steel skull screw" or "online common average referencing". ',
                 'default': None},

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -91,7 +91,7 @@ class PatchClampSeries(TimeSeries):
             {'name': 'electrode', 'type': IntracellularElectrode,  # required
              'doc': 'IntracellularElectrode group that describes the electrode that was used to apply '
                      'or record this data.'},
-            {'name': 'gain', 'type': 'float', 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},  # required
+            {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp (v-clamp) or Volt/Volt (c-clamp)'},  # required
             {'name': 'stimulus_description', 'type': str, 'doc': 'the stimulus name/protocol', 'default': "N/A"},
             *get_docval(TimeSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
                         'comments', 'description', 'control', 'control_description', 'offset'),
@@ -126,11 +126,11 @@ class CurrentClampSeries(PatchClampSeries):
                      'capacitance_compensation')
 
     @docval(*get_docval(PatchClampSeries.__init__, 'name', 'data', 'electrode'),  # required
-            {'name': 'gain', 'type': 'float', 'doc': 'Units: Volt/Volt'},
+            {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Volt'},
             *get_docval(PatchClampSeries.__init__, 'stimulus_description'),
-            {'name': 'bias_current', 'type': 'float', 'doc': 'Unit: Amp', 'default': None},
-            {'name': 'bridge_balance', 'type': 'float', 'doc': 'Unit: Ohm', 'default': None},
-            {'name': 'capacitance_compensation', 'type': 'float', 'doc': 'Unit: Farad', 'default': None},
+            {'name': 'bias_current', 'type': float, 'doc': 'Unit: Amp', 'default': None},
+            {'name': 'bridge_balance', 'type': float, 'doc': 'Unit: Ohm', 'default': None},
+            {'name': 'capacitance_compensation', 'type': float, 'doc': 'Unit: Farad', 'default': None},
             *get_docval(PatchClampSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
                         'comments', 'description', 'control', 'control_description', 'sweep_number', 'offset'),
             {'name': 'unit', 'type': str, 'doc': "The base unit of measurement (must be 'volts')",
@@ -158,7 +158,7 @@ class IZeroClampSeries(CurrentClampSeries):
     __nwbfields__ = ()
 
     @docval(*get_docval(CurrentClampSeries.__init__, 'name', 'data', 'electrode'),  # required
-            {'name': 'gain', 'type': 'float', 'doc': 'Units: Volt/Volt'},  # required
+            {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Volt'},  # required
             {'name': 'stimulus_description', 'type': str,
              'doc': ('The stimulus name/protocol. Setting this to a value other than "N/A" is deprecated as of '
                      'NWB 2.3.0.'),
@@ -229,15 +229,15 @@ class VoltageClampSeries(PatchClampSeries):
                      'whole_cell_series_resistance_comp')
 
     @docval(*get_docval(PatchClampSeries.__init__, 'name', 'data', 'electrode'),  # required
-            {'name': 'gain', 'type': 'float', 'doc': 'Units: Volt/Amp'},  # required
+            {'name': 'gain', 'type': float, 'doc': 'Units: Volt/Amp'},  # required
             *get_docval(PatchClampSeries.__init__, 'stimulus_description'),
-            {'name': 'capacitance_fast', 'type': 'float', 'doc': 'Unit: Farad', 'default': None},
-            {'name': 'capacitance_slow', 'type': 'float', 'doc': 'Unit: Farad', 'default': None},
-            {'name': 'resistance_comp_bandwidth', 'type': 'float', 'doc': 'Unit: Hz', 'default': None},
-            {'name': 'resistance_comp_correction', 'type': 'float', 'doc': 'Unit: percent', 'default': None},
-            {'name': 'resistance_comp_prediction', 'type': 'float', 'doc': 'Unit: percent', 'default': None},
-            {'name': 'whole_cell_capacitance_comp', 'type': 'float', 'doc': 'Unit: Farad', 'default': None},
-            {'name': 'whole_cell_series_resistance_comp', 'type': 'float', 'doc': 'Unit: Ohm', 'default': None},
+            {'name': 'capacitance_fast', 'type': float, 'doc': 'Unit: Farad', 'default': None},
+            {'name': 'capacitance_slow', 'type': float, 'doc': 'Unit: Farad', 'default': None},
+            {'name': 'resistance_comp_bandwidth', 'type': float, 'doc': 'Unit: Hz', 'default': None},
+            {'name': 'resistance_comp_correction', 'type': float, 'doc': 'Unit: percent', 'default': None},
+            {'name': 'resistance_comp_prediction', 'type': float, 'doc': 'Unit: percent', 'default': None},
+            {'name': 'whole_cell_capacitance_comp', 'type': float, 'doc': 'Unit: Farad', 'default': None},
+            {'name': 'whole_cell_series_resistance_comp', 'type': float, 'doc': 'Unit: Ohm', 'default': None},
             *get_docval(PatchClampSeries.__init__, 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
                         'comments', 'description', 'control', 'control_description', 'sweep_number', 'offset'),
             {'name': 'unit', 'type': str, 'doc': "The base unit of measurement (must be 'amperes')",

--- a/src/pynwb/icephys.py
+++ b/src/pynwb/icephys.py
@@ -469,13 +469,13 @@ class IntracellularRecordingsTable(AlignedDynamicTable):
         super().__init__(**kwargs)
 
     @docval({'name': 'electrode', 'type': IntracellularElectrode, 'doc': 'The intracellular electrode used'},
-            {'name': 'stimulus_start_index', 'type': 'int', 'doc': 'Start index of the stimulus', 'default': None},
-            {'name': 'stimulus_index_count', 'type': 'int', 'doc': 'Stop index of the stimulus', 'default': None},
+            {'name': 'stimulus_start_index', 'type': int, 'doc': 'Start index of the stimulus', 'default': None},
+            {'name': 'stimulus_index_count', 'type': int, 'doc': 'Stop index of the stimulus', 'default': None},
             {'name': 'stimulus', 'type': TimeSeries,
              'doc': 'The TimeSeries (usually a PatchClampSeries) with the stimulus',
              'default': None},
-            {'name': 'response_start_index', 'type': 'int', 'doc': 'Start index of the response', 'default': None},
-            {'name': 'response_index_count', 'type': 'int', 'doc': 'Stop index of the response', 'default': None},
+            {'name': 'response_start_index', 'type': int, 'doc': 'Start index of the response', 'default': None},
+            {'name': 'response_index_count', 'type': int, 'doc': 'Stop index of the response', 'default': None},
             {'name': 'response', 'type': TimeSeries,
              'doc': 'The TimeSeries (usually a PatchClampSeries) with the response',
              'default': None},

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -208,7 +208,7 @@ class OpticalSeries(ImageSeries):
                      'orientation')
 
     @docval(*get_docval(ImageSeries.__init__, 'name'),  # required
-            {'name': 'distance', 'type': 'float', 'doc': 'Distance from camera/monitor to target/eye.'},  # required
+            {'name': 'distance', 'type': float, 'doc': 'Distance from camera/monitor to target/eye.'},  # required
             {'name': 'field_of_view', 'type': ('array_data', 'data', 'TimeSeries'), 'shape': ((2, ), (3, )),  # required
              'doc': 'Width, height and depth of image, or imaged area (meters).'},
             {'name': 'orientation', 'type': str,  # required

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -8,6 +8,7 @@ from hdmf.utils import docval, getargs, popargs, popargs_to_dict, get_docval
 
 from . import register_class, CORE_NAMESPACE
 from .base import TimeSeries
+from .ecephys import ElectrodeGroup
 from hdmf.common import DynamicTable, DynamicTableRegion
 
 

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -29,7 +29,7 @@ class AnnotationSeries(TimeSeries):
         name, data, timestamps = popargs('name', 'data', 'timestamps', kwargs)
         super().__init__(name=name, data=data, unit='n/a', resolution=-1.0, timestamps=timestamps, **kwargs)
 
-    @docval({'name': 'time', 'type': 'float', 'doc': 'The time for the annotation'},
+    @docval({'name': 'time', 'type': float, 'doc': 'The time for the annotation'},
             {'name': 'annotation', 'type': str, 'doc': 'the annotation'})
     def add_annotation(self, **kwargs):
         """Add an annotation."""
@@ -70,7 +70,7 @@ class AbstractFeatureSeries(TimeSeries):
         self.features = features
         self.feature_units = feature_units
 
-    @docval({'name': 'time', 'type': 'float', 'doc': 'the time point of this feature'},
+    @docval({'name': 'time', 'type': float, 'doc': 'the time point of this feature'},
             {'name': 'features', 'type': (list, np.ndarray), 'doc': 'the feature values for this time point'})
     def add_features(self, **kwargs):
         time, features = getargs('time', 'features', kwargs)
@@ -106,8 +106,8 @@ class IntervalSeries(TimeSeries):
         self.__interval_data = data
         super().__init__(name=name, data=data, unit='n/a', resolution=-1.0, timestamps=timestamps, **kwargs)
 
-    @docval({'name': 'start', 'type': 'float', 'doc': 'The start time of the interval'},
-            {'name': 'stop', 'type': 'float', 'doc': 'The stop time of the interval'})
+    @docval({'name': 'start', 'type': float, 'doc': 'The start time of the interval'},
+            {'name': 'stop', 'type': float, 'doc': 'The stop time of the interval'})
     def add_interval(self, **kwargs):
         start, stop = getargs('start', 'stop', kwargs)
         self.__interval_timestamps.append(start)
@@ -158,11 +158,11 @@ class Units(DynamicTable):
             {'name': 'description', 'type': str, 'doc': 'a description of what is in this table', 'default': None},
             {'name': 'electrode_table', 'type': DynamicTable,
              'doc': 'the table that the *electrodes* column indexes', 'default': None},
-            {'name': 'waveform_rate', 'type': 'float',
+            {'name': 'waveform_rate', 'type': float,
              'doc': 'Sampling rate of the waveform means', 'default': None},
             {'name': 'waveform_unit', 'type': str,
              'doc': 'Unit of measurement of the waveform means', 'default': 'volts'},
-            {'name': 'resolution', 'type': 'float',
+            {'name': 'resolution', 'type': float,
              'doc': 'The smallest possible difference between two spike times', 'default': None}
             )
     def __init__(self, **kwargs):
@@ -303,9 +303,9 @@ class DecompositionSeries(TimeSeries):
              'default': None},
             {'name': 'band_limits', 'type': ('array_data', 'data'), 'default': None,
              'doc': 'low and high frequencies of bandpass filter in Hz'},
-            {'name': 'band_mean', 'type': 'float', 'doc': 'the mean of Gaussian filters in Hz',
+            {'name': 'band_mean', 'type': float, 'doc': 'the mean of Gaussian filters in Hz',
              'default': None},
-            {'name': 'band_stdev', 'type': 'float', 'doc': 'the standard deviation of Gaussian filters in Hz',
+            {'name': 'band_stdev', 'type': float, 'doc': 'the standard deviation of Gaussian filters in Hz',
              'default': None},
             allow_extra=True)
     def add_band(self, **kwargs):

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -187,7 +187,7 @@ class Units(DynamicTable):
              'default': None, 'shape': (None, 2)},
             {'name': 'electrodes', 'type': 'array_data', 'doc': 'the electrodes that each unit came from',
              'default': None},
-            {'name': 'electrode_group', 'type': 'ElectrodeGroup', 'default': None,
+            {'name': 'electrode_group', 'type': ElectrodeGroup, 'default': None,
              'doc': 'the electrode group that each unit came from'},
             {'name': 'waveform_mean', 'type': 'array_data',
              'doc': 'the spike waveform mean for each unit. Shape is (time,) or (time, electrodes)',

--- a/src/pynwb/ogen.py
+++ b/src/pynwb/ogen.py
@@ -18,7 +18,7 @@ class OptogeneticStimulusSite(NWBContainer):
     @docval({'name': 'name', 'type': str, 'doc': 'The name of this stimulus site.'},
             {'name': 'device', 'type': Device, 'doc': 'The device that was used.'},
             {'name': 'description', 'type': str, 'doc': 'Description of site.'},
-            {'name': 'excitation_lambda', 'type': 'float', 'doc': 'Excitation wavelength in nm.'},
+            {'name': 'excitation_lambda', 'type': float, 'doc': 'Excitation wavelength in nm.'},
             {'name': 'location', 'type': str, 'doc': 'Location of stimulation site.'})
     def __init__(self, **kwargs):
         args_to_set = popargs_to_dict(('device', 'description', 'excitation_lambda', 'location'), kwargs)

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -21,7 +21,7 @@ class OpticalChannel(NWBContainer):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this electrode'},  # required
             {'name': 'description', 'type': str, 'doc': 'Any notes or comments about the channel.'},  # required
-            {'name': 'emission_lambda', 'type': 'float', 'doc': 'Emission wavelength for channel, in nm.'})  # required
+            {'name': 'emission_lambda', 'type': float, 'doc': 'Emission wavelength for channel, in nm.'})  # required
     def __init__(self, **kwargs):
         description, emission_lambda = popargs("description", "emission_lambda", kwargs)
         super().__init__(**kwargs)
@@ -50,17 +50,17 @@ class ImagingPlane(NWBContainer):
              'doc': 'One of possibly many groups storing channel-specific data.'},
             {'name': 'description', 'type': str, 'doc': 'Description of this ImagingPlane.'},  # required
             {'name': 'device', 'type': Device, 'doc': 'the device that was used to record'},  # required
-            {'name': 'excitation_lambda', 'type': 'float', 'doc': 'Excitation wavelength in nm.'},  # required
+            {'name': 'excitation_lambda', 'type': float, 'doc': 'Excitation wavelength in nm.'},  # required
             {'name': 'indicator', 'type': str, 'doc': 'Calcium indicator'},  # required
             {'name': 'location', 'type': str, 'doc': 'Location of image plane.'},  # required
-            {'name': 'imaging_rate', 'type': 'float',
+            {'name': 'imaging_rate', 'type': float,
              'doc': 'Rate images are acquired, in Hz. If the corresponding TimeSeries is present, the rate should be '
                     'stored there instead.', 'default': None},
             {'name': 'manifold', 'type': 'array_data',
              'doc': ('DEPRECATED: Physical position of each pixel. size=("height", "width", "xyz"). '
                      'Deprecated in favor of origin_coords and grid_spacing.'),
              'default': None},
-            {'name': 'conversion', 'type': 'float',
+            {'name': 'conversion', 'type': float,
              'doc': ('DEPRECATED: Multiplier to get from stored values to specified unit (e.g., 1e-3 for millimeters) '
                      'Deprecated in favor of origin_coords and grid_spacing.'),
              'default': 1.0},
@@ -134,8 +134,8 @@ class TwoPhotonSeries(ImageSeries):
             *get_docval(ImageSeries.__init__, 'data', 'unit', 'format'),
             {'name': 'field_of_view', 'type': (Iterable, TimeSeries), 'shape': ((2, ), (3, )),
              'doc': 'Width, height and depth of image, or imaged area (meters).', 'default': None},
-            {'name': 'pmt_gain', 'type': 'float', 'doc': 'Photomultiplier gain.', 'default': None},
-            {'name': 'scan_line_rate', 'type': 'float',
+            {'name': 'pmt_gain', 'type': float, 'doc': 'Photomultiplier gain.', 'default': None},
+            {'name': 'scan_line_rate', 'type': float,
              'doc': 'Lines imaged per second. This is also stored in /general/optophysiology but is kept '
                     'here as it is useful information for analysis, and so good to be stored w/ the actual data.',
              'default': None},

--- a/src/pynwb/retinotopy.py
+++ b/src/pynwb/retinotopy.py
@@ -42,7 +42,7 @@ class FocalDepthImage(RetinotopyImage):
     __nwbfields__ = ('focal_depth', )
 
     @docval(*get_docval(RetinotopyImage.__init__),
-            {'name': 'focal_depth', 'type': 'float', 'doc': 'Focal depth offset, in meters.'})
+            {'name': 'focal_depth', 'type': float, 'doc': 'Focal depth offset, in meters.'})
     def __init__(self, **kwargs):
         focal_depth = popargs('focal_depth', kwargs)
         super().__init__(**kwargs)


### PR DESCRIPTION
## Motivation

On the docsite, when type annotations are provided as a string, they render weird on the docsite, for example:
<img width="261" alt="Screen Shot 2022-07-30 at 10 49 10 AM" src="https://user-images.githubusercontent.com/7727566/181919707-6961211b-e2bc-4f4e-968a-09d01973e58a.png">

This is usually the case for `float` - searching for why this is points back to this PR:
https://github.com/NeurodataWithoutBorders/pynwb/pull/1043

^The original use of 'float' was to address an issue on Py3.5. Since pynwb is now tagged at python >= 3.7, this workaround is no longer needed, so it seems these types can revert back to the normal way, which should fix some of the rendering on the docsite. 

The first commit is explicitly updating 'float', the second updates some miscellaneous other type listing in the same way. 

## How to test the behavior?

There are no real code changes - as long as the tests pass and the generated docsite look fine, this should be good I think.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
