### PR TITLE
Allow resetting data and timestamps on TimeSeries

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -167,7 +167,7 @@ class TimeSeries(NWBDataInterface):
             setattr(self, key, val)
 
         data = args_to_process['data']
-        self.fields['data'] = data
+        self.data = data
         if isinstance(data, TimeSeries):
             data.__add_link('data_link', self)
 
@@ -177,7 +177,7 @@ class TimeSeries(NWBDataInterface):
                 raise ValueError('Specifying rate and timestamps is not supported.')
             if self.starting_time is not None:
                 raise ValueError('Specifying starting_time and timestamps is not supported.')
-            self.fields['timestamps'] = timestamps
+            self.timestamps = timestamps
             self.timestamps_unit = self.__time_unit
             self.interval = 1
             if isinstance(timestamps, TimeSeries):
@@ -252,6 +252,10 @@ class TimeSeries(NWBDataInterface):
         else:
             return self.fields['data']
 
+    @data.setter
+    def data(self, val):
+        self.fields['data'] = val
+
     @property
     def data_link(self):
         return self.__get_links('data_link')
@@ -264,6 +268,10 @@ class TimeSeries(NWBDataInterface):
             return self.fields['timestamps'].timestamps
         else:
             return self.fields['timestamps']
+
+    @timestamps.setter
+    def timestamps(self, val):
+        self.fields['timestamps'] = val
 
     @property
     def timestamp_link(self):


### PR DESCRIPTION
## Motivation

Partner PR to https://github.com/hdmf-dev/hdmf/pull/868

TODO:
- [ ] Add tests
- [ ] Move validation to separate function that is called on build or into the setter (moving it into the setter would still not allow modifying multiple fields at once, e.g., changing TimeSeries with rate to having timestamps, but maybe that is OK for now)

## How to test the behavior?

Currently without the validation safeguards, this is allowed:
```
from pynwb.testing.mock.base import mock_TimeSeries

ts = mock_TimeSeries(timestamps=[1,2,3,4], rate=None)
ts.rate = 5  # this works
ts.data = [2,3,4,5]
ts.timestamps = [1,2,3]
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
