### PR TITLE
Support nwb_version as a fixed-length string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # PyNWB Changelog
 
-
 ## PyNWB 2.3.2 (Upcoming)
 
 ### Enhancements and minor changes
 - Fixed typos and added codespell GitHub action to check spelling in the future. @yarikoptic [#1648](https://github.com/NeurodataWithoutBorders/pynwb/pull/1648)
+
+### Bug fixes
+- Fixed bug in ``NWBHDF5IO.nwb_version`` property to support files written by third-party software with a fixed-length ``nwb_version`` attribute. @oruebel [#1669](https://github.com/NeurodataWithoutBorders/pynwb/pull/1669)
 
 ## PyNWB 2.3.1 (February 24, 2023)
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -259,7 +259,7 @@ class NWBHDF5IO(_HDF5IO):
         except KeyError:
             return None, None
         # Other system may have written nwb_version as a fixed-length string, resulting in a numpy.bytes_ object
-        # on read, rather than a variable length string. To address this, decode the bytes if necessary.
+        # on read, rather than a variable-length string. To address this, decode the bytes if necessary.
         if not isinstance(nwb_version_string, str):
             nwb_version_string = nwb_version_string.decode()
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -258,6 +258,11 @@ class NWBHDF5IO(_HDF5IO):
         #  or when the HDF5 file is not a valid NWB file
         except KeyError:
             return None, None
+        # Other system may have written nwb_version as a fixed-length string, resulting in a numpy.bytes_ object
+        # on read, rather than a variable length string. To address this, decode the bytes if necessary.
+        if not isinstance(nwb_version_string, str):
+            nwb_version_string = nwb_version_string.decode()
+
         # Parse the version string
         nwb_version_parts = nwb_version_string.replace("-", ".").replace("_", ".").split(".")
         nwb_version = tuple([int(i) if i.isnumeric() else i

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -443,7 +443,7 @@ class TestNWBHDF5IO(TestCase):
             del io.attrs['nwb_version']
         with NWBHDF5IO(self.path, 'r') as io:
             self.assertTupleEqual(io.nwb_version, (None, None))
-        # check that it works when setting the attribute to a fixed-legnth numpy-bytes string
+        # check that it works when setting the attribute to a fixed-length numpy-bytes string
         with File(self.path, mode='a') as io:
             io.attrs['nwb_version'] = np.asarray("2.0.5", dtype=np.bytes_)[()]
         with NWBHDF5IO(self.path, 'r') as io:

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -443,6 +443,11 @@ class TestNWBHDF5IO(TestCase):
             del io.attrs['nwb_version']
         with NWBHDF5IO(self.path, 'r') as io:
             self.assertTupleEqual(io.nwb_version, (None, None))
+        # check that it works when setting the attribute to a fixed-legnth numpy-bytes string
+        with File(self.path, mode='a') as io:
+            io.attrs['nwb_version'] = np.asarray("2.0.5", dtype=np.bytes_)[()]
+        with NWBHDF5IO(self.path, 'r') as io:
+            self.assertTupleEqual(io.nwb_version, ("2.0.5", (2, 0, 5)))
 
     def test_check_nwb_version_ok(self):
         """Test that opening a current NWBFile passes the version check"""


### PR DESCRIPTION
## Motivation

Fix #1668 

In #1612 we added support to do version checks on NWB HDF5 files to improve error reporting. The new ``nwb_version`` function implictly assumed that the attribute was written as a variable-lenght string. This leads to errors for NWB files that may use fixed-length strings instead (see #1668 for detail). This PR updated the ``NWBHDF5IO.new_version`` property to make sure the resulting bytes object is being decoded to a string in case that the attribute was written as a fixed-length bytes.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
