### PR TITLE
Remove redundant mapper functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,13 @@
 
 ### Enhancements and minor changes
 - `Subject.age` can be input as a `timedelta`. @bendichter [#1590](https://github.com/NeurodataWithoutBorders/pynwb/pull/1590)
+- Remove redundant object mapper code. @rly [#1600](https://github.com/NeurodataWithoutBorders/pynwb/pull/1600)
 
 ### Documentation and tutorial enhancements:
 - Adjusted [ecephys tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/ecephys.html) to create fake data with proper dimensions @bendichter [#1581](https://github.com/NeurodataWithoutBorders/pynwb/pull/1581)
-- Refactored testing documentation, including addition of section on ``pynwb.testing.mock`` submodule. @bendichter 
+- Refactored testing documentation, including addition of section on ``pynwb.testing.mock`` submodule. @bendichter
   [#1583](https://github.com/NeurodataWithoutBorders/pynwb/pull/1583)
-- Update round trip tutorial to the newer ``NWBH5IOMixin`` and ``AcquisitionH5IOMixin`` classes. @bendichter 
+- Update round trip tutorial to the newer ``NWBH5IOMixin`` and ``AcquisitionH5IOMixin`` classes. @bendichter
   [#1586](https://github.com/NeurodataWithoutBorders/pynwb/pull/1586)
 - More informative error message for common installation error. @bendichter, @rly
   [#1591](https://github.com/NeurodataWithoutBorders/pynwb/pull/1591)

--- a/src/pynwb/io/base.py
+++ b/src/pynwb/io/base.py
@@ -15,10 +15,6 @@ class ModuleMap(NWBContainerMapper):
         self.map_spec('data_interfaces', containers_spec)
         self.map_spec('data_interfaces', table_spec)
 
-    @NWBContainerMapper.constructor_arg('name')
-    def name(self, builder, manager):
-        return builder.name
-
 
 @register_map(TimeSeries)
 class TimeSeriesMap(NWBContainerMapper):
@@ -43,10 +39,6 @@ class TimeSeriesMap(NWBContainerMapper):
         # TODO map the sync group to something
         sync_spec = self.spec.get_group('sync')
         self.unmap(sync_spec)
-
-    @NWBContainerMapper.constructor_arg('name')
-    def name(self, builder, manager):
-        return builder.name
 
     @NWBContainerMapper.object_attr("timestamps")
     def timestamps_attr(self, container, manager):

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -29,14 +29,7 @@ class NWBContainerMapper(NWBBaseTypeMapper):
 
 @register_map(NWBData)
 class NWBDataMap(NWBBaseTypeMapper):
-
-    @ObjectMapper.constructor_arg('name')
-    def carg_name(self, builder, manager):
-        return builder.name
-
-    # @ObjectMapper.constructor_arg('data')
-    # def carg_data(self, builder, manager):
-    #     return builder.data
+    pass
 
 
 @register_map(ScratchData)


### PR DESCRIPTION
## Motivation

See https://github.com/NeurodataWithoutBorders/helpdesk/discussions/37#discussioncomment-4162108

These `name` mapper functions are handled by `ObjectMapper` automatically and appear to be legacy code that adds confusion.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
