### PR TITLE
Enable offset, conversion and channel conversion in `mock_ElectricalSeries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `NWBHDF5IO.can_read()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
-- Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries` @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
+- Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries`. @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
 
 ## PyNWB 2.5.0 (August 18, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `NWBHDF5IO.can_read()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
-- Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries` [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
+- Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries` @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
 
 ## PyNWB 2.5.0 (August 18, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Add `NWBHDF5IO.can_read()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
-- Expose the the offset, conversion and channel conversion parameters in `mock_ElectricalSeries` [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
+- Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries` [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
 
 ## PyNWB 2.5.0 (August 18, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `NWBHDF5IO.can_read()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
+- Expose the the offset, conversion and channel conversion parameters in `mock_ElectricalSeries` [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
 
 ## PyNWB 2.5.0 (August 18, 2023)
 

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -75,8 +75,8 @@ def mock_ElectricalSeries(
     filtering: str = "filtering",
     nwbfile: Optional[NWBFile] = None,
     channel_conversion: Optional[np.ndarray] = None,
-    conversion: Optional[float] = None,
-    offset: Optional[float] = None,
+    conversion: float = 1.0,
+    offset: float =0.,
 ) -> ElectricalSeries:
     electrical_series = ElectricalSeries(
         name=name or name_generator("ElectricalSeries"),

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -73,7 +73,10 @@ def mock_ElectricalSeries(
     timestamps=None,
     electrodes: Optional[DynamicTableRegion] = None,
     filtering: str = "filtering",
-    nwbfile: Optional[NWBFile] = None
+    nwbfile: Optional[NWBFile] = None,
+    channel_conversion: Optional[np.ndarray] = None,
+    conversion: Optional[float] = None,
+    offset: Optional[float] = None,
 ) -> ElectricalSeries:
     electrical_series = ElectricalSeries(
         name=name or name_generator("ElectricalSeries"),
@@ -83,6 +86,9 @@ def mock_ElectricalSeries(
         timestamps=timestamps,
         electrodes=electrodes or mock_electrodes(nwbfile=nwbfile),
         filtering=filtering,
+        conversion=conversion,
+        offset=offset,
+        channel_conversion=channel_conversion,
     )
 
     if nwbfile is not None:

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -76,7 +76,7 @@ def mock_ElectricalSeries(
     nwbfile: Optional[NWBFile] = None,
     channel_conversion: Optional[np.ndarray] = None,
     conversion: float = 1.0,
-    offset: float =0.,
+    offset: float = 0.,
 ) -> ElectricalSeries:
     electrical_series = ElectricalSeries(
         name=name or name_generator("ElectricalSeries"),


### PR DESCRIPTION
## Motivation

I use this functions often for quick tests and and I am interested in having in testing scenarios that involve those attributes. Currently, they are not available  so the goal of this PR is to enable them. Note those arguments are enabled in `mock_TimeSeries`  as well so this makes the signatures more consistent.

https://github.com/h-mayorquin/pynwb/blob/8c4d62cc9c67645b04a2633b14148bcbbe2a8c45/src/pynwb/testing/mock/base.py#L10-L27



## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
