### PR TITLE
Add GH Action to gen test files, update script

### DIFF
--- a/.github/workflows/generate_test_files.yml
+++ b/.github/workflows/generate_test_files.yml
@@ -1,0 +1,42 @@
+name: Generate test files
+on:
+  workflow_dispatch:
+
+jobs:
+  gen-test-files:
+    name: ${{ matrix.os }}
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { name: pynwb-1.5.1, pynwb-version: "1.5.1", python-version: "3.8"}
+          - { name: pynwb-2.1.0, pynwb-version: "2.1.0", python-version: "3.9"}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install package
+        run: |
+          python -m pip install "pynwb==${{ matrix.pynwb-version }}"
+          python -m pip list
+
+      - name: Generate test files
+        run: |
+          python src/pynwb/testing/make_test_files.py
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-files
+          path: |
+            tests/back_compat/*.nwb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
   otherwise throws a warning when reading from a file. The new checks in `ImageSeries` when `external_file`
   is provided is used with this method to ensure that that files with invalid data can be read, but prohibits
   the user from creating new instances when these checks are violated. @weiglszonja (#1516)
+- Created a GitHub Actions workflow to generate test files for testing backward compatibility. @rly
+  [#1548](https://github.com/NeurodataWithoutBorders/pynwb/pull/1548)
 
 ## PyNWB 2.1.0 (July 6, 2022)
 

--- a/src/pynwb/testing/make_test_files.py
+++ b/src/pynwb/testing/make_test_files.py
@@ -168,5 +168,3 @@ if __name__ == '__main__':
         _make_imageseries_no_data()
         _make_imageseries_non_external_format()
         _make_imageseries_nonmatch_starting_frame()
-
-

--- a/src/pynwb/testing/make_test_files.py
+++ b/src/pynwb/testing/make_test_files.py
@@ -19,7 +19,7 @@ def _write(test_name, nwbfile):
     return filename
 
 
-def make_nwbfile_empty():
+def _make_empty():
     nwbfile = NWBFile(session_description='ADDME',
                       identifier='ADDME',
                       session_start_time=datetime.now().astimezone())
@@ -27,7 +27,7 @@ def make_nwbfile_empty():
     _write(test_name, nwbfile)
 
 
-def make_nwbfile_str_experimenter():
+def _make_str_experimenter():
     nwbfile = NWBFile(session_description='ADDME',
                       identifier='ADDME',
                       session_start_time=datetime.now().astimezone(),
@@ -36,7 +36,7 @@ def make_nwbfile_str_experimenter():
     _write(test_name, nwbfile)
 
 
-def make_nwbfile_str_pub():
+def _make_str_pub():
     nwbfile = NWBFile(session_description='ADDME',
                       identifier='ADDME',
                       session_start_time=datetime.now().astimezone(),
@@ -45,7 +45,7 @@ def make_nwbfile_str_pub():
     _write(test_name, nwbfile)
 
 
-def make_nwbfile_timeseries_no_data():
+def _make_timeseries_no_data():
     nwbfile = NWBFile(session_description='ADDME',
                       identifier='ADDME',
                       session_start_time=datetime.now().astimezone())
@@ -60,7 +60,7 @@ def make_nwbfile_timeseries_no_data():
     _write(test_name, nwbfile)
 
 
-def make_nwbfile_timeseries_no_unit():
+def _make_timeseries_no_unit():
     nwbfile = NWBFile(session_description='ADDME',
                       identifier='ADDME',
                       session_start_time=datetime.now().astimezone())
@@ -75,7 +75,8 @@ def make_nwbfile_timeseries_no_unit():
     _write(test_name, nwbfile)
 
 
-def make_nwbfile_imageseries_no_data():
+def _make_imageseries_no_data():
+    """Create a test file with an ImageSeries with no data."""
     nwbfile = NWBFile(session_description='ADDME',
                       identifier='ADDME',
                       session_start_time=datetime.now().astimezone())
@@ -83,7 +84,7 @@ def make_nwbfile_imageseries_no_data():
         name='test_imageseries',
         external_file=['external_file'],
         starting_frame=[1, 2, 3],
-        format='tiff',
+        format='external',
         timestamps=[1., 2., 3.]
     )
 
@@ -93,7 +94,7 @@ def make_nwbfile_imageseries_no_data():
     _write(test_name, nwbfile)
 
 
-def make_nwbfile_imageseries_no_unit():
+def _make_imageseries_no_unit():
     """Create a test file with an ImageSeries with data and no unit."""
     nwbfile = NWBFile(session_description='ADDME',
                       identifier='ADDME',
@@ -101,9 +102,6 @@ def make_nwbfile_imageseries_no_unit():
     image_series = ImageSeries(
         name='test_imageseries',
         data=np.ones((3, 3, 3)),
-        external_file=['external_file'],
-        starting_frame=[1, 2, 3],
-        format='tiff',
         timestamps=[1., 2., 3.]
     )
 
@@ -113,15 +111,62 @@ def make_nwbfile_imageseries_no_unit():
     _write(test_name, nwbfile)
 
 
+def _make_imageseries_non_external_format():
+    """Create a test file with an ImageSeries with external_file set and format != 'external'."""
+    nwbfile = NWBFile(session_description='ADDME',
+                      identifier='ADDME',
+                      session_start_time=datetime.now().astimezone())
+    image_series = ImageSeries(
+        name='test_imageseries',
+        external_file=['external_file'],
+        starting_frame=[1],
+        format='tiff',
+        timestamps=[1., 2., 3.]
+    )
+
+    nwbfile.add_acquisition(image_series)
+
+    test_name = 'imageseries_non_external_format'
+    _write(test_name, nwbfile)
+
+
+def _make_imageseries_nonmatch_starting_frame():
+    """Create a test file with an ImageSeries where len(starting_frame) != len(external_file)."""
+    nwbfile = NWBFile(session_description='ADDME',
+                      identifier='ADDME',
+                      session_start_time=datetime.now().astimezone())
+    image_series = ImageSeries(
+        name='test_imageseries',
+        external_file=['external_file'],
+        starting_frame=[1, 2, 3],
+        format='external',
+        timestamps=[1., 2., 3.]
+    )
+
+    nwbfile.add_acquisition(image_series)
+
+    test_name = 'imageseries_nonmatch_starting_frame'
+    _write(test_name, nwbfile)
+
+
 if __name__ == '__main__':
+    # install these versions of PyNWB and run this script to generate new files
+    # python src/pynwb/testing/make_test_files.py
 
     if __version__ == '1.1.2':
-        make_nwbfile_empty()
-        make_nwbfile_str_experimenter()
-        make_nwbfile_str_pub()
+        _make_empty()
+        _make_str_experimenter()
+        _make_str_pub()
 
     if __version__ == '1.5.1':
-        make_nwbfile_timeseries_no_data()
-        make_nwbfile_timeseries_no_unit()
-        make_nwbfile_imageseries_no_data()
-        make_nwbfile_imageseries_no_unit()
+        _make_timeseries_no_data()
+        _make_timeseries_no_unit()
+        _make_imageseries_no_data()
+        _make_imageseries_no_unit()
+
+    if __version__ == '2.1.0':
+        _make_imageseries_no_data()
+        _make_imageseries_non_external_format()
+        _make_imageseries_nonmatch_starting_frame()
+
+


### PR DESCRIPTION
## Motivation

To generate test files using older versions of PyNWB, I need to be able to install and run older versions. However, some older versions cannot be installed on Mac M1 machines because the wheels do not exist and are not easily built. This PR creates a GitHub Actions workflow to generate the test files on an ubuntu machine and store them on GitHub temporarily. I can then download the files and test them locally.

## How to test the behavior?
Trigger the new GitHub Action after merging into dev


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
