### PR TITLE
Adjust test to not count warnings on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   [#1690](https://github.com/NeurodataWithoutBorders/pynwb/pull/1690)
 - Update `requirements-doc.txt` to resolve Python 3.7 incompatibility. @rly
   [#1694](https://github.com/NeurodataWithoutBorders/pynwb/pull/1694)
+- Fixed test battery to show and check for warnings appropriately. @rly
+  [#1698](https://github.com/NeurodataWithoutBorders/pynwb/pull/1698)
 
 ## PyNWB 2.3.2 (April 10, 2023)
 

--- a/src/pynwb/testing/testh5io.py
+++ b/src/pynwb/testing/testh5io.py
@@ -107,7 +107,7 @@ class NWBH5IOMixin(metaclass=ABCMeta):
                                            BrokenLinkWarning)):
                     raise Exception('%s: %s' % (w.category.__name__, w.message))
                 else:
-                    warnings.warn(w.message, w.category)
+                    warnings.showwarning(w.message, w.category, w.filename, w.lineno, w.file, w.line)
 
         try:
             return self.getContainer(self.read_nwbfile)
@@ -141,7 +141,7 @@ class NWBH5IOMixin(metaclass=ABCMeta):
                                            BrokenLinkWarning)):
                     raise Exception('%s: %s' % (w.category.__name__, w.message))
                 else:
-                    warnings.warn(w.message, w.category)
+                    warnings.showwarning(w.message, w.category, w.filename, w.lineno, w.file, w.line)
 
         try:
             return self.getContainer(self.read_exported_nwbfile)

--- a/tests/unit/test_epoch_legacy.py
+++ b/tests/unit/test_epoch_legacy.py
@@ -66,41 +66,35 @@ class TestTimeIntervalsIO(NWBH5IOMixin, TestCase):
         nwbfile = NWBFile(description, identifier, self.start_time, file_create_date=self.create_date)
         self.addContainer(nwbfile)
 
-        with warnings.catch_warnings(record=True) as ws:
-            # write the file
-            with NWBHDF5IO(self.filename, mode='w') as write_io:
-                write_io.write(nwbfile, cache_spec=False)
-            # Modify the HDF5 file to look like NWB 2.4 and earlier. This simply means
-            # modifying the neurodata_type on the TimeIntervals.timeseries column
-            with h5py.File(self.filename, mode='a') as infile:
-                infile['/intervals/epochs/timeseries'].attrs['neurodata_type'] = 'VectorData'
-                infile.attrs['nwb_version'] = '2.3.0'
-            # Make sure we didn't have warnings
-            self.assertEqual(len(ws), 0)
+        # write the file
+        with NWBHDF5IO(self.filename, mode='w') as write_io:
+            write_io.write(nwbfile, cache_spec=False)
+        # Modify the HDF5 file to look like NWB 2.4 and earlier. This simply means
+        # modifying the neurodata_type on the TimeIntervals.timeseries column
+        with h5py.File(self.filename, mode='a') as infile:
+            infile['/intervals/epochs/timeseries'].attrs['neurodata_type'] = 'VectorData'
+            infile.attrs['nwb_version'] = '2.3.0'
 
         # Read the file back
-        with warnings.catch_warnings(record=True) as ws:
-            self.reader = NWBHDF5IO(self.filename, mode='r')
-            self.read_nwbfile = self.reader.read()
+        self.reader = NWBHDF5IO(self.filename, mode='r')
+        self.read_nwbfile = self.reader.read()
 
-            # Test that the VectorData column for timeseries has been converted to TimeSeriesReferenceVectorData
-            self.assertIsInstance(self.read_nwbfile.epochs.timeseries, TimeSeriesReferenceVectorData)
+        # Test that the VectorData column for timeseries has been converted to TimeSeriesReferenceVectorData
+        self.assertIsInstance(self.read_nwbfile.epochs.timeseries, TimeSeriesReferenceVectorData)
 
-            # Test that slicing into epochs.timeseries works as expected
-            re = self.read_nwbfile.epochs.timeseries[0]
-            self.assertIsInstance(re, TimeSeriesReference)
-            self.assertTupleEqual((re[0], re[1], re[2].object_id), (0, 5, nwbfile.get_acquisition('a').object_id))
+        # Test that slicing into epochs.timeseries works as expected
+        re = self.read_nwbfile.epochs.timeseries[0]
+        self.assertIsInstance(re, TimeSeriesReference)
+        self.assertTupleEqual((re[0], re[1], re[2].object_id), (0, 5, nwbfile.get_acquisition('a').object_id))
 
-            # Test that slicing into epochs works as expected
-            re = self.read_nwbfile.epochs[0:1]
-            self.assertListEqual(re.columns.tolist(), ['start_time', 'stop_time', 'temperature', 'tags', 'timeseries'])
-            for i in re.loc[0, 'timeseries']:
-                self.assertIsInstance(i, TimeSeriesReference)
-            self.assertTupleEqual(
-                (re.loc[0, 'timeseries'][0][0], re.loc[0, 'timeseries'][0][1], re.loc[0, 'timeseries'][0][2].object_id),
-                (0, 5, nwbfile.get_acquisition('a').object_id))
-            self.assertTupleEqual(
-                (re.loc[0, 'timeseries'][1][0], re.loc[0, 'timeseries'][1][1], re.loc[0, 'timeseries'][1][2].object_id),
-                (0, 3, nwbfile.get_acquisition('b').object_id))
-            # Make sure we didn't have warnings
-            self.assertEqual(len(ws), 0)
+        # Test that slicing into epochs works as expected
+        re = self.read_nwbfile.epochs[0:1]
+        self.assertListEqual(re.columns.tolist(), ['start_time', 'stop_time', 'temperature', 'tags', 'timeseries'])
+        for i in re.loc[0, 'timeseries']:
+            self.assertIsInstance(i, TimeSeriesReference)
+        self.assertTupleEqual(
+            (re.loc[0, 'timeseries'][0][0], re.loc[0, 'timeseries'][0][1], re.loc[0, 'timeseries'][0][2].object_id),
+            (0, 5, nwbfile.get_acquisition('a').object_id))
+        self.assertTupleEqual(
+            (re.loc[0, 'timeseries'][1][0], re.loc[0, 'timeseries'][1][1], re.loc[0, 'timeseries'][1][2].object_id),
+            (0, 3, nwbfile.get_acquisition('b').object_id))

--- a/tests/unit/test_epoch_legacy.py
+++ b/tests/unit/test_epoch_legacy.py
@@ -3,7 +3,6 @@ from pynwb.testing import NWBH5IOMixin, TestCase
 from pynwb import NWBFile, NWBHDF5IO
 from pynwb.base import TimeSeries, TimeSeriesReference, TimeSeriesReferenceVectorData
 import numpy as np
-import warnings
 import h5py
 
 


### PR DESCRIPTION
## Motivation

Counting the warnings is too coarse of a check. Warnings may be triggered from dependencies and not pynwb/hdmf. If we know what warning to look for, we should filter for that warning subclass and raise an error when it is seen. In the case of this test, I do not think we need to count the warnings, but let me know if you think otherwise @oruebel and what warning you are guarding against. I think you wrote this code?

Fix #1697. 

## How to test the behavior?
```
Run tests with numpy==1.25rc1
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
