### PR TITLE
Add driver argument to new validation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed pending deprecations and issues in CI. @rly [#1594](https://github.com/NeurodataWithoutBorders/pynwb/pull/1594)
 - Added ``NWBHDF5IO.nwb_version`` property to get the NWB version from an NWB HDF5 file @oruebel [#1612](https://github.com/NeurodataWithoutBorders/pynwb/pull/1612)
 - Updated ``NWBHDF5IO.read`` to check NWB version before read and raise more informative error if an unsupported version is found @oruebel [#1612](https://github.com/NeurodataWithoutBorders/pynwb/pull/1612)
+- Added the `driver` keyword argument to the `pynwb.validate` function as well as the corresponding namespace caching. @CodyCBakerPhD [#1588](https://github.com/NeurodataWithoutBorders/pynwb/pull/1588)
 
 ### Documentation and tutorial enhancements:
 - Adjusted [ecephys tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/ecephys.html) to create fake data with proper dimensions @bendichter [#1581](https://github.com/NeurodataWithoutBorders/pynwb/pull/1581)
@@ -32,9 +33,6 @@
 - Updated the [images tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/images.html) to provide example usage of an ``IndexSeries``
   with a reference to ``Images``. @bendichter [#1602](https://github.com/NeurodataWithoutBorders/pynwb/pull/1602)
 - Fixed an issue with the `tox` tool when upgrading to tox 4. @rly [#1608](https://github.com/NeurodataWithoutBorders/pynwb/pull/1608)
-
-### 
-- Added the `driver` keyword argument to the `pynwb.validate` function as well as the corresponding namespace caching. @CodyCBakerPhD [#1588](https://github.com/NeurodataWithoutBorders/pynwb/pull/1588)
 
 ## PyNWB 2.2.0 (October 19, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Refactored testing documentation, including addition of section on ``pynwb.testing.mock`` submodule. @bendichter 
   [#1583](https://github.com/NeurodataWithoutBorders/pynwb/pull/1583)
 
+### 
+- Added the `driver` keyword argument to the `pynwb.validate` function as well as the corresponding namespace caching. @CodyCBakerPhD [#1588](https://github.com/NeurodataWithoutBorders/pynwb/pull/1588)
+
 ## PyNWB 2.2.0 (October 19, 2022)
 
 ### Enhancements and minor changes

--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -29,7 +29,9 @@ def _validate_helper(io: HDMFIO, namespace: str = CORE_NAMESPACE) -> list:
     return validator.validate(builder)
 
 
-def _get_cached_namespaces_to_validate(path: str, driver: Optional[str] = None) -> Tuple[List[str], BuildManager, Dict[str, str]]:
+def _get_cached_namespaces_to_validate(
+    path: str, driver: Optional[str] = None
+) -> Tuple[List[str], BuildManager, Dict[str, str]]:
     """
     Determine the most specific namespace(s) that are cached in the given NWBFile that can be used for validation.
 
@@ -138,7 +140,9 @@ def validate(**kwargs):
         io_kwargs = dict(path=path, mode="r", driver=driver)
 
         if use_cached_namespaces:
-            cached_namespaces, manager, namespace_dependencies = _get_cached_namespaces_to_validate(path=path, driver=driver)
+            cached_namespaces, manager, namespace_dependencies = _get_cached_namespaces_to_validate(
+                path=path, driver=driver
+            )
             io_kwargs.update(manager=manager)
 
             if any(cached_namespaces):

--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -111,7 +111,7 @@ def _get_cached_namespaces_to_validate(
     },
     {
         "name": "driver",
-        "type": list,
+        "type": str,
         "doc": "Driver for h5py to use when opening the HDF5 file.",
         "default": None,
     },

--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -112,7 +112,7 @@ def _get_cached_namespaces_to_validate(path: str, driver: Optional[str] = None) 
         "type": list,
         "doc": "Driver for h5py to use when opening the HDF5 file.",
         "default": None,
-    }
+    },
     returns="Validation errors in the file.",
     rtype=(list, (list, bool)),
     is_method=False,

--- a/tests/integration/ros3/test_ros3.py
+++ b/tests/integration/ros3/test_ros3.py
@@ -72,7 +72,9 @@ class TestRos3Streaming(TestCase):
                 )
             }
         }
-        found_namespaces, _, found_namespace_dependencies = _get_cached_namespaces_to_validate(path=self.s3_test_path, driver="ros3")
+        found_namespaces, _, found_namespace_dependencies = _get_cached_namespaces_to_validate(
+            path=self.s3_test_path, driver="ros3"
+        )
 
         self.assertCountEqual(first=found_namespaces, second=expected_namespaces)
         self.assertDictEqual(d1=expected_namespace_dependencies, d2=expected_namespace_dependencies)

--- a/tests/integration/ros3/test_ros3.py
+++ b/tests/integration/ros3/test_ros3.py
@@ -1,4 +1,6 @@
 from pynwb import NWBHDF5IO
+from pynwb import validate
+from pynwb.validate import _get_cached_namespaces_to_validate
 from pynwb.testing import TestCase
 import urllib.request
 import h5py
@@ -10,6 +12,11 @@ class TestRos3Streaming(TestCase):
 
     This test module requires h5py to be built with the ROS3 driver: conda install -c conda-forge h5py
     """
+    @classmethod
+    def setUpClass(cls):
+        # this is the NWB Test Data dandiset #000126 sub-1/sub-1.nwb
+        cls.s3_test_path = "https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991"
+
     def setUp(self):
         # Skip ROS3 tests if internet is not available or the ROS3 driver is not installed
         try:
@@ -27,10 +34,51 @@ class TestRos3Streaming(TestCase):
             self.assertEqual(len(test_data), 3)
 
     def test_dandi_read(self):
-        # this is the NWB Test Data dandiset #000126 sub-1/sub-1.nwb
-        s3_path = 'https://dandiarchive.s3.amazonaws.com/blobs/11e/c89/11ec8933-1456-4942-922b-94e5878bb991'
-
-        with NWBHDF5IO(s3_path, mode='r', driver='ros3') as io:
+        with NWBHDF5IO(path=self.s3_test_path, mode='r', driver='ros3') as io:
             nwbfile = io.read()
             test_data = nwbfile.acquisition['TestData'].data[:]
             self.assertEqual(len(test_data), 3)
+
+    def test_dandi_get_cached_namespaces(self):
+        expected_namespaces = ["core"]
+        expected_namespace_dependencies = {
+            'core': {
+                'hdmf-common': (
+                    'AlignedDynamicTable',
+                    'CSRMatrix',
+                    'Container',
+                    'Data',
+                    'DynamicTable',
+                    'DynamicTableRegion',
+                    'ElementIdentifiers',
+                    'SimpleMultiContainer',
+                    'VectorData',
+                    'VectorIndex'
+                )
+            },
+            'hdmf-common': {},
+            'hdmf-experimental': {
+                'hdmf-common': (
+                    'AlignedDynamicTable',
+                    'CSRMatrix',
+                    'Container',
+                    'Data',
+                    'DynamicTable',
+                    'DynamicTableRegion',
+                    'ElementIdentifiers',
+                    'SimpleMultiContainer',
+                    'VectorData',
+                    'VectorIndex'
+                )
+            }
+        }
+        found_namespaces, _, found_namespace_dependencies = _get_cached_namespaces_to_validate(path=self.s3_test_path, driver="ros3")
+
+        self.assertCountEqual(first=found_namespaces, second=expected_namespaces)
+        self.assertDictEqual(d1=expected_namespace_dependencies, d2=expected_namespace_dependencies)
+
+    def test_dandi_validate(self):
+        result, status = validate(paths=[self.s3_test_path], driver="ros3")
+
+        assert result == []
+        assert status == 0


### PR DESCRIPTION
When working on https://github.com/NeurodataWithoutBorders/nwbinspector/pull/265 (the integration of the recent validation changes into the NWB Inspector) I ran into an issue getting the cached namespaces for files when using the streaming mode of the Inspector.

Traced it back to these particular function calls - thankfully, `NWBHDF5IO.load_namespaces(...)` already supports a `driver` keyword argument, we just need to add control and propagate it as shown here.

@rly What would your recommendations be for adding tests for this?