### PR TITLE
Fix version of sphinx gallery to fix gallery index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
   [#1694](https://github.com/NeurodataWithoutBorders/pynwb/pull/1694)
 - Fixed test battery to show and check for warnings appropriately. @rly
   [#1698](https://github.com/NeurodataWithoutBorders/pynwb/pull/1698)
+- Fixed version of sphinx-gallery to 0.10.1 to avoid broken galley index in the docs. @oruebel
+  [#1728](https://github.com/NeurodataWithoutBorders/pynwb/pull/1728)
 
 ## PyNWB 2.3.2 (April 10, 2023)
 

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,7 +3,7 @@
 sphinx>=4  # improved support for docutils>=0.17
 sphinx_rtd_theme>=1  # <1 does not work with docutils>=0.17
 matplotlib
-sphinx-gallery
+sphinx-gallery==0.10.1 # See issue 1726. Gallery index is broken for 0.11 - 0.13. TODO relax version once issue is fixed
 # allensdk>=2.13.2  # allensdk reinstalls pynwb and hdmf. TODO set up a separate workflow to test allensdk
 # MarkupSafe==2.0.1  # resolve incompatibility between jinja2 and markupsafe: https://github.com/AllenInstitute/AllenSDK/issues/2308
 Pillow


### PR DESCRIPTION
## Motivation

Fix #1726  . This PR fixes the version for sphinx-gallery to version 0.10.1 because the page index for the gallery is broken when using sphinx-gallery 0.11.0 and up (I tested with 0.13, 0.12.2, 0.11.1 and they all show the same bad behavior).

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
