### PR TITLE
Don't run validation test in integration tests

### DIFF
--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Run integration tests and generate coverage report
         run: |
-          python -m coverage run -p test.py --integration --backwards
+          python -m coverage run -p test.py --integration --validation --backwards
           # validation CLI tests generate separate .coverage files that need to be merged
           python -m coverage combine
           python -m coverage xml  # codecov uploader requires xml format

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Run integration tests and generate coverage report
         run: |
-          python -m coverage run -p test.py --integration --validation --backwards
+          python -m coverage run -p test.py --integration --validation-module --backwards
           # validation CLI tests generate separate .coverage files that need to be merged
           python -m coverage combine
           python -m coverage xml  # codecov uploader requires xml format

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## PyNWB 2.4.1 (July 26, 2023)
+
+### Bug fixes
+- Stop running validation tests as part of integration tests. They cause issues in CI and can be run separately. @rly [#1740](https://github.com/NeurodataWithoutBorders/pynwb/pull/1740)
+
 ## PyNWB 2.4.0 (July 23, 2023)
 
 ### Enhancements and minor changes

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -12,4 +12,4 @@ dependencies:
   - pandas==2.0.0
   - python-dateutil==2.8.2
   - setuptools
-  - dandi==0.52.0  # NOTE: dandi does not support osx-arm64
+  - dandi==0.55.1  # NOTE: dandi does not support osx-arm64

--- a/test.py
+++ b/test.py
@@ -233,9 +233,6 @@ def run_integration_tests(verbose=True):
 
     run_test_suite("tests/integration/utils", "integration utils tests", verbose=verbose)
 
-    # also test the validation script
-    run_test_suite("tests/validation", "validation tests", verbose=verbose)
-
 
 def clean_up_tests():
     # remove files generated from running example files

--- a/test.py
+++ b/test.py
@@ -304,12 +304,12 @@ def main():
                         help='run example tests with ros3 streaming')
     parser.add_argument('-b', '--backwards', action='append_const', const=flags['backwards'], dest='suites',
                         help='run backwards compatibility tests')
-    parser.add_argument('-w', '--validate-examples', action='append_const', const=flags['validate-examples'], dest='suites',
-                        help='run example tests and validation tests on example NWB files')
+    parser.add_argument('-w', '--validate-examples', action='append_const', const=flags['validate-examples'],
+                        dest='suites', help='run example tests and validation tests on example NWB files')
     parser.add_argument('-r', '--ros3', action='append_const', const=flags['ros3'], dest='suites',
                         help='run ros3 streaming tests')
-    parser.add_argument('-x', '--validation-module', action='append_const', const=flags['validation-module'], dest='suites',
-                        help='run ros3 streaming tests')
+    parser.add_argument('-x', '--validation-module', action='append_const', const=flags['validation-module'],
+                        dest='suites', help='run tests on pynwb.validate')
     args = parser.parse_args()
     if not args.suites:
         args.suites = list(flags.values())


### PR DESCRIPTION
Don't run validation test in integration tests. It causes issues in CI that has stderr output. This test can be triggered separately (`-w` flag)

## Motivation

See failing tests in https://github.com/conda-forge/pynwb-feedstock/pull/51

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
