### PR TITLE
Fix importlib_metadata incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   [#1688](https://github.com/NeurodataWithoutBorders/pynwb/pull/1688)
 - Remove references to discontinued `requires.io` service in documentation. @rly
   [#1690](https://github.com/NeurodataWithoutBorders/pynwb/pull/1690)
+- Update `requirements-doc.txt` to resolve Python 3.7 incompatibility. @rly
+  [#1694](https://github.com/NeurodataWithoutBorders/pynwb/pull/1694)
 
 ## PyNWB 2.3.2 (April 10, 2023)
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -11,3 +11,5 @@ sphinx-copybutton
 dataframe_image   # used to render large dataframe as image in the sphinx gallery to improve html display
 lxml  # used by dataframe_image when using the matplotlib backend
 hdf5plugin
+importlib-metadata<4.3; python_version < "3.8"  # TODO: remove when minimum python version is 3.8
+


### PR DESCRIPTION
## Motivation

Gallery tests are failing because `pip install requirements-doc.txt` after installing the latest hdmf results in an incompatibility in the requirements for python 3.7. This PR fixes it.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
