### PR TITLE
Fix two typos in documentation

### DIFF
--- a/docs/source/export.rst
+++ b/docs/source/export.rst
@@ -109,7 +109,7 @@ How do I write a newly instantiated ``NWBFile`` to two different file paths?
 -----------------------------------------------------------------------------------------------------------------------
 PyNWB does not support writing an :py:class:`~pynwb.file.NWBFile` that was not read from a file to two different files.
 For example, if you instantiate :py:class:`~pynwb.file.NWBFile` A and write it to file path 1, you cannot also write it
-to file path 2. However, you can first write the :py:class:`~pynwb.file.NWBFile`` to file path 1, read the
+to file path 2. However, you can first write the :py:class:`~pynwb.file.NWBFile` to file path 1, read the
 :py:class:`~pynwb.file.NWBFile` from file path 1, and then export it to file path 2.
 
 .. code-block:: python

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -11,7 +11,7 @@ The validator can be invoked like so:
   python -m pynwb.validate test.nwb
 
 If the file contains no NWB extensions, then this command will validate the file ``test.nwb`` against the
-*core* NWB specification. On success, the output will is:
+*core* NWB specification. On success, the output will be:
 
 .. code-block:: text
 


### PR DESCRIPTION
## Motivation

What was the reasoning behind this change? Please explain the changes briefly.
I was looking at the docs and noticed two very small typos (one formatting using a `` instead of ` and one grammatical using the wrong tense of a verb). Also happy to just open an issue if that's preferred, but they were easy enough to just fix.

## How to test the behavior?
No need to test for these typo fixes as far as I know.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes? **did you want changelog.md for a typo fix?**
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
