### PR TITLE
Fix HDMF intersphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -140,7 +140,7 @@ intersphinx_mapping = {
     'numpy': ('https://numpy.org/doc/stable/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'h5py': ('https://docs.h5py.org/en/latest/', None),
-    'hdmf': ('https://hdmf.readthedocs.io/en/latest/', None),
+    'hdmf': ('https://hdmf.readthedocs.io/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'dandi': ('https://dandi.readthedocs.io/en/stable/', None),
     'fsspec': ("https://filesystem-spec.readthedocs.io/en/latest/", None),


### PR DESCRIPTION
Tried to click on the `H5DataIO` button here: https://pynwb.readthedocs.io/en/stable/tutorials/advanced_io/h5dataio.html?highlight=h5dataio

It led to missing page: https://hdmf.readthedocs.io/en/latest/hdmf.backends.hdf5.h5_utils.html#hdmf.backends.hdf5.h5_utils.H5DataIO

Replacing 'latest' with 'stable' loaded the page: https://hdmf.readthedocs.io/en/stable/hdmf.backends.hdf5.h5_utils.html#hdmf.backends.hdf5.h5_utils.H5DataIO

Fixed the intersphinx in this PR