### PR TITLE
Fix broken link and update docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -2,8 +2,7 @@ Prepare for release of PyNWB [version]
 
 ### Before merging:
 - [ ] Major and minor releases: Update package versions in `requirements.txt`, `requirements-dev.txt`,
-  `requirements-doc.txt`, `requirements-min.txt`, `setup.py` as needed
-  See https://requires.io/github/NeurodataWithoutBorders/pynwb/requirements/?branch=dev
+  `requirements-doc.txt`, `requirements-min.txt`, `environment-ros3.yml`, and `setup.py` as needed.
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
 - [ ] Update `setup.py` as needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 ### Bug fixes
 - Remove unused, deprecated `codecov` package from dev installation requirements. @rly
   [#1688](https://github.com/NeurodataWithoutBorders/pynwb/pull/1688)
+- Remove references to discontinued `requires.io` service in documentation. @rly
+  [#1690](https://github.com/NeurodataWithoutBorders/pynwb/pull/1690)
 
 ## PyNWB 2.3.2 (April 10, 2023)
 

--- a/README.rst
+++ b/README.rst
@@ -55,10 +55,6 @@ Overall Health
 .. image:: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/deploy_release.yml/badge.svg
     :target: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/deploy_release.yml
 
-.. image:: https://requires.io/github/NeurodataWithoutBorders/pynwb/requirements.svg?branch=dev
-     :target: https://requires.io/github/NeurodataWithoutBorders/pynwb/requirements/?branch=dev
-     :alt: Requirements Status
-
 .. image:: https://readthedocs.org/projects/pynwb/badge/?version=latest
      :target: https://pynwb.readthedocs.io/en/latest/?badge=latest
      :alt: Documentation Status

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -32,11 +32,23 @@ codecov_, which shows line by line which lines are covered by the tests.
 .. _coverage: https://coverage.readthedocs.io
 .. _codecov: https://app.codecov.io/gh/NeurodataWithoutBorders/pynwb/tree/dev/src/pynwb
 
---------------------------
-Requirement Specifications
---------------------------
+-------------------------
+Installation Requirements
+-------------------------
 
-There are 5 kinds of requirements specification in PyNWB.
+:pynwb:`setup.py <blob/dev/setup.py>` contains a list of package dependencies and their version ranges allowed for
+running PyNWB. As a library, upper bound version constraints create more harm than good in the long term (see this
+`blog post`_) so we avoid setting upper bounds on requirements.
+
+If some of the packages are outdated, see :ref:`update_requirements_files`.
+
+.. _blog post: https://iscinumpy.dev/post/bound-version-constraints/
+
+--------------------
+Testing Requirements
+--------------------
+
+There are several kinds of requirements files used for testing PyNWB.
 
 The first one is the :pynwb:`requirements-min.txt <blob/dev/requirements-min.txt>` file, which lists the package dependencies and their minimum versions for
 installing PyNWB.
@@ -48,20 +60,19 @@ The third one is :pynwb:`requirements-dev.txt <blob/dev/requirements-dev.txt>`, 
 an entire development environment to use PyNWB, run PyNWB tests, check code style, compute coverage, and create test
 environments.
 
-The fourth one is :pynwb:`requirements-doc.txt <blob/dev/requirements-doc.txt>`, which lists the dependencies to generate the documentation for PyNWB.
-Both this file and :pynwb:`requirements.txt <blob/dev/requirements.txt>` are used by ReadTheDocs_ to initialize the local environment for Sphinx to run.
+The final one is :pynwb:`environment-ros3.yml <blob/dev/environment-ros3.yml>`, which lists the dependencies used to
+test ROS3 streaming in PyNWB.
 
-The final one is within :pynwb:`setup.py <blob/dev/setup.py>`, which contains a list of package dependencies and their version ranges allowed for
-running PyNWB.
+--------------------------
+Documentation Requirements
+--------------------------
 
-In order to check the status of the required packages, requires.io_ is used to create a badge on the project
-:pynwb:`README <#readme>`. If all the required packages are up to date, a green badge appears.
-
-If some of the packages are outdated, see :ref:`update_requirements_files`.
+:pynwb:`requirements-doc.txt <blob/dev/requirements-doc.txt>` lists the dependencies to generate the documentation
+for PyNWB.
+Both this file and :pynwb:`requirements.txt <blob/dev/requirements.txt>` are used by ReadTheDocs_ to initialize the
+local environment for Sphinx to run.
 
 .. _ReadTheDocs: https://readthedocs.org/projects/pynwb/
-.. _requires.io: https://requires.io/github/NeurodataWithoutBorders/pynwb/requirements/?branch=dev
-
 
 -------------------------
 Versioning and Releasing


### PR DESCRIPTION
## Motivation

Fix broken link caught by Sphinx checks:
```
(software_process: line   66) broken    https://requires.io/github/hdmf-dev/hdmf/requirements/?branch=dev - HTTPSConnectionPool(host='requires.io', port=443): Max retries exceeded with url: /github/hdmf-dev/hdmf/requirements/?branch=dev (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7feb49abbc50>: Failed to establish a new connection: [Errno -2] Name or service not known'))
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
