### PR TITLE
Add CI to read first NWB file from each dandiset

### DIFF
--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -48,4 +48,4 @@ jobs:
 
       - name: Run DANDI read tests
         run: |
-          pytest tests/read_dandi/
+          pytest -rP tests/read_dandi/

--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}  # necessary for conda
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -20,21 +23,28 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
-      - name: Set up Python
-        uses: actions/setup-python@v4
+      - name: Set up Conda
+        uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: '3.11'
+          auto-update-conda: true
+          activate-environment: ros3
+          environment-file: environment-ros3.yml
+          python-version: ${{ matrix.python-ver }}
+          channels: conda-forge
+          auto-activate-base: false
 
-      - name: Update pip
-        run: python -m pip install --upgrade pip
-
-      - name: Install DANDI and install dev branch of PyNWB
+      - name: Install run dependencies
         run: |
-          python -m pip list
-          python -m pip install dandi pytest
+          python -m pip install pytest
           python -m pip uninstall -y pynwb  # uninstall pynwb
-          python -m pip install .  # reinstall current branch of pynwb
+          python -m pip install -e .
           python -m pip list
+
+      - name: Conda reporting
+        run: |
+          conda info
+          conda config --show-sources
+          conda list --show-channel-urls
 
       - name: Run DANDI read tests
         run: |

--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -1,0 +1,41 @@
+name: Run DANDI read tests
+on:
+  pull_request:  # TODO remove me
+  schedule:
+    - cron: '0 5 * * *'  # once per day at midnight ET
+  workflow_dispatch:
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel non-latest runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          all_but_latest: true
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v3
+        with:
+          submodules: 'recursive'
+          fetch-depth: 0  # tags are required for versioneer to determine the version
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Update pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install DANDI and install dev branch of PyNWB
+        run: |
+          python -m pip list
+          python -m pip install dandi pytest
+          python -m pip uninstall -y pynwb  # uninstall pynwb
+          python -m pip install .  # reinstall current branch of pynwb
+          python -m pip list
+
+      - name: Run DANDI read tests
+        run: |
+          pytest tests/read_dandi/

--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -29,13 +29,13 @@ jobs:
           auto-update-conda: true
           activate-environment: ros3
           environment-file: environment-ros3.yml
-          python-version: ${{ matrix.python-ver }}
+          python-version: "3.11"
           channels: conda-forge
           auto-activate-base: false
 
       - name: Install run dependencies
         run: |
-          python -m pip install pytest
+          python -m pip install dandi pytest
           python -m pip uninstall -y pynwb  # uninstall pynwb
           python -m pip install -e .
           python -m pip list

--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -1,8 +1,7 @@
 name: Run DANDI read tests
 on:
-  pull_request:  # TODO remove me
   schedule:
-    - cron: '0 5 * * *'  # once per day at midnight ET
+    - cron: '0 6 * * *'  # once per day at 1am ET
   workflow_dispatch:
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements and minor changes
 - Add testing support for Python 3.11. @rly [#1687](https://github.com/NeurodataWithoutBorders/pynwb/pull/1687)
+- Add CI testing of NWB files on DANDI. @rly [#1695](https://github.com/NeurodataWithoutBorders/pynwb/pull/1695)
 
 ### Bug fixes
 - Remove unused, deprecated `codecov` package from dev installation requirements. @rly

--- a/tests/read_dandi/test_read_dandi.py
+++ b/tests/read_dandi/test_read_dandi.py
@@ -43,7 +43,6 @@ class TestReadNWBDandisets(TestCase):
             try:
                 with NWBHDF5IO(path=s3_url, load_namespaces=True, driver="ros3") as io:
                     nwbfile = io.read()
-                    print(nwbfile)
             except Exception as e:
                 print(traceback.format_exc())
                 failed_reads[dandiset] = e

--- a/tests/read_dandi/test_read_dandi.py
+++ b/tests/read_dandi/test_read_dandi.py
@@ -40,7 +40,3 @@ class TestReadNWBDandisets(TestCase):
             with NWBHDF5IO(path=s3_url, load_namespaces=True, driver="ros3") as io:
                 nwbfile = io.read()
                 print(nwbfile)
-
-
-
-

--- a/tests/read_dandi/test_read_dandi.py
+++ b/tests/read_dandi/test_read_dandi.py
@@ -42,7 +42,7 @@ class TestReadNWBDandisets(TestCase):
 
             try:
                 with NWBHDF5IO(path=s3_url, load_namespaces=True, driver="ros3") as io:
-                    nwbfile = io.read()
+                    io.read()
             except Exception as e:
                 print(traceback.format_exc())
                 failed_reads[dandiset] = e

--- a/tests/read_dandi/test_read_dandi.py
+++ b/tests/read_dandi/test_read_dandi.py
@@ -1,0 +1,46 @@
+from dandi.dandiapi import DandiAPIClient
+
+from pynwb import NWBHDF5IO
+from pynwb.testing import TestCase
+
+
+class TestReadNWBDandisets(TestCase):
+    """Test reading NWB files from the DANDI Archive using ROS3."""
+
+    def test_read_first_nwb_asset(self):
+        """Test reading the first NWB asset from each dandiset that uses NWB."""
+        client = DandiAPIClient()
+        dandisets = client.get_dandisets()
+
+        for i, dandiset in enumerate(dandisets):
+            dandiset_metadata = dandiset.get_raw_metadata()
+
+            # skip any dandisets that do not use NWB
+            if not any(
+                data_standard["identifier"] == "RRID:SCR_015242"  # this is the RRID for NWB
+                for data_standard in dandiset_metadata["assetsSummary"].get("dataStandard", [])
+            ):
+                continue
+
+            dandiset_identifier = dandiset_metadata["identifier"]
+            print("--------------")
+            print(f"{i}: {dandiset_identifier}")
+
+            # iterate through assets until we get an NWB file (it could be MP4)
+            assets = dandiset.get_assets()
+            first_asset = next(assets)
+            while first_asset.path.split(".")[-1] != "nwb":
+                first_asset = next(assets)
+            if first_asset.path.split(".")[-1] != "nwb":
+                print("No NWB files?!")
+                continue
+
+            s3_url = first_asset.get_content_url(follow_redirects=1, strip_query=True)
+
+            with NWBHDF5IO(path=s3_url, load_namespaces=True, driver="ros3") as io:
+                nwbfile = io.read()
+                print(nwbfile)
+
+
+
+


### PR DESCRIPTION
## Motivation

This adds a quick version of https://github.com/dandi/dandisets-healthstatus

Currently it takes under two hours to read an NWB file from all 158 dandisets with NWB files on DANDI. The max GitHub Actions runtime is 6 hours.
Note that some reads may time out. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
