### PR TITLE
Adjust toxfile for tox 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements and minor changes
 - `Subject.age` can be input as a `timedelta`. @bendichter [#1590](https://github.com/NeurodataWithoutBorders/pynwb/pull/1590)
-- Add module `pynwb.testing.mock.icephys` and corresponding tests. @bendichter 
+- Add module `pynwb.testing.mock.icephys` and corresponding tests. @bendichter
   [1595](https://github.com/NeurodataWithoutBorders/pynwb/pull/1595)
 - Remove redundant object mapper code. @rly [#1600](https://github.com/NeurodataWithoutBorders/pynwb/pull/1600)
 - Fix pending deprecations and issues in CI. @rly [#1594](https://github.com/NeurodataWithoutBorders/pynwb/pull/1594)
@@ -17,12 +17,14 @@
   [#1586](https://github.com/NeurodataWithoutBorders/pynwb/pull/1586)
 - More informative error message for common installation error. @bendichter, @rly
   [#1591](https://github.com/NeurodataWithoutBorders/pynwb/pull/1591)
-  
+
 ### Bug fixes
-- Add shape constraint to `PatchClampSeries.data`. @bendichter 
+- Add shape constraint to `PatchClampSeries.data`. @bendichter
   [#1596](https://github.com/NeurodataWithoutBorders/pynwb/pull/1596)
 - Update the [images tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/images.html) to provide example usage of an ``IndexSeries``
   with a reference to ``Images``. @bendichter [#1602](https://github.com/NeurodataWithoutBorders/pynwb/pull/1602)
+- Fixed an issue with the `tox` tool when upgrading to tox 4. @rly [#1608](https://github.com/NeurodataWithoutBorders/pynwb/pull/1608)
+
 ## PyNWB 2.2.0 (October 19, 2022)
 
 ### Enhancements and minor changes

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ commands =
 [testenv:py310-optional]
 basepython = python3.10
 install_command =
-    python -m pip install -e . {opts} {packages}
+    python -m pip install {opts} {packages}
 deps =
     -rrequirements-dev.txt
     ; -rrequirements-opt.txt
@@ -45,7 +45,7 @@ commands = {[testenv]commands}
 [testenv:py310-upgraded]
 basepython = python3.10
 install_command =
-    python -m pip install -U -e . {opts} {packages}
+    python -m pip install -U {opts} {packages}
 deps =
     -rrequirements-dev.txt
     ; -rrequirements-opt.txt
@@ -55,7 +55,7 @@ commands = {[testenv]commands}
 [testenv:py310-prerelease]
 basepython = python3.10
 install_command =
-    python -m pip install -U --pre -e . {opts} {packages}
+    python -m pip install -U --pre {opts} {packages}
 deps =
     -rrequirements-dev.txt
     ; -rrequirements-opt.txt
@@ -101,7 +101,7 @@ commands = {[testenv:build]commands}
 [testenv:build-py310-upgraded]
 basepython = python3.10
 install_command =
-    python -m pip install -U -e . {opts} {packages}
+    python -m pip install -U {opts} {packages}
 deps =
     -rrequirements-dev.txt
     ; -rrequirements-opt.txt
@@ -110,7 +110,7 @@ commands = {[testenv:build]commands}
 [testenv:build-py310-prerelease]
 basepython = python3.10
 install_command =
-    python -m pip install -U --pre -e . {opts} {packages}
+    python -m pip install -U --pre {opts} {packages}
 deps =
     -rrequirements-dev.txt
     ; -rrequirements-opt.txt


### PR DESCRIPTION
## Motivation

Fix #1607 

It seems like `-e .` is unnecessary when `develop = True` which was already set.

## How to test the behavior?
```
tox
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
