### PR TITLE
Change timeseries data checks to warn instead of error on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - For `NWBHDF5IO()`, change the default of arg `load_namespaces` from `False` to `True`. @bendichter [#1748](https://github.com/NeurodataWithoutBorders/pynwb/pull/1748)
 - Add `NWBHDF5IO.can_read()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
+- Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
 
 ## PyNWB 2.5.0 (August 18, 2023)
 

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -174,15 +174,23 @@ class TimeSeries(NWBDataInterface):
         timestamps = args_to_process['timestamps']
         if timestamps is not None:
             if self.rate is not None:
-                raise ValueError('Specifying rate and timestamps is not supported.')
+                self._error_on_new_warn_on_construct(
+                    error_msg='Specifying rate and timestamps is not supported.'
+                )
             if self.starting_time is not None:
-                raise ValueError('Specifying starting_time and timestamps is not supported.')
+                self._error_on_new_warn_on_construct(
+                    error_msg='Specifying starting_time and timestamps is not supported.'
+                )
             self.fields['timestamps'] = timestamps
             self.timestamps_unit = self.__time_unit
             self.interval = 1
             if isinstance(timestamps, TimeSeries):
                 timestamps.__add_link('timestamp_link', self)
         elif self.rate is not None:
+            if self.rate <= 0:
+                self._error_on_new_warn_on_construct(
+                    error_msg='Rate must be a positive value.'
+                )
             if self.starting_time is None:  # override default if rate is provided but not starting time
                 self.starting_time = 0.0
             self.starting_time_unit = self.__time_unit

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -444,6 +444,24 @@ class TestTimeSeries(TestCase):
                 timestamps=[1, 2, 3, 4, 5]
             )
 
+    def test_file_with_starting_time_and_timestamps_in_construct_mode(self):
+        """Test that UserWarning is raised when starting_time and timestamps are both specified
+         while being in construct mode (i.e,. on data read)."""
+        obj = TimeSeries.__new__(TimeSeries,
+                                 container_source=None,
+                                 parent=None,
+                                 object_id="test",
+                                 in_construct_mode=True)
+        with self.assertWarnsWith(warn_type=UserWarning,
+                                  exc_msg='Specifying starting_time and timestamps is not supported.'):
+            obj.__init__(
+                name="test_ts",
+                data=[11, 12, 13, 14, 15],
+                unit="volts",
+                starting_time=1.0,
+                timestamps=[1, 2, 3, 4, 5]
+            )
+
 
 class TestImage(TestCase):
     def test_init(self):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -405,6 +405,45 @@ class TestTimeSeries(TestCase):
         ts = mock_TimeSeries(data=[1., 2., 3.])
         assert_array_equal(ts.get_data_in_units(), [1., 2., 3.])
 
+    def test_non_positive_rate(self):
+        with self.assertRaisesWith(ValueError, 'Rate must be a positive value.'):
+            TimeSeries(name='test_ts', data=list(), unit='volts', rate=-1.0)
+        with self.assertRaisesWith(ValueError, 'Rate must be a positive value.'):
+            TimeSeries(name='test_ts1', data=list(), unit='volts', rate=0.0)
+
+    def test_file_with_non_positive_rate_in_construct_mode(self):
+        """Test that UserWarning is raised when rate is 0 or negative
+         while being in construct mode (i.e,. on data read)."""
+        obj = TimeSeries.__new__(TimeSeries,
+                                 container_source=None,
+                                 parent=None,
+                                 object_id="test",
+                                 in_construct_mode=True)
+        with self.assertWarnsWith(warn_type=UserWarning, exc_msg='Rate must be a positive value.'):
+            obj.__init__(
+                name="test_ts",
+                data=list(),
+                unit="volts",
+                rate=-1.0
+            )
+
+    def test_file_with_rate_and_timestamps_in_construct_mode(self):
+        """Test that UserWarning is raised when rate and timestamps are both specified
+         while being in construct mode (i.e,. on data read)."""
+        obj = TimeSeries.__new__(TimeSeries,
+                                 container_source=None,
+                                 parent=None,
+                                 object_id="test",
+                                 in_construct_mode=True)
+        with self.assertWarnsWith(warn_type=UserWarning, exc_msg='Specifying rate and timestamps is not supported.'):
+            obj.__init__(
+                name="test_ts",
+                data=[11, 12, 13, 14, 15],
+                unit="volts",
+                rate=1.0,
+                timestamps=[1, 2, 3, 4, 5]
+            )
+
 
 class TestImage(TestCase):
     def test_init(self):


### PR DESCRIPTION
## Motivation

Fixes #1786 and #1721.

- Changes data validation checks for rate and timestamps to warnings if reading in data
- adds error for making a new time series with a non-positive rate. Will only give warning if reading in data with non-positive rate

## How to test the behavior?

See example in #1721 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
