### PR TITLE
Show recommended usaege for hdf5plugin in tutorial

### DIFF
--- a/docs/gallery/advanced_io/h5dataio.py
+++ b/docs/gallery/advanced_io/h5dataio.py
@@ -234,7 +234,7 @@ from pynwb.file import TimeSeries
 
 wrapped_data = H5DataIO(
     data=data,
-    **hdf5plugin.Zstd().filter_id,  # this sets the compression and compression_opts parameters
+    **hdf5plugin.Zstd().filter_id,  # set the compression and compression_opts parameters
     allow_plugin_filters=True,
 )
 

--- a/docs/gallery/advanced_io/h5dataio.py
+++ b/docs/gallery/advanced_io/h5dataio.py
@@ -234,7 +234,7 @@ from pynwb.file import TimeSeries
 
 wrapped_data = H5DataIO(
     data=data,
-    compression=hdf5plugin.Zstd().filter_id,
+    **hdf5plugin.Zstd().filter_id,  # this sets the compression and compression_opts parameters
     allow_plugin_filters=True,
 )
 

--- a/docs/gallery/advanced_io/h5dataio.py
+++ b/docs/gallery/advanced_io/h5dataio.py
@@ -234,7 +234,7 @@ from pynwb.file import TimeSeries
 
 wrapped_data = H5DataIO(
     data=data,
-    **hdf5plugin.Zstd().filter_id,  # set the compression and compression_opts parameters
+    **hdf5plugin.Zstd(clevel=3),  # set the compression and compression_opts parameters
     allow_plugin_filters=True,
 )
 


### PR DESCRIPTION
## Motivation

Fix #1629 to show recommended usage for hdf5plugin to set compression and compression_opts parameters for H5DataIO

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
