### PR TITLE
Add testing for python 3.11, update reqs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -64,6 +64,7 @@ body:
         - "3.8"
         - "3.9"
         - "3.10"
+        - "3.11"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/check_external_links.yml
+++ b/.github/workflows/check_external_links.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.8'  # allensdk requires 3.8
+          python-version: '3.11'
 
       - name: Install Sphinx dependencies and package
         run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install build dependencies
         run: |
@@ -28,11 +28,11 @@ jobs:
 
       - name: Run tox tests
         run: |
-          tox -e py310-upgraded
+          tox -e py311-upgraded
 
       - name: Build wheel and source distribution
         run: |
-          tox -e build-py310-upgraded
+          tox -e build-py311-upgraded
           ls -1 dist
 
       - name: Test installation from a wheel

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -26,23 +26,26 @@ jobs:
           - { name: linux-python3.8              , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: ubuntu-latest }
           - { name: linux-python3.9              , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: ubuntu-latest }
           - { name: linux-python3.10             , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.10-optional    , test-tox-env: py310-optional  , build-tox-env: build-py310-optional  , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.10-upgraded    , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.10-prerelease  , test-tox-env: py310-prerelease, build-tox-env: build-py310-prerelease, python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-optional    , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-prerelease  , test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
           - { name: windows-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: windows-latest }
           - { name: windows-python3.8            , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: windows-latest }
           - { name: windows-python3.9            , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.10           , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.10-optional  , test-tox-env: py310-optional  , build-tox-env: build-py310-optional  , python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.10-upgraded  , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.10-prerelease, test-tox-env: py310-prerelease, build-tox-env: build-py310-prerelease, python-ver: "3.10", os: windows-latest }
+          - { name: windows-python3.11           , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.11-optional  , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.11-prerelease, test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: windows-latest }
           - { name: macos-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: macos-latest }
           - { name: macos-python3.8              , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: macos-latest }
           - { name: macos-python3.9              , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: macos-latest }
           - { name: macos-python3.10             , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.10-optional    , test-tox-env: py310-optional  , build-tox-env: build-py310-optional  , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.10-upgraded    , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.10-prerelease  , test-tox-env: py310-prerelease, build-tox-env: build-py310-prerelease, python-ver: "3.10", os: macos-latest }
+          - { name: macos-python3.11             , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.11-optional    , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.11-prerelease  , test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -90,14 +93,14 @@ jobs:
       matrix:
         include:
           - { name: linux-gallery-python3.7-minimum      , test-tox-env: gallery-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.10-upgraded    , test-tox-env: gallery-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-gallery-python3.10-prerelease  , test-tox-env: gallery-py310-prerelease, python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-gallery-python3.11-upgraded    , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-gallery-python3.11-prerelease  , test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
           - { name: windows-gallery-python3.7-minimum    , test-tox-env: gallery-py37-minimum    , python-ver: "3.7" , os: windows-latest }
-          - { name: windows-gallery-python3.10-upgraded  , test-tox-env: gallery-py310-upgraded  , python-ver: "3.10", os: windows-latest }
-          - { name: windows-gallery-python3.10-prerelease, test-tox-env: gallery-py310-prerelease, python-ver: "3.10", os: windows-latest }
+          - { name: windows-gallery-python3.11-upgraded  , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: windows-latest }
+          - { name: windows-gallery-python3.11-prerelease, test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: windows-latest }
           - { name: macos-gallery-python3.7-minimum      , test-tox-env: gallery-py37-minimum    , python-ver: "3.7" , os: macos-latest }
-          - { name: macos-gallery-python3.10-upgraded    , test-tox-env: gallery-py310-upgraded  , python-ver: "3.10", os: macos-latest }
-          - { name: macos-gallery-python3.10-prerelease  , test-tox-env: gallery-py310-prerelease, python-ver: "3.10", os: macos-latest }
+          - { name: macos-gallery-python3.11-upgraded    , test-tox-env: gallery-py311-upgraded  , python-ver: "3.11", os: macos-latest }
+          - { name: macos-gallery-python3.11-prerelease  , test-tox-env: gallery-py311-prerelease, python-ver: "3.11", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -138,9 +141,10 @@ jobs:
           - { name: conda-linux-python3.8            , test-tox-env: py38            , build-tox-env: build-py38            , python-ver: "3.8" , os: ubuntu-latest }
           - { name: conda-linux-python3.9            , test-tox-env: py39            , build-tox-env: build-py39            , python-ver: "3.9" , os: ubuntu-latest }
           - { name: conda-linux-python3.10           , test-tox-env: py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
-          - { name: conda-linux-python3.10-optional  , test-tox-env: py310-optional  , build-tox-env: build-py310-optional  , python-ver: "3.10", os: ubuntu-latest }
-          - { name: conda-linux-python3.10-upgraded  , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest }
-          - { name: conda-linux-python3.10-prerelease, test-tox-env: py310-prerelease, build-tox-env: build-py310-prerelease, python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.11           , test-tox-env: py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.11-optional  , test-tox-env: py311-optional  , build-tox-env: build-py311-optional  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.11-prerelease, test-tox-env: py311-prerelease, build-tox-env: build-py311-prerelease, python-ver: "3.11", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -195,9 +199,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.10-ros3  , python-ver: "3.10", os: ubuntu-latest }
-          - { name: windows-python3.10-ros3, python-ver: "3.10", os: windows-latest }
-          - { name: macos-python3.10-ros3  , python-ver: "3.10", os: macos-latest }
+          - { name: linux-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: windows-python3.11-ros3, python-ver: "3.11", os: windows-latest }
+          - { name: macos-python3.11-ros3  , python-ver: "3.11", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -241,9 +245,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.10-ros3  , python-ver: "3.10", os: ubuntu-latest }
-          - { name: windows-gallery-python3.10-ros3, python-ver: "3.10", os: windows-latest }
-          - { name: macos-gallery-python3.10-ros3  , python-ver: "3.10", os: macos-latest }
+          - { name: linux-gallery-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
+          - { name: windows-gallery-python3.11-ros3, python-ver: "3.11", os: windows-latest }
+          - { name: macos-gallery-python3.11-ros3  , python-ver: "3.11", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -24,7 +24,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.10'
+      PYTHON: '3.11'
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ env.PYTHON }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/run_flake8.yml
+++ b/.github/workflows/run_flake8.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Install flake8
         run: |

--- a/.github/workflows/run_inspector_tests.yml
+++ b/.github/workflows/run_inspector_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Update pip
         run: python -m pip install --upgrade pip

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,6 +23,7 @@ jobs:
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
           - { name: linux-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: windows-latest }
+          - { name: windows-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: windows-latest }
           - { name: macos-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: macos-latest }
     steps:
       - name: Cancel non-latest runs

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,7 +21,7 @@ jobs:
         include:
           - { name: linux-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
-          - { name: linux-python3.10-upgraded    , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest , upload-wheels: true }
+          - { name: linux-python3.11-upgraded    , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: windows-latest }
           - { name: macos-python3.7-minimum      , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: macos-latest }
     steps:
@@ -78,9 +78,9 @@ jobs:
       matrix:
         include:
           - { name: linux-gallery-python3.7-minimum    , test-tox-env: gallery-py37-minimum  , python-ver: "3.7" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.10-upgraded  , test-tox-env: gallery-py310-upgraded, python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-gallery-python3.11-upgraded  , test-tox-env: gallery-py311-upgraded, python-ver: "3.11", os: ubuntu-latest }
           - { name: windows-gallery-python3.7-minimum  , test-tox-env: gallery-py37-minimum  , python-ver: "3.7" , os: windows-latest }
-          - { name: windows-gallery-python3.10-upgraded, test-tox-env: gallery-py310-upgraded, python-ver: "3.10", os: windows-latest }
+          - { name: windows-gallery-python3.11-upgraded, test-tox-env: gallery-py311-upgraded, python-ver: "3.11", os: windows-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -118,7 +118,7 @@ jobs:
       matrix:
         include:
           - { name: conda-linux-python3.7-minimum    , test-tox-env: py37-minimum    , build-tox-env: build-py37-minimum    , python-ver: "3.7" , os: ubuntu-latest }
-          - { name: conda-linux-python3.10-upgraded  , test-tox-env: py310-upgraded  , build-tox-env: build-py310-upgraded  , python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.11-upgraded  , test-tox-env: py311-upgraded  , build-tox-env: build-py311-upgraded  , python-ver: "3.11", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -173,7 +173,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.10-ros3  , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -217,7 +217,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-gallery-python3.10-ros3  , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-gallery-python3.11-ros3  , python-ver: "3.11", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -275,7 +275,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Download wheel and source distributions from artifact
         uses: actions/download-artifact@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # PyNWB Changelog
 
-## PyNWB 2.4.0 (Upcoming)
+## PyNWB 2.3.3 (Upcoming)
 
 ### Enhancements and minor changes
 - Add testing support for Python 3.11. @rly [#1687](https://github.com/NeurodataWithoutBorders/pynwb/pull/1687)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## PyNWB 2.4.0 (Upcoming)
+
+### Enhancements and minor changes
+- Add testing support for Python 3.11. @rly [#1687](https://github.com/NeurodataWithoutBorders/pynwb/pull/1687)
+
 ## PyNWB 2.3.2 (April 10, 2023)
 
 ### Enhancements and minor changes

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -137,7 +137,7 @@ sphinx_gallery_conf = {
 }
 
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3.10', None),
+    'python': ('https://docs.python.org/3.11', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'matplotlib': ('https://matplotlib.org/stable/', None),
     'h5py': ('https://docs.h5py.org/en/latest/', None),

--- a/docs/source/install_developers.rst
+++ b/docs/source/install_developers.rst
@@ -6,7 +6,7 @@ Installing PyNWB for Developers
 
 PyNWB has the following minimum requirements, which must be installed before you can get started using PyNWB.
 
-#. Python 3.7, 3.8, 3.9, or 3.10
+#. Python 3.7, 3.8, 3.9, 3.10, or 3.11
 #. pip
 
 

--- a/docs/source/install_users.rst
+++ b/docs/source/install_users.rst
@@ -6,7 +6,7 @@ Installing PyNWB
 
 PyNWB has the following minimum requirements, which must be installed before you can get started using PyNWB.
 
-#. Python 3.7, 3.8, 3.9, or 3.10
+#. Python 3.7, 3.8, 3.9, 3.10, or 3.11
 #. pip
 
 .. note:: If you are a developer then please see the :ref:`install_developers` installation instructions instead.

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -4,12 +4,12 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.10
+  - python==3.11
   - h5py==3.8.0
-  - hdmf==3.5.1
+  - hdmf==3.5.4
   - matplotlib==3.7.1
-  - numpy==1.23.3
-  - pandas==1.5.0
+  - numpy==1.24.2
+  - pandas==2.0.0
   - python-dateutil==2.8.2
   - setuptools
-  - dandi==0.51.0  # NOTE: dandi does not support osx-arm64
+  - dandi==0.52.0  # NOTE: dandi does not support osx-arm64

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
-h5py==3.7.0
+h5py==3.8.0
 hdmf==3.5.4
-numpy==1.23.3; python_version >= "3.8"
+numpy==1.24.2; python_version >= "3.8"
 numpy==1.21.5; python_version < "3.8"  # note that numpy 1.22 dropped python 3.7 support
-pandas==1.5.0; python_version >= "3.8"
+pandas==2.0.0; python_version >= "3.8"
 pandas==1.3.5; python_version < "3.8"  # note that pandas 1.4 dropped python 3.7 support
 python-dateutil==2.8.2
 setuptools==65.5.1

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup_args = {
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/tests/integration/hdf5/test_nwbfile.py
+++ b/tests/integration/hdf5/test_nwbfile.py
@@ -340,7 +340,7 @@ class TestEpochsIODf(TestEpochsIO):
                                [(4, 1, tsa)]],
                 'tags': [[''], [''], ['fizz', 'buzz'], ['qaz']]
             },
-            index=pd.Index(np.arange(4), name='id')
+            index=pd.Index(np.arange(4, dtype=np.int64), name='id')
         )
         # pop the timeseries column out because ts_obt has rows of lists of tuples and ts_exp has rows of lists of lists
         ts_obt = df_obt.pop('timeseries')
@@ -367,7 +367,7 @@ class TestEpochsIODf(TestEpochsIO):
                 'stop_time': [0.25, 0.30, 0.40, 0.45],
                 'tags': [[''], [''], ['fizz', 'buzz'], ['qaz']]
             },
-            index=pd.Index(np.arange(4), name='id')
+            index=pd.Index(np.arange(4, dtype=np.int64), name='id')
         )
 
         df_obt = self.read_container.to_dataframe(exclude=set(['timeseries', 'timeseries_index']))

--- a/tox.ini
+++ b/tox.ini
@@ -88,7 +88,7 @@ basepython = python3.9
 commands = {[testenv:build]commands}
 
 [testenv:build-py310]
-basepython = python3.9
+basepython = python3.10
 commands = {[testenv:build]commands}
 
 [testenv:build-py311]
@@ -162,7 +162,7 @@ deps = {[testenv:gallery]deps}
 commands = {[testenv:gallery]commands}
 
 [testenv:gallery-py310]
-basepython = python3.9
+basepython = python3.10
 deps = {[testenv:gallery]deps}
 commands = {[testenv:gallery]commands}
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py38, py39, py310
+envlist = py37, py38, py39, py310, py311
 requires = pip >= 22.0
 
 [testenv]
@@ -26,14 +26,14 @@ commands =
 
 # Env to create coverage report locally
 [testenv:localcoverage]
-basepython = python3.10
+basepython = python3.11
 commands =
     python -m coverage run test.py --pynwb
     coverage html -d tests/coverage/htmlcov
 
-# Test with python 3.10; pinned dev and optional reqs
-[testenv:py310-optional]
-basepython = python3.10
+# Test with python 3.11; pinned dev and optional reqs
+[testenv:py311-optional]
+basepython = python3.11
 install_command =
     python -m pip install {opts} {packages}
 deps =
@@ -41,9 +41,9 @@ deps =
     ; -rrequirements-opt.txt
 commands = {[testenv]commands}
 
-# Test with python 3.10; pinned dev and optional reqs; upgraded run reqs
-[testenv:py310-upgraded]
-basepython = python3.10
+# Test with python 3.11; pinned dev and optional reqs; upgraded run reqs
+[testenv:py311-upgraded]
+basepython = python3.11
 install_command =
     python -m pip install -U {opts} {packages}
 deps =
@@ -51,9 +51,9 @@ deps =
     ; -rrequirements-opt.txt
 commands = {[testenv]commands}
 
-# Test with python 3.10; pinned dev and optional reqs; upgraded, pre-release run reqs
-[testenv:py310-prerelease]
-basepython = python3.10
+# Test with python 3.11; pinned dev and optional reqs; upgraded, pre-release run reqs
+[testenv:py311-prerelease]
+basepython = python3.11
 install_command =
     python -m pip install -U --pre {opts} {packages}
 deps =
@@ -88,18 +88,22 @@ basepython = python3.9
 commands = {[testenv:build]commands}
 
 [testenv:build-py310]
-basepython = python3.10
+basepython = python3.9
 commands = {[testenv:build]commands}
 
-[testenv:build-py310-optional]
-basepython = python3.10
+[testenv:build-py311]
+basepython = python3.11
+commands = {[testenv:build]commands}
+
+[testenv:build-py311-optional]
+basepython = python3.11
 deps =
     -rrequirements-dev.txt
     ; -rrequirements-opt.txt
 commands = {[testenv:build]commands}
 
-[testenv:build-py310-upgraded]
-basepython = python3.10
+[testenv:build-py311-upgraded]
+basepython = python3.11
 install_command =
     python -m pip install -U {opts} {packages}
 deps =
@@ -107,8 +111,8 @@ deps =
     ; -rrequirements-opt.txt
 commands = {[testenv:build]commands}
 
-[testenv:build-py310-prerelease]
-basepython = python3.10
+[testenv:build-py311-prerelease]
+basepython = python3.11
 install_command =
     python -m pip install -U --pre {opts} {packages}
 deps =
@@ -158,13 +162,18 @@ deps = {[testenv:gallery]deps}
 commands = {[testenv:gallery]commands}
 
 [testenv:gallery-py310]
-basepython = python3.10
+basepython = python3.9
 deps = {[testenv:gallery]deps}
 commands = {[testenv:gallery]commands}
 
-# Test with python 3.10; pinned dev, doc, and optional reqs; upgraded run reqs
-[testenv:gallery-py310-upgraded]
-basepython = python3.10
+[testenv:gallery-py311]
+basepython = python3.11
+deps = {[testenv:gallery]deps}
+commands = {[testenv:gallery]commands}
+
+# Test with python 3.11; pinned dev, doc, and optional reqs; upgraded run reqs
+[testenv:gallery-py311-upgraded]
+basepython = python3.11
 deps =
     -rrequirements-dev.txt
 commands =
@@ -174,9 +183,9 @@ commands =
     python -m pip list
     python test.py --example
 
-# Test with python 3.10; pinned dev, doc, and optional reqs; pre-release run reqs
-[testenv:gallery-py310-prerelease]
-basepython = python3.10
+# Test with python 3.11; pinned dev, doc, and optional reqs; pre-release run reqs
+[testenv:gallery-py311-prerelease]
+basepython = python3.11
 deps =
     -rrequirements-dev.txt
 commands =


### PR DESCRIPTION
## Motivation

`requirements.txt` had set the h5py version to 3.7.0 which needs to be built for python 3.11. This can cause issues in CI and local builds. So, we update the `requirements.txt` to use h5py 3.8.0 and in the process also add support for Python 3.11.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
