### PR TITLE
update versioneer configuration to fix reported readthedocs version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 - Fix bug where namespaces were loaded in "w-" mode. @h-mayorquin [#1795](https://github.com/NeurodataWithoutBorders/pynwb/pull/1795)
+- Fix bug where pynwb version was reported as "unknown" to readthedocs @stephprince [#1810](https://github.com/NeurodataWithoutBorders/pynwb/pull/1810)
 
 ## PyNWB 2.5.0 (August 18, 2023)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,7 @@ VCS = git
 versionfile_source = src/pynwb/_version.py
 versionfile_build = pynwb/_version.py
 tag_prefix = ''
+style = pep440-pre
 
 [flake8]
 max-line-length = 120

--- a/src/pynwb/_version.py
+++ b/src/pynwb/_version.py
@@ -44,7 +44,7 @@ def get_config():
     cfg = VersioneerConfig()
     cfg.VCS = "git"
     cfg.style = "pep440-pre"
-    cfg.tag_prefix = "*.*.*"
+    cfg.tag_prefix = ""
     cfg.parentdir_prefix = "None"
     cfg.versionfile_source = "src/pynwb/_version.py"
     cfg.verbose = False


### PR DESCRIPTION
## Motivation

Fix #1655 . `_version.py` and `setup.cfg` versioneer configurations were different so I rebuilt `_version.py` with versioneer so they would be consistent 
- `_version.py` was configured to use a tag prefix with the glob pattern `*.*.*`, but it is not setup to do pattern matching. This led to `_version.get_versions()` in `docs\source\conf.py` returning an `unknown`
- `pep440-pre` was the style configuration  in `_version.py`, but the default `pep440` was being used by `setup.cfg`. Not sure which one is best to use. (See - https://github.com/python-versioneer/python-versioneer#styles)

## How to test the behavior?
Build docs with `make html` and look at page title

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
