### PR TITLE
Fix rendering error in parallel I/O tutorial

### DIFF
--- a/docs/gallery/advanced_io/parallelio.py
+++ b/docs/gallery/advanced_io/parallelio.py
@@ -22,7 +22,7 @@ HDF5 installed in a MPI configuration.
 #
 # 3. **Read from the file in parallel using MPI**: Here each of the 4 MPI ranks reads one time
 # step from the file
-
+#
 # .. code-block:: python
 #
 #     from mpi4py import MPI


### PR DESCRIPTION
## Motivation

The code block in the parallel I/O tutorial is currently being rendered incorrectly as a commented block.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
