### PR TITLE
Check nwb_version on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,26 +6,28 @@
 - `Subject.age` can be input as a `timedelta`. @bendichter [#1590](https://github.com/NeurodataWithoutBorders/pynwb/pull/1590)
 - `IntracellularRecordingsTable.add_recording`: the `electrode` arg is now optional, and is automatically populated from the stimulus or response.
   [#1597](https://github.com/NeurodataWithoutBorders/pynwb/pull/1597)
-- Add module `pynwb.testing.mock.icephys` and corresponding tests. @bendichter
+- Added module `pynwb.testing.mock.icephys` and corresponding tests. @bendichter
   [1595](https://github.com/NeurodataWithoutBorders/pynwb/pull/1595)
-- Remove redundant object mapper code. @rly [#1600](https://github.com/NeurodataWithoutBorders/pynwb/pull/1600)
-- Fix pending deprecations and issues in CI. @rly [#1594](https://github.com/NeurodataWithoutBorders/pynwb/pull/1594)
+- Removed redundant object mapper code. @rly [#1600](https://github.com/NeurodataWithoutBorders/pynwb/pull/1600)
+- Fixed pending deprecations and issues in CI. @rly [#1594](https://github.com/NeurodataWithoutBorders/pynwb/pull/1594)
+- Added ``NWBHDF5IO.nwb_version`` property to get the NWB version from an NWB HDF5 file @oruebel [#1612](https://github.com/NeurodataWithoutBorders/pynwb/pull/1612)
+- Updated ``NWBHDF5IO.read`` to check NWB version before read and raise more informative error if an unsupported version is found @oruebel [#1612](https://github.com/NeurodataWithoutBorders/pynwb/pull/1612)
 
 ### Documentation and tutorial enhancements:
 - Adjusted [ecephys tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/ecephys.html) to create fake data with proper dimensions @bendichter [#1581](https://github.com/NeurodataWithoutBorders/pynwb/pull/1581)
 - Refactored testing documentation, including addition of section on ``pynwb.testing.mock`` submodule. @bendichter
   [#1583](https://github.com/NeurodataWithoutBorders/pynwb/pull/1583)
-- Update round trip tutorial to the newer ``NWBH5IOMixin`` and ``AcquisitionH5IOMixin`` classes. @bendichter
+- Updated round trip tutorial to the newer ``NWBH5IOMixin`` and ``AcquisitionH5IOMixin`` classes. @bendichter
   [#1586](https://github.com/NeurodataWithoutBorders/pynwb/pull/1586)
-- More informative error message for common installation error. @bendichter, @rly
+- Added more informative error message for common installation error. @bendichter, @rly
   [#1591](https://github.com/NeurodataWithoutBorders/pynwb/pull/1591)
-- Update citation for PyNWB in docs and duecredit to use the eLife NWB paper. @oruebel [#1604](https://github.com/NeurodataWithoutBorders/pynwb/pull/1604)
-- Fix docs build warnings due to use of hardcoded links. @oruebel [#1604](https://github.com/NeurodataWithoutBorders/pynwb/pull/1604)
+- Updated citation for PyNWB in docs and duecredit to use the eLife NWB paper. @oruebel [#1604](https://github.com/NeurodataWithoutBorders/pynwb/pull/1604)
+- Fixed docs build warnings due to use of hardcoded links. @oruebel [#1604](https://github.com/NeurodataWithoutBorders/pynwb/pull/1604)
 
 ### Bug fixes
-- Add shape constraint to `PatchClampSeries.data`. @bendichter
+- Added shape constraint to `PatchClampSeries.data`. @bendichter
   [#1596](https://github.com/NeurodataWithoutBorders/pynwb/pull/1596)
-- Update the [images tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/images.html) to provide example usage of an ``IndexSeries``
+- Updated the [images tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/images.html) to provide example usage of an ``IndexSeries``
   with a reference to ``Images``. @bendichter [#1602](https://github.com/NeurodataWithoutBorders/pynwb/pull/1602)
 - Fixed an issue with the `tox` tool when upgrading to tox 4. @rly [#1608](https://github.com/NeurodataWithoutBorders/pynwb/pull/1608)
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -269,7 +269,7 @@ class NWBHDF5IO(_HDF5IO):
         """
         Read the NWB file from the IO source.
 
-        :raises : If the NWB file version is missing or not support
+        :raises TypeError: If the NWB file version is missing or not support
 
         :return: NWBFile container
         """

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -246,9 +246,9 @@ class NWBHDF5IO(_HDF5IO):
         """
         Get the version tuple for the NWB file.
 
-        NOTE: The version will be None if no data has been written yet
+        NOTE: The version will be None if no data has been written yet.
 
-        :returns: Tuple with the file version or None if the version is missing
+        :returns: Tuple with the file version or None if the version is missing.
         """
         # Get the version string for the NWB file
         try:
@@ -269,13 +269,13 @@ class NWBHDF5IO(_HDF5IO):
         """
         Read the NWB file from the IO source.
 
-        :raises TypeError: If the NWB file version is missing or not support
+        :raises TypeError: If the NWB file version is missing or not supported
 
         :return: NWBFile container
         """
         # Check that the NWB file is supported
-        skip_verison_check = popargs('skip_version_check', kwargs)
-        if not skip_verison_check:
+        skip_version_check = popargs('skip_version_check', kwargs)
+        if not skip_version_check:
             file_version = self.nwb_version
             if file_version is None:
                 raise TypeError("Missing NWB version in file. The file is not a valid NWB file.")

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -418,6 +418,30 @@ class TestNWBHDF5IO(TestCase):
     def tearDown(self):
         remove_test_file(self.path)
 
+    def test_nwb_version_property(self):
+        """Test reading of files with missing nwb_version"""
+        # check empty version before write
+        with NWBHDF5IO(self.path, 'w') as io:
+            self.assertIsNone(io.nwb_version)
+        # write the example file
+        with NWBHDF5IO(self.path, 'w') as io:
+            io.write(self.nwbfile)
+        # check behavior for various different version strings
+        for ver in [("2.0.5", (2, 0, 5)),
+                    ("2.0.5-alpha", (2, 0, 5, "alpha")),
+                    ("bad_version", ("bad_version", ))]:
+            # Set version string
+            with File(self.path, mode='a') as io:
+                io.attrs['nwb_version'] = ver[0]
+            # Assert expected result for nwb_version tuple
+            with NWBHDF5IO(self.path, 'r') as io:
+                self.assertTupleEqual(io.nwb_version, ver[1])
+        # check empty version attribute
+        with File(self.path, mode='a') as io:
+            del io.attrs['nwb_version']
+        with NWBHDF5IO(self.path, 'r') as io:
+            self.assertIsNone(io.nwb_version)
+
     def test_check_nwb_version_ok(self):
         """Test that opening a current NWBFile passes the version check"""
         with NWBHDF5IO(self.path, 'w') as io:

--- a/tests/unit/test_icephys_metadata_tables.py
+++ b/tests/unit/test_icephys_metadata_tables.py
@@ -579,7 +579,7 @@ class IntracellularRecordingsTableTests(ICEphysMetaTestBase):
         with NWBHDF5IO(self.path, 'w') as io:
             io.write(curr)
         with NWBHDF5IO(self.path, 'r') as io:
-            incon = io.read()
+            incon = io.read(skip_version_check=True)
             self.assertListEqual(incon.categories, curr.categories)
             for n in curr.categories:
                 # empty columns from file have dtype int64 or float64 but empty in-memory columns have dtype object


### PR DESCRIPTION
## Motivation

Fix #1609

This PR:
* Adds the function ``NWBHDF5IO.nwb_version`` to check the nwb_version of an HDF5 file (i.e., before reading the file)
* Adds checking of nwb_version to ``NWBHDF5IO.read`` to raise a more informative error in case unsupported in case that unsupported file versions (i.e., NWB 1 files) are found
* Adds tests for the new functions

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
