### PR TITLE
Add to nwb-overview website from the frontpage of the docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -7,7 +7,9 @@ NWB for Python
 ==============
 
 PyNWB is a Python package for working with NWB files. It provides a high-level API for
-efficiently working with Neurodata stored in the `NWB format <https://nwb-schema.readthedocs.io>`_.
+efficiently working with neurodata stored in the NWB format. If you are new to NWB
+and would like to learn more, then please also visit the :nwb_overview:`NWB Overview <>`
+website, which provides an entry point for researchers and developers interested in using NWB.
 
 `Neurodata Without Borders (NWB) <http://www.nwb.org/>`_ is a project to develop a
 unified data format for cellular-based neurophysiology data, focused on the


### PR DESCRIPTION
## Motivation

Participants at the NWB User Days 2022 suggested that the front-page of the PyNWB docs should link to the nwb-overview website (instead of the NWB schema) to make it easier for new users to find the documentation resources most appropriate  for them.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
