### PR TITLE
fix bug with w- io mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
 - Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries`. @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
 
+### Bug fixes
+- Fix bug where namespaces were loaded in "w-" mode. @h-mayorquin [#1795](https://github.com/NeurodataWithoutBorders/pynwb/pull/1795)
+
 ## PyNWB 2.5.0 (August 18, 2023)
 
 ### Enhancements and minor changes

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -261,7 +261,8 @@ class NWBHDF5IO(_HDF5IO):
             popargs('path', 'mode', 'manager', 'extensions', 'load_namespaces',
                     'file', 'comm', 'driver', 'herd_path', kwargs)
         # Define the BuildManager to use
-        if mode in 'wx' or manager is not None or extensions is not None:
+        io_modes_that_create_file = ['w', 'w-', 'x']
+        if mode in io_modes_that_create_file or manager is not None or extensions is not None:
             load_namespaces = False
 
         if load_namespaces:

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -123,6 +123,19 @@ class TestHDF5Writer(TestCase):
             io.write(self.container, cache_spec=False)
         with File(self.path, 'r') as f:
             self.assertNotIn('specifications', f)
+    
+    def test_file_creation_io_modes(self):
+        io_modes_that_create_file = ["w", "w-", "x"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir = Path(temp_dir)
+            for io_mode in io_modes_that_create_file:
+                file_path = temp_dir / f"test_io_mode={io_mode}.nwb"
+
+                # Test file creation
+                nwbfile = mock_NWBFile()
+                with NWBHDF5IO(str(file_path), io_mode) as io:
+                    io.write(nwbfile)
 
 
 class TestHDF5WriterWithInjectedFile(TestCase):
@@ -519,17 +532,3 @@ class TestNWBHDF5IO(TestCase):
             read_file = io.read()
             self.assertContainerEqual(read_file, self.nwbfile)
 
-
-class TestNWBHDF5IOModes(TestCase):
-    def test_file_creation_and_deletion(self):
-        io_modes_that_create_file = ["w", "w-", "x"]
-
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_dir = Path(temp_dir)
-            for io_mode in io_modes_that_create_file:
-                file_path = temp_dir / f"test_io_mode={io_mode}.nwb"
-
-                # Test file creation
-                nwbfile = mock_NWBFile()
-                with NWBHDF5IO(str(file_path), io_mode) as io:
-                    io.write(nwbfile)

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -3,6 +3,7 @@ from dateutil.tz import tzlocal, tzutc
 import numpy as np
 from h5py import File
 from pathlib import Path
+import tempfile
 
 from pynwb import NWBFile, TimeSeries, get_manager, NWBHDF5IO, validate
 
@@ -14,6 +15,7 @@ from hdmf.spec import NamespaceCatalog
 from pynwb.spec import NWBGroupSpec, NWBDatasetSpec, NWBNamespace
 from pynwb.ecephys import ElectricalSeries, LFP
 from pynwb.testing import remove_test_file, TestCase
+from pynwb.testing.mock.file import mock_NWBFile
 
 
 class TestHDF5Writer(TestCase):
@@ -516,3 +518,18 @@ class TestNWBHDF5IO(TestCase):
         with NWBHDF5IO(pathlib_path, 'r') as io:
             read_file = io.read()
             self.assertContainerEqual(read_file, self.nwbfile)
+
+
+class TestNWBHDF5IOModes(TestCase):
+    def test_file_creation_and_deletion(self):
+        io_modes_that_create_file = ["w", "w-", "x"]
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_dir = Path(temp_dir)
+            for io_mode in io_modes_that_create_file:
+                file_path = temp_dir / f"test_io_mode={io_mode}.nwb"
+
+                # Test file creation
+                nwbfile = mock_NWBFile()
+                with NWBHDF5IO(str(file_path), io_mode) as io:
+                    io.write(nwbfile)

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -123,7 +123,7 @@ class TestHDF5Writer(TestCase):
             io.write(self.container, cache_spec=False)
         with File(self.path, 'r') as f:
             self.assertNotIn('specifications', f)
-    
+
     def test_file_creation_io_modes(self):
         io_modes_that_create_file = ["w", "w-", "x"]
 
@@ -531,4 +531,3 @@ class TestNWBHDF5IO(TestCase):
         with NWBHDF5IO(pathlib_path, 'r') as io:
             read_file = io.read()
             self.assertContainerEqual(read_file, self.nwbfile)
-


### PR DESCRIPTION
## Motivation

@bendichter 

The PR in #1748 introduced a bug where the io mode "w-" still tries to load the name space. See coments:
https://github.com/NeurodataWithoutBorders/pynwb/pull/1748/files#r1421748605
https://github.com/NeurodataWithoutBorders/pynwb/pull/1748/files#r1421748559

## How to test the behavior?

Currently this fails in dev / main
```python

from pathlib import Path
from pynwb import NWBHDF5IO
from pynwb.testing.mock.file import mock_NWBFile


nwbfile = mock_NWBFile()

file_path = Path('test.nwb')
if file_path.exists():
    file_path.unlink()

with NWBHDF5IO('test.nwb', 'w-') as io:
    io.write(nwbfile)


Traceback (most recent call last):
  File "/home/heberto/development/pynwb/build/error_test.py", line 13, in <module>
    with NWBHDF5IO('test.nwb', 'w-') as io:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/heberto/miniconda3/envs/pynwb/lib/python3.11/site-packages/hdmf/utils.py", line 644, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/heberto/development/pynwb/src/pynwb/__init__.py", line 269, in __init__
    super().load_namespaces(tm, path, file=file_obj, driver=driver)
  File "/home/heberto/miniconda3/envs/pynwb/lib/python3.11/site-packages/hdmf/utils.py", line 644, in func_call
    return func(args[0], **pargs)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/heberto/miniconda3/envs/pynwb/lib/python3.11/site-packages/hdmf/backends/hdf5/h5tools.py", line 167, in load_namespaces
    open_file_obj = cls.__resolve_file_obj(path, file_obj, driver)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/heberto/miniconda3/envs/pynwb/lib/python3.11/site-packages/hdmf/backends/hdf5/h5tools.py", line 142, in __resolve_file_obj
    file_obj = File(path, 'r', **file_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/heberto/miniconda3/envs/pynwb/lib/python3.11/site-packages/h5py/_hl/files.py", line 567, in __init__
    fid = make_fid(name, mode, userblock_size, fapl, fcpl, swmr=swmr)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/heberto/miniconda3/envs/pynwb/lib/python3.11/site-packages/h5py/_hl/files.py", line 231, in make_fid
    fid = h5f.open(name, flags, fapl=fapl)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "h5py/h5f.pyx", line 106, in h5py.h5f.open
FileNotFoundError: [Errno 2] Unable to open file (unable to open file: name = 'test.nwb', errno = 2, error message = 'No such file or directory', flags = 0, o_flags = 0)
```

The current PR fixes this.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
