### PR TITLE
Make `get_data_in_units` work with `channel_conversion`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
 - Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries`. @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
-- Enchance `get_data_in_units()` to work with objects that have a `channel_conversion` attribute like the `ElectricalSeries`  @h-mayorquin [#1806](https://github.com/NeurodataWithoutBorders/pynwb/pull/1806)
+- Enhance `get_data_in_units()` to work with objects that have a `channel_conversion` attribute like the `ElectricalSeries`  @h-mayorquin [#1806](https://github.com/NeurodataWithoutBorders/pynwb/pull/1806)
 
 ### Bug fixes
 - Fix bug where namespaces were loaded in "w-" mode. @h-mayorquin [#1795](https://github.com/NeurodataWithoutBorders/pynwb/pull/1795)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
 - Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries`. @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
+- Enchance `get_data_in_units()` to work with objects that have a `channel_conversion` attribute like the `ElectricalSeries`  @h-mayorquin [#1806](https://github.com/NeurodataWithoutBorders/pynwb/pull/1806)
 
 ### Bug fixes
 - Fix bug where namespaces were loaded in "w-" mode. @h-mayorquin [#1795](https://github.com/NeurodataWithoutBorders/pynwb/pull/1795)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -296,7 +296,7 @@ class TimeSeries(NWBDataInterface):
             return np.arange(len(self.data)) / self.rate + self.starting_time
 
     def get_data_in_units(self):
-        return np.asarray(self.data) * self.conversion + self.offset
+        return np.asarray(self.data) * self.conversion * self.channel_conversion[:, np.newaxis] + self.offset
 
 
 @register_class('Image', CORE_NAMESPACE)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -297,7 +297,7 @@ class TimeSeries(NWBDataInterface):
 
     def get_data_in_units(self):
         if "channel_conversion" in self.fields:
-            scale_factor =  self.conversion * self.channel_conversion[:, np.newaxis]
+            scale_factor = self.conversion * self.channel_conversion[:, np.newaxis]
         else:
             scale_factor = self.conversion
         return np.asarray(self.data) * scale_factor + self.offset

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -296,7 +296,11 @@ class TimeSeries(NWBDataInterface):
             return np.arange(len(self.data)) / self.rate + self.starting_time
 
     def get_data_in_units(self):
-        return np.asarray(self.data) * self.conversion * self.channel_conversion[:, np.newaxis] + self.offset
+        if "channel_conversion" in self.fields:
+            scale_factor =  self.conversion * self.channel_conversion[:, np.newaxis]
+        else:
+            scale_factor = self.conversion
+        return np.asarray(self.data) * scale_factor + self.offset
 
 
 @register_class('Image', CORE_NAMESPACE)

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -131,9 +131,10 @@ def test_get_data_in_units():
     )
 
     data_in_units = electrical_series.get_data_in_units()
-    expected_data =  data * conversion * channel_conversion[:, np.newaxis] + offset
+    expected_data = data * conversion * channel_conversion[:, np.newaxis] + offset
 
     np.testing.assert_almost_equal(data_in_units, expected_data)
+
 
 class SpikeEventSeriesConstructor(TestCase):
 

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -117,23 +117,23 @@ class ElectricalSeriesConstructor(TestCase):
                    ) in str(w[-1].message)
 
 
-def test_get_data_in_units():
+    def test_get_data_in_units(self):
 
-    data = np.asarray([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]])
-    conversion = 1.0
-    offset = 3.0
-    channel_conversion = np.asarray([2.0, 2.0])
-    electrical_series = mock_ElectricalSeries(
-        data=data,
-        conversion=conversion,
-        offset=offset,
-        channel_conversion=channel_conversion,
-    )
+        data = np.asarray([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]])
+        conversion = 1.0
+        offset = 3.0
+        channel_conversion = np.asarray([2.0, 2.0])
+        electrical_series = mock_ElectricalSeries(
+            data=data,
+            conversion=conversion,
+            offset=offset,
+            channel_conversion=channel_conversion,
+        )
 
-    data_in_units = electrical_series.get_data_in_units()
-    expected_data = data * conversion * channel_conversion[:, np.newaxis] + offset
+        data_in_units = electrical_series.get_data_in_units()
+        expected_data = data * conversion * channel_conversion[:, np.newaxis] + offset
 
-    np.testing.assert_almost_equal(data_in_units, expected_data)
+        np.testing.assert_almost_equal(data_in_units, expected_data)
 
 
 class SpikeEventSeriesConstructor(TestCase):

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -18,6 +18,7 @@ from pynwb.ecephys import (
 from pynwb.device import Device
 from pynwb.file import ElectrodeTable
 from pynwb.testing import TestCase
+from pynwb.testing.mock.ecephys import mock_ElectricalSeries
 
 from hdmf.common import DynamicTableRegion
 
@@ -115,6 +116,24 @@ class ElectricalSeriesConstructor(TestCase):
                "but instead the first does. Data is oriented incorrectly and should be transposed."
                    ) in str(w[-1].message)
 
+
+def test_get_data_in_units():
+
+    data = np.asarray([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]])
+    conversion = 1.0
+    offset = 3.0
+    channel_conversion = np.asarray([2.0, 2.0])
+    electrical_series = mock_ElectricalSeries(
+        data=data,
+        conversion=conversion,
+        offset=offset,
+        channel_conversion=channel_conversion,
+    )
+
+    data_in_units = electrical_series.get_data_in_units()
+    expected_data =  data * conversion * channel_conversion[:, np.newaxis] + offset
+
+    np.testing.assert_almost_equal(data_in_units, expected_data)
 
 class SpikeEventSeriesConstructor(TestCase):
 

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -116,7 +116,6 @@ class ElectricalSeriesConstructor(TestCase):
                "but instead the first does. Data is oriented incorrectly and should be transposed."
                    ) in str(w[-1].message)
 
-
     def test_get_data_in_units(self):
 
         data = np.asarray([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]])


### PR DESCRIPTION
## Motivation

Fix #1797
## How to test the behavior?
Added test
## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
