### PR TITLE
Fix broken link to install instructions in READM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ breaking down the barriers to data sharing in neuroscience.
 Installation
 ============
 
-See the PyNWB documentation for details http://pynwb.readthedocs.io/en/latest/getting_started.html#installation
+See the PyNWB documentation for details https://pynwb.readthedocs.io/en/stable/install_users.html
 
 Code of Conduct
 ===============


### PR DESCRIPTION
## Motivation

The link for the install instruction in the README points to the ``latest`` version of the docs (which as been removed from RTD). Instead the link should point to the ``stable`` version. This PR updates this link

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
