### PR TITLE
Update citation for PyNWB to eLife paper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   [#1586](https://github.com/NeurodataWithoutBorders/pynwb/pull/1586)
 - More informative error message for common installation error. @bendichter, @rly
   [#1591](https://github.com/NeurodataWithoutBorders/pynwb/pull/1591)
+- Update citation for PyNWB in docs and duecredit to use the eLife NWB paper. @oruebel [#1604](https://github.com/NeurodataWithoutBorders/pynwb/pull/1604)
   
 ### Bug fixes
 - Add shape constraint to `PatchClampSeries.data`. @bendichter 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - More informative error message for common installation error. @bendichter, @rly
   [#1591](https://github.com/NeurodataWithoutBorders/pynwb/pull/1591)
 - Update citation for PyNWB in docs and duecredit to use the eLife NWB paper. @oruebel [#1604](https://github.com/NeurodataWithoutBorders/pynwb/pull/1604)
+- Fix docs build warnings due to use of hardcoded links. @oruebel [#1604](https://github.com/NeurodataWithoutBorders/pynwb/pull/1604)
   
 ### Bug fixes
 - Add shape constraint to `PatchClampSeries.data`. @bendichter 

--- a/docs/gallery/domain/plot_behavior.py
+++ b/docs/gallery/domain/plot_behavior.py
@@ -243,8 +243,7 @@ behavior_module.add(behavioral_events)
 ####################
 # Storing only the timestamps of the events is possible with the `ndx-events <https://pypi.org/project/ndx-events/>`_
 # NWB extension. You can also add labels associated with the events with this extension.
-# You can find information about installation and example usage `here
-# <https://github.com/nwb-extensions/ndx-events-record>`_.
+# You can find information about installation and example usage :nwb_extension:`here <ndx-events-record>`.
 #
 # .. seealso::
 #    You can learn more about using extensions in the :ref:`tutorial-extending-nwb` tutorial.

--- a/docs/source/make_a_release.rst
+++ b/docs/source/make_a_release.rst
@@ -16,7 +16,7 @@ A core developer should use the following steps to create a release ``X.Y.Z`` of
 Prerequisites
 -------------
 
-* All CI tests are passing on `GitHub Actions`_.
+* All CI tests are passing on :pynwb:`GitHub Actions <actions>`.
 
 * You have a `GPG signing key`_.
 
@@ -61,7 +61,7 @@ means that ``echo "Hello"`` should be copied and evaluated in the terminal.
 Publish release on PyPI: Step-by-step
 -------------------------------------
 
-1. Make sure that all CI tests are passing on `GitHub Actions`_.
+1. Make sure that all CI tests are passing on :pynwb:`GitHub Actions <actions>`.
 
 
 2. List all tags sorted by version.
@@ -109,19 +109,19 @@ Publish release on PyPI: Step-by-step
 
   .. important::
 
-      This will trigger the "Deploy release" GitHub Actions workflow which will automatically upload the wheels
-      and source distribution to both the `PyNWB PyPI project page`_ and a new `GitHub release`_
-      using the nwb-bot account.
+      This will trigger the "Deploy release" GitHub Actions workflow which will automatically
+      upload the wheels and source distribution to both the  `PyNWB PyPI project page`_ and a
+      new :pynwb:`GitHub release <releases>` using the nwb-bot account.
 
 
-7. Check the status of the builds on `GitHub Actions`_.
+7. Check the status of the builds on :pynwb:`GitHub Actions <actions>`.
 
 
 8. Once the builds are completed, check that the distributions are available on `PyNWB PyPI project page`_ and that
-   a new `GitHub release`_ was created.
+   a new :pynwb:`GitHub release <releases>` was created.
 
 
-9. Copy the release notes from ``CHANGELOG.md`` to the newly created `GitHub release`_.
+9. Copy the release notes from ``CHANGELOG.md`` to the newly created :pynwb:`GitHub release <releases>`.
 
 
 10. Create a clean testing environment to test the installation.
@@ -157,8 +157,6 @@ Publish release on PyPI: Step-by-step
 
 .. _GPG signing key: https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key
 .. _ReadTheDocs project: https://readthedocs.org/projects/pynwb/builds/
-.. _GitHub Actions: https://github.com/NeurodataWithoutBorders/pynwb/actions
-.. _GitHub release: https://github.com/NeurodataWithoutBorders/pynwb/releases
 .. _PyNWB PyPI project page: https://pypi.org/project/pynwb
 .. _Python instructions for creating a virtual environment: https://docs.python.org/3/library/venv.html#creating-virtual-environments
 

--- a/docs/source/make_a_release.rst
+++ b/docs/source/make_a_release.rst
@@ -159,6 +159,7 @@ Publish release on PyPI: Step-by-step
 .. _ReadTheDocs project: https://readthedocs.org/projects/pynwb/builds/
 .. _PyNWB PyPI project page: https://pypi.org/project/pynwb
 .. _Python instructions for creating a virtual environment: https://docs.python.org/3/library/venv.html#creating-virtual-environments
+.. _PyPI: https://pypi.org/project/pynwb
 
 
 --------------------------------------------

--- a/docs/source/overview_citing.rst
+++ b/docs/source/overview_citing.rst
@@ -10,18 +10,27 @@ If you use PyNWB in your research, please use the following citation:
 
 .. code-block:: bibtex
 
-    @article {R{\"u}bel2021.03.13.435173,
-     author = {R{\"u}bel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K. and Ghosh, Satrajit and Niu, Lawrence and Soltesz, Ivan and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E.},
-     title = {The Neurodata Without Borders ecosystem for neurophysiological data science},
-     elocation-id = {2021.03.13.435173},
-     year = {2021},
-     doi = {10.1101/2021.03.13.435173},
-     publisher = {Cold Spring Harbor Laboratory},
-     abstract = {The neurophysiology of cells and tissues are monitored electrophysiologically and optically in diverse experiments and species, ranging from flies to humans. Understanding the brain requires integration of data across this diversity, and thus these data must be findable, accessible, interoperable, and reusable (FAIR). This requires a standard language for data and metadata that can coevolve with neuroscience. We describe design and implementation principles for a language for neurophysiology data. Our software (Neurodata Without Borders, NWB) defines and modularizes the interdependent, yet separable, components of a data language. We demonstrate NWB{\textquoteright}s impact through unified description of neurophysiology data across diverse modalities and species. NWB exists in an ecosystem which includes data management, analysis, visualization, and archive tools. Thus, the NWB data language enables reproduction, interchange, and reuse of diverse neurophysiology data. More broadly, the design principles of NWB are generally applicable to enhance discovery across biology through data FAIRness.Competing Interest StatementThe authors have declared no competing interest.},
-     URL = {https://www.biorxiv.org/content/early/2021/03/15/2021.03.13.435173},
-     eprint = {https://www.biorxiv.org/content/early/2021/03/15/2021.03.13.435173.full.pdf},
-     journal = {bioRxiv}
-    }
+   @article {10.7554/eLife.78362,
+        article_type = {journal},
+        title = {{The Neurodata Without Borders ecosystem for neurophysiological data science}},
+        author = {R\"ubel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K. and
+                 Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and
+                 Ng, Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E.},
+        editor = {Colgin, Laura L and Jadhav, Shantanu P},
+        volume = {11{,
+        year = {2022},
+        month = {oct},
+        pub_date = {2022-10-04},
+        pages = {e78362},
+        citation = {eLife 2022;11:e78362},
+        doi = {10.7554/eLife.78362},
+        url = {https://doi.org/10.7554/eLife.78362},
+        keywords = {Neurophysiology, data ecosystem, data language, data standard, FAIR data, archive},
+        journal = {eLife},
+        issn = {2050-084X},
+        publisher = {eLife Sciences Publications, Ltd},
+  }
+
 
 Using RRID
 ----------

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -10,33 +10,27 @@ Continuous Integration
 
 PyNWB is tested against Ubuntu, macOS, and Windows operating systems.
 The project has both unit and integration tests.
-Tests run on `GitHub Actions`_.
+Tests run on :pynwb:`GitHub Actions <actions>`.
 
-Each time a PR is published or updated, the project is built, packaged, and tested on all supported operating systems
-and python distributions. That way, as a contributor, you know if you introduced regressions or coding style
+Each time a PR is published or updated, the project is built, packaged, and
+tested on all supported operating systems and python distributions. That way,
+as a contributor, you know if you introduced regressions or coding style
 inconsistencies.
 
-There are badges in the README_ file which shows the current condition of the dev branch.
-
-.. _GitHub Actions: https://github.com/NeurodataWithoutBorders/pynwb/actions
-.. _README: https://github.com/NeurodataWithoutBorders/pynwb#readme
-
+There are badges in the :pynwb:`README <#readme>` file which shows
+the current condition of the dev branch.
 
 --------
 Coverage
 --------
 
-Code coverage is computed and reported using the coverage_ tool. There are two coverage-related badges in the README_
-file. One shows the status of the `GitHub Action workflow`_ which runs the coverage_ tool and uploads the report to
+Code coverage is computed and reported using the coverage_ tool. There are two coverage-related
+badges in the :pynwb:`README <#readme>` file. One shows the status of the :pynwb:`GitHub Action workflow <actions?query=workflow%3A%22Run+coverage%22>` which runs the coverage_ tool and uploads the report to
 codecov_, and the other badge shows the percentage coverage reported from codecov_. A detailed report can be found on
 codecov_, which shows line by line which lines are covered by the tests.
 
 .. _coverage: https://coverage.readthedocs.io
-.. _GitHub Action workflow: https://github.com/NeurodataWithoutBorders/pynwb/actions?query=workflow%3A%22Run+coverage%22
 .. _codecov: https://codecov.io/gh/NeurodataWithoutBorders/pynwb/tree/dev/src/pynwb
-
-..  _software_process_requirement_specifications:
-
 
 --------------------------
 Requirement Specifications
@@ -61,7 +55,7 @@ The final one is within :pynwb:`setup.py <blob/dev/setup.py>`, which contains a 
 running PyNWB.
 
 In order to check the status of the required packages, requires.io_ is used to create a badge on the project
-README_. If all the required packages are up to date, a green badge appears.
+:pynwb:`README <#readme>`. If all the required packages are up to date, a green badge appears.
 
 If some of the packages are outdated, see :ref:`update_requirements_files`.
 
@@ -86,7 +80,6 @@ thus do not serve as a complete installation. For a complete source code archive
 by CircleCI, typically named `pynwb-{version}.tar.gz`.
 
 .. _versioneer: https://github.com/warner/python-versioneer
-.. _release: https://github.com/NeurodataWithoutBorders/pynwb/releases
 
 ----------------------------------------------------
 Coordinating with nwb-schema Repository and Releases

--- a/docs/source/testing/make_roundtrip_test.rst
+++ b/docs/source/testing/make_roundtrip_test.rst
@@ -164,9 +164,9 @@ Continuing from the :py:class:`~pynwb.base.TimeSeries` example, lets add ``setUp
 
 .. _rt_below:
 
------------------------
+------------------------
 ``AcquisitionH5IOMixin``
------------------------
+------------------------
 
 If you are testing something that can go in *acquisition*, you can avoid writing ``addContainer`` and ``getContainer``
 by extending :py:class:`~pynwb.testing.testh5io.AcquisitionH5IOMixin`.  This class has already overridden these

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -313,7 +313,7 @@ article_type = {journal},
 title = {{The Neurodata Without Borders ecosystem for neurophysiological data science}},
 author = {R\"ubel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K and Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and Ng, Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E},
 editor = {Colgin, Laura L and Jadhav, Shantanu P},
-volume = {11{,
+volume = {11},
 year = {2022},
 month = {oct},
 pub_date = {2022-10-04},
@@ -324,8 +324,7 @@ url = {https://doi.org/10.7554/eLife.78362},
 keywords = {Neurophysiology, data ecosystem, data language, data standard, FAIR data, archive},
 journal = {eLife},
 issn = {2050-084X},
-publisher = {eLife Sciences Publications, Ltd},
-}
+publisher = {eLife Sciences Publications, Ltd}}
 """), description="The Neurodata Without Borders ecosystem for neurophysiological data science",  # noqa: E501
          path="pynwb/", version=__version__, cite_module=True)
 del due, BibTeX

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -308,17 +308,23 @@ __version__ = _version.get_versions()['version']
 
 from ._due import due, BibTeX  # noqa: E402
 due.cite(BibTeX("""
-@article {R{\"u}bel2021.03.13.435173,
-    author = {R{\"u}bel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K. and Ghosh, Satrajit and Niu, Lawrence and Soltesz, Ivan and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E.},
-    title = {The Neurodata Without Borders ecosystem for neurophysiological data science},
-    elocation-id = {2021.03.13.435173},
-    year = {2021},
-    doi = {10.1101/2021.03.13.435173},
-    publisher = {Cold Spring Harbor Laboratory},
-    abstract = {The neurophysiology of cells and tissues are monitored electrophysiologically and optically in diverse experiments and species, ranging from flies to humans. Understanding the brain requires integration of data across this diversity, and thus these data must be findable, accessible, interoperable, and reusable (FAIR). This requires a standard language for data and metadata that can coevolve with neuroscience. We describe design and implementation principles for a language for neurophysiology data. Our software (Neurodata Without Borders, NWB) defines and modularizes the interdependent, yet separable, components of a data language. We demonstrate NWB{\textquoteright}s impact through unified description of neurophysiology data across diverse modalities and species. NWB exists in an ecosystem which includes data management, analysis, visualization, and archive tools. Thus, the NWB data language enables reproduction, interchange, and reuse of diverse neurophysiology data. More broadly, the design principles of NWB are generally applicable to enhance discovery across biology through data FAIRness.Competing Interest StatementThe authors have declared no competing interest.},
-    URL = {https://www.biorxiv.org/content/early/2021/03/15/2021.03.13.435173},
-    eprint = {https://www.biorxiv.org/content/early/2021/03/15/2021.03.13.435173.full.pdf},
-    journal = {bioRxiv}
+@article {10.7554/eLife.78362,
+article_type = {journal},
+title = {{The Neurodata Without Borders ecosystem for neurophysiological data science}},
+author = {R\"ubel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K and Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and Ng, Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E},
+editor = {Colgin, Laura L and Jadhav, Shantanu P},
+volume = {11{,
+year = {2022},
+month = {oct},
+pub_date = {2022-10-04},
+pages = {e78362},
+citation = {eLife 2022;11:e78362},
+doi = {10.7554/eLife.78362},
+url = {https://doi.org/10.7554/eLife.78362},
+keywords = {Neurophysiology, data ecosystem, data language, data standard, FAIR data, archive},
+journal = {eLife},
+issn = {2050-084X},
+publisher = {eLife Sciences Publications, Ltd},
 }
 """), description="The Neurodata Without Borders ecosystem for neurophysiological data science",  # noqa: E501
          path="pynwb/", version=__version__, cite_module=True)

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -307,11 +307,14 @@ from . import _version    # noqa: F401,E402
 __version__ = _version.get_versions()['version']
 
 from ._due import due, BibTeX  # noqa: E402
-due.cite(BibTeX("""
+due.cite(
+    BibTeX("""
 @article {10.7554/eLife.78362,
 article_type = {journal},
 title = {{The Neurodata Without Borders ecosystem for neurophysiological data science}},
-author = {R\"ubel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K and Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and Ng, Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E},
+author = {R\"ubel, Oliver and Tritt, Andrew and Ly, Ryan and Dichter, Benjamin K and
+          Ghosh, Satrajit and Niu, Lawrence and Baker, Pamela and Soltesz, Ivan and Ng,
+          Lydia and Svoboda, Karel and Frank, Loren and Bouchard, Kristofer E},
 editor = {Colgin, Laura L and Jadhav, Shantanu P},
 volume = {11},
 year = {2022},
@@ -325,6 +328,9 @@ keywords = {Neurophysiology, data ecosystem, data language, data standard, FAIR 
 journal = {eLife},
 issn = {2050-084X},
 publisher = {eLife Sciences Publications, Ltd}}
-"""), description="The Neurodata Without Borders ecosystem for neurophysiological data science",  # noqa: E501
-         path="pynwb/", version=__version__, cite_module=True)
+"""),
+    description="The Neurodata Without Borders ecosystem for neurophysiological data science",
+    path="pynwb/", version=__version__,
+    cite_module=True
+)
 del due, BibTeX


### PR DESCRIPTION
## Motivation

Fix #1605  
Fix #1606

* Update the citation for PyNWB to point users to the eLife paper rather than the pre-print. 
    * Update citation in the docs
    * Update citation for duecredit
* Fix hardcoded link warnings in the docs build


## Checklist

- [X] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
