### PR TITLE
Update sphinx-gallery settings to support version >=0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@
 - Update links for making a release. @mavaylon1 [#1720](https://github.com/NeurodataWithoutBorders/pynwb/pull/1720)
 
 ### Bug fixes
-- Fixed version of sphinx-gallery to 0.10.1 to avoid broken galley index in the docs. @oruebel
-  [#1728](https://github.com/NeurodataWithoutBorders/pynwb/pull/1728)
+- Fixed sphinx-gallery setting to correctly display index in the docs with sphinx-gallery>=0.11. @oruebel [#1728](https://github.com/NeurodataWithoutBorders/pynwb/pull/1728)
 
 ### Documentation and tutorial enhancements
 - Added thumbnail for Optogentics tutorial @oruebel [#1729](https://github.com/NeurodataWithoutBorders/pynwb/pull/1729)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Update links for making a release. @mavaylon1 [#1720](https://github.com/NeurodataWithoutBorders/pynwb/pull/1720)
 
 ### Bug fixes
-- Fixed sphinx-gallery setting to correctly display index in the docs with sphinx-gallery>=0.11. @oruebel [#1728](https://github.com/NeurodataWithoutBorders/pynwb/pull/1728)
+- Fixed sphinx-gallery setting to correctly display index in the docs with sphinx-gallery>=0.11. @oruebel [#1733](https://github.com/NeurodataWithoutBorders/pynwb/pull/1733)
 
 ### Documentation and tutorial enhancements
 - Added thumbnail for Optogentics tutorial @oruebel [#1729](https://github.com/NeurodataWithoutBorders/pynwb/pull/1729)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -134,6 +134,7 @@ sphinx_gallery_conf = {
     'min_reported_time': 5,
     'remove_config_comments': True,
     'within_subsection_order': CustomSphinxGallerySectionSortKey,
+    'nested_sections': False,  # See issue https://github.com/sphinx-gallery/sphinx-gallery/issues/1152
 }
 
 intersphinx_mapping = {

--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -3,7 +3,7 @@
 sphinx>=4  # improved support for docutils>=0.17
 sphinx_rtd_theme>=1  # <1 does not work with docutils>=0.17
 matplotlib
-sphinx-gallery==0.10.1 # See issue 1726. Gallery index is broken for 0.11 - 0.13. TODO relax version once issue is fixed
+sphinx-gallery
 # allensdk>=2.13.2  # allensdk reinstalls pynwb and hdmf. TODO set up a separate workflow to test allensdk
 # MarkupSafe==2.0.1  # resolve incompatibility between jinja2 and markupsafe: https://github.com/AllenInstitute/AllenSDK/issues/2308
 Pillow


### PR DESCRIPTION
## Motivation

Add ``'nested_sections': False`` setting for sphinx-gallery to force using the orginial behavior for generating the page index to allow us to use the latest versions of sphinx-gallery (>=0.11) instead of having to fix the version to 0.10.1

This PR reverts the changes from https://github.com/NeurodataWithoutBorders/pynwb/pull/1728 such that the version of sphinx-gallery is no longer fixed. 


## Checklist

- [X] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
