### PR TITLE
change from error to warn when timeseries has a zero rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - For `NWBHDF5IO()`, change the default of arg `load_namespaces` from `False` to `True`. @bendichter [#1748](https://github.com/NeurodataWithoutBorders/pynwb/pull/1748)
 - Add `NWBHDF5IO.can_read()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
 - Add `pynwb.get_nwbfile_version()`. @bendichter [#1703](https://github.com/NeurodataWithoutBorders/pynwb/pull/1703)
-- Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793)
+- Updated timeseries data checks to warn instead of error when reading invalid files. @stephprince [#1793](https://github.com/NeurodataWithoutBorders/pynwb/pull/1793) and [#1809](https://github.com/NeurodataWithoutBorders/pynwb/pull/1809)
 - Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries`. @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
 
 ### Bug fixes

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -187,10 +187,12 @@ class TimeSeries(NWBDataInterface):
             if isinstance(timestamps, TimeSeries):
                 timestamps.__add_link('timestamp_link', self)
         elif self.rate is not None:
-            if self.rate <= 0:
+            if self.rate < 0:
                 self._error_on_new_warn_on_construct(
-                    error_msg='Rate must be a positive value.'
+                    error_msg='Rate must not be a negative value.'
                 )
+            elif self.rate == 0.0 and get_data_shape(data)[0] > 1:
+                warn('Timeseries has a rate of 0.0 Hz, but the length of the data is greater than 1.')
             if self.starting_time is None:  # override default if rate is provided but not starting time
                 self.starting_time = 0.0
             self.starting_time_unit = self.__time_unit

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -406,10 +406,12 @@ class TestTimeSeries(TestCase):
         assert_array_equal(ts.get_data_in_units(), [1., 2., 3.])
 
     def test_non_positive_rate(self):
-        with self.assertRaisesWith(ValueError, 'Rate must be a positive value.'):
+        with self.assertRaisesWith(ValueError, 'Rate must not be a negative value.'):
             TimeSeries(name='test_ts', data=list(), unit='volts', rate=-1.0)
-        with self.assertRaisesWith(ValueError, 'Rate must be a positive value.'):
-            TimeSeries(name='test_ts1', data=list(), unit='volts', rate=0.0)
+
+        with self.assertWarnsWith(UserWarning,
+                                  'Timeseries has a rate of 0.0 Hz, but the length of the data is greater than 1.'):
+            TimeSeries(name='test_ts1', data=[1, 2, 3], unit='volts', rate=0.0)
 
     def test_file_with_non_positive_rate_in_construct_mode(self):
         """Test that UserWarning is raised when rate is 0 or negative
@@ -419,7 +421,7 @@ class TestTimeSeries(TestCase):
                                  parent=None,
                                  object_id="test",
                                  in_construct_mode=True)
-        with self.assertWarnsWith(warn_type=UserWarning, exc_msg='Rate must be a positive value.'):
+        with self.assertWarnsWith(warn_type=UserWarning, exc_msg='Rate must not be a negative value.'):
             obj.__init__(
                 name="test_ts",
                 data=list(),


### PR DESCRIPTION
## Motivation

See discussion on #1793. There are some cases where TimeSeries with a zero rate have been used to store static microscopy images that we don't want to break back-compatibility for.

- change the new check to only check for `self.rate < 0`
- add a warning for `self.rate == 0.0` if the size of the first axis is greater than 1

## How to test the behavior?
```
TimeSeries(name='test_ts1', data=[1, 2, 3], unit='volts', rate=0.0)
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
