### PR TITLE
Update requirements-min.txt

### DIFF
--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,7 +1,7 @@
 # minimum versions of package dependencies for installing PyNWB
-h5py==2.10  # support for selection of datasets with list of indices added in 2.10
-hdmf==3.4.0
-numpy==1.16
-pandas==1.1.5
-python-dateutil==2.7.3
+h5py>=2.10  # support for selection of datasets with list of indices added in 2.10
+hdmf>=3.4.0
+numpy>=1.16
+pandas>=1.1.5
+python-dateutil>=2.7.3
 setuptools


### PR DESCRIPTION
I think min requirements should be gte. That way they don't cause conflicts with other packages.
