### PR TITLE
Fix issue with importlib-metadata on conda py37

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -171,7 +171,8 @@ jobs:
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          conda install -c conda-forge tox
+          # there are incompatibilies in the python 3.7 workflow when importlib-metadata>=4
+          conda install -c conda-forge tox "importlib_metadata<4"
           conda list
 
       - name: Run tox tests

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -163,20 +163,20 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          auto-activate-base: true
-          activate-environment: true
           python-version: ${{ matrix.python-ver }}
 
       - name: Install build dependencies
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          # there are incompatibilies in the python 3.7 workflow when importlib-metadata>=4
-          if [[ "${{ matrix.python-ver }}" == "3.7" ]]; then
-            conda install -c conda-forge "importlib_metadata<4"
-          fi
-          conda install -c conda-forge tox
-          conda list
+          # the conda dependency resolution for tox under python 3.7 can install the wrong importlib_metadata
+          conda install -c conda-forge tox "importlib_metadata>4"
+
+      - name: Conda reporting
+        run: |
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
 
       - name: Run tox tests
         run: |
@@ -276,9 +276,13 @@ jobs:
         run: |
           pip install matplotlib
           pip install -e .
-          conda info
-          conda list
           pip list
+
+      - name: Conda reporting
+        run: |
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
 
       - name: Run gallery ros3 tests
         run: |

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -172,7 +172,10 @@ jobs:
           conda config --set always_yes yes --set changeps1 no
           conda info
           # there are incompatibilies in the python 3.7 workflow when importlib-metadata>=4
-          conda install -c conda-forge tox "importlib_metadata<4"
+          if [[ "${{ matrix.python-ver }}" == "3.7" ]]; then
+            conda install -c conda-forge "importlib_metadata<4"
+          fi
+          conda install -c conda-forge tox
           conda list
 
       - name: Run tox tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -138,20 +138,20 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          auto-activate-base: true
-          activate-environment: true
           python-version: ${{ matrix.python-ver }}
 
       - name: Install build dependencies
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          # there are incompatibilies in the python 3.7 workflow when importlib-metadata>=4
-          if [[ "${{ matrix.python-ver }}" == "3.7" ]]; then
-            conda install -c conda-forge "importlib_metadata<4"
-          fi
-          conda install -c conda-forge tox
-          conda list
+          # the conda dependency resolution for tox under python 3.7 can install the wrong importlib_metadata
+          conda install -c conda-forge tox "importlib_metadata>4"
+
+      - name: Conda reporting
+        run: |
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
 
       - name: Run tox tests
         run: |
@@ -246,9 +246,13 @@ jobs:
         run: |
           pip install matplotlib
           pip install -e .
-          conda info
-          conda list
           pip list
+
+      - name: Conda reporting
+        run: |
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
 
       - name: Run gallery ros3 tests
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -146,7 +146,8 @@ jobs:
         run: |
           conda config --set always_yes yes --set changeps1 no
           conda info
-          conda install -c conda-forge tox
+          # there are incompatibilies in the python 3.7 workflow when importlib-metadata>=4
+          conda install -c conda-forge tox "importlib_metadata<4"
           conda list
 
       - name: Run tox tests

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -147,7 +147,10 @@ jobs:
           conda config --set always_yes yes --set changeps1 no
           conda info
           # there are incompatibilies in the python 3.7 workflow when importlib-metadata>=4
-          conda install -c conda-forge tox "importlib_metadata<4"
+          if [[ "${{ matrix.python-ver }}" == "3.7" ]]; then
+            conda install -c conda-forge "importlib_metadata<4"
+          fi
+          conda install -c conda-forge tox
           conda list
 
       - name: Run tox tests


### PR DESCRIPTION
## Motivation

See failing build https://github.com/NeurodataWithoutBorders/pynwb/actions/runs/4170640270

importlib_metadata >= 4 has issues with Python 3.7.
Not quite sure why this problem affects all of a sudden. ~It is certainly odd that multiple versions of importlib_metadata are installed by conda~:

<details>
  <summary>Past snippet</summary>
```
The following NEW packages will be INSTALLED:
 ...
  importlib-metadata conda-forge/linux-64::importlib-metadata-4.11.4-py37h89c1867_0 
  importlib_metadata conda-forge/linux-64::importlib_metadata-1.5.0-py37_0 
```
</details>
`importlib_metadata` is an alias for `importlib-metadata` (underscore vs hyphen)

In any case, in this PR, the version of importlib_metadata is restricted to <4 for python 3.7.

See also #1427

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
