### PR TITLE
Fix flake8 in gallery due to upgrade of flake8 version

### DIFF
--- a/docs/gallery/advanced_io/iterative_write.py
+++ b/docs/gallery/advanced_io/iterative_write.py
@@ -160,7 +160,7 @@ def iter_sin(chunk_length=10, max_chunks=100):
     """
     x = 0
     num_chunks = 0
-    while(x < 0.5 and num_chunks < max_chunks):
+    while (x < 0.5 and num_chunks < max_chunks):
         val = np.asarray([sin(random() * 2 * pi) for i in range(chunk_length)])
         x = random()
         num_chunks += 1


### PR DESCRIPTION
## Motivation

Flake8 tests are failing in #1521 even though the PR doesn't modify any of the files in violation. As far as I can tell this is due to tests running a newer version of flake8, which appears to trigger some additional warnings. 

## How to test the behavior?

Upgrade falke8 to the latest version and run

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
