### PR TITLE
Increase stacklevel of timezone warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Added ``NWBHDF5IO.nwb_version`` property to get the NWB version from an NWB HDF5 file @oruebel [#1612](https://github.com/NeurodataWithoutBorders/pynwb/pull/1612)
 - Updated ``NWBHDF5IO.read`` to check NWB version before read and raise more informative error if an unsupported version is found @oruebel [#1612](https://github.com/NeurodataWithoutBorders/pynwb/pull/1612)
 - Added the `driver` keyword argument to the `pynwb.validate` function as well as the corresponding namespace caching. @CodyCBakerPhD [#1588](https://github.com/NeurodataWithoutBorders/pynwb/pull/1588)
+- Increased the stacklevel of the warning from `_add_missing_timezone` in `pynwb.file` to make identification of which datetime field is missing a timezone easier. @CodyCBakerPhD [#1641](https://github.com/NeurodataWithoutBorders/pynwb/pull/1641)
 
 ### Documentation and tutorial enhancements:
 - Adjusted [ecephys tutorial](https://pynwb.readthedocs.io/en/stable/tutorials/domain/ecephys.html) to create fake data with proper dimensions @bendichter [#1581](https://github.com/NeurodataWithoutBorders/pynwb/pull/1581)

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -1120,7 +1120,7 @@ def _add_missing_timezone(date):
     if not isinstance(date, datetime):
         raise ValueError("require datetime object")
     if date.tzinfo is None:
-        warn("Date is missing timezone information. Updating to local timezone.")
+        warn("Date is missing timezone information. Updating to local timezone.", stacklevel=2)
         return date.replace(tzinfo=tzlocal())
     return date
 

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -561,3 +561,17 @@ class TestTimestampsRefAware(TestCase):
                     'TEST124',
                     self.start_time,
                     timestamps_reference_time=self.ref_time_notz)
+
+
+class TestTimezone(TestCase):
+    def test_raise_warning__add_missing_timezone(self):
+        with self.assertWarnsWith(UserWarning, "Date is missing timezone information. Updating to local timezone."):
+            Subject(age='P90D',
+                    description='An unfortunate rat',
+                    genotype='WT',
+                    sex='M',
+                    species='Rattus norvegicus',
+                    subject_id='RAT123',
+                    weight='2 kg',
+                    date_of_birth=datetime(2017, 5, 1, 12),
+                    strain='my_strain')

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -561,17 +561,3 @@ class TestTimestampsRefAware(TestCase):
                     'TEST124',
                     self.start_time,
                     timestamps_reference_time=self.ref_time_notz)
-
-
-class TestTimezone(TestCase):
-    def test_raise_warning__add_missing_timezone(self):
-        with self.assertWarnsWith(UserWarning, "Date is missing timezone information. Updating to local timezone."):
-            Subject(age='P90D',
-                    description='An unfortunate rat',
-                    genotype='WT',
-                    sex='M',
-                    species='Rattus norvegicus',
-                    subject_id='RAT123',
-                    weight='2 kg',
-                    date_of_birth=datetime(2017, 5, 1, 12),
-                    strain='my_strain')

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -6,7 +6,7 @@ from dateutil.tz import tzlocal, tzutc
 
 from pynwb import NWBFile, TimeSeries, NWBHDF5IO
 from pynwb.base import Image, Images
-from pynwb.file import Subject, ElectrodeTable
+from pynwb.file import Subject, ElectrodeTable, _add_missing_timezone
 from pynwb.epoch import TimeIntervals
 from pynwb.ecephys import ElectricalSeries
 from pynwb.testing import TestCase, remove_test_file
@@ -561,3 +561,9 @@ class TestTimestampsRefAware(TestCase):
                     'TEST124',
                     self.start_time,
                     timestamps_reference_time=self.ref_time_notz)
+
+
+class TestTimezone(TestCase):
+    def test_raise_warning__add_missing_timezone(self):
+        with self.assertWarnsWith(UserWarning, "Date is missing timezone information. Updating to local timezone."):
+            _add_missing_timezone(datetime(2017, 5, 1, 12))


### PR DESCRIPTION
## Motivation

I just ran across a confusing case during a conversion.

I'm setting both `session_start_time` and the subect's `date_of_birth`.

I intentionally set the `tzinfo` for the `datetime` of the `session_start_time`, but was very confused for while as to why I kept getting the warning from PyNWB about not having set a timezone.

Little did I know it was not coming from the `session_start_time` (which 90+% of the time is the cause of that warning), but it was from https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/src/pynwb/file.py#L120 which does the same thing to the subject `date_of_birth`.

Using a higher `stacklevel` would have saved me a lot of time figuring this out, because it would have shown me a line in the traceback related to the field that was being parsed.



## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
