### PR TITLE
Remove unused codecov dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 ### Enhancements and minor changes
 - Add testing support for Python 3.11. @rly [#1687](https://github.com/NeurodataWithoutBorders/pynwb/pull/1687)
 
+### Bug fixes
+- Remove unused, deprecated `codecov` package from dev installation requirements. @rly
+  [#1688](https://github.com/NeurodataWithoutBorders/pynwb/pull/1688)
+
 ## PyNWB 2.3.2 (April 10, 2023)
 
 ### Enhancements and minor changes

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,6 @@
 # versions of requirements may be installed due to package incompatibilities.
 #
 black==23.3.0
-codecov==2.1.12
 codespell==2.2.4
 coverage==7.2.2
 flake8==6.0.0; python_version >= "3.8"


### PR DESCRIPTION
## Motivation

The `codecov` package on PyPI was deprecated and suddenly deleted today. See https://community.codecov.com/t/codecov-yanked-from-pypi-all-versions/4259 and https://about.codecov.io/blog/message-regarding-the-pypi-package/

We no longer use the CLI for codecov so we can safely remove it as a dependency in `requirements-dev.txt`

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
