### PR TITLE
RF: centralize invocation of coverage within run_coverage and use sys.executable -m coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Expose the offset, conversion and channel conversion parameters in `mock_ElectricalSeries`. @h-mayorquin [#1796](https://github.com/NeurodataWithoutBorders/pynwb/pull/1796)
 - Expose `starting_time` in `mock_ElectricalSeries`. @h-mayorquin [#1805](https://github.com/NeurodataWithoutBorders/pynwb/pull/1805)
 - Enhance `get_data_in_units()` to work with objects that have a `channel_conversion` attribute like the `ElectricalSeries`. @h-mayorquin [#1806](https://github.com/NeurodataWithoutBorders/pynwb/pull/1806)
+- Refactor validation CLI tests to use `{sys.executable} -m coverage` to use the same Python version and run correctly on Debian systems. @yarikoptic [#1811](https://github.com/NeurodataWithoutBorders/pynwb/pull/1811)
 
 ### Bug fixes
 - Fix bug where namespaces were loaded in "w-" mode. @h-mayorquin [#1795](https://github.com/NeurodataWithoutBorders/pynwb/pull/1795)

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -131,7 +131,7 @@ class TestValidateCLI(TestCase):
 
     def test_validate_file_cached_ignore(self):
         """Test that validating a file with cached spec against the core namespace succeeds."""
-        result = run_coverage(["tests/back_compat/1.1.2_nwbfile.nwb", "--no-cached-namespace"]  )
+        result = run_coverage(["tests/back_compat/1.1.2_nwbfile.nwb", "--no-cached-namespace"])
 
         self.assertEqual(result.stderr.decode('utf-8'), '')
 


### PR DESCRIPTION
## Motivation

- duplication is evil
- some systems might have it installed as python3-coverage not as coverage (Debian)
- executable "coverage" might use shebang pointing to another python than used here

Originally crafted for Debian package

<details>
<summary>Note that locally I have two tests there failing while testing 2.5.0 release even without this diff</summary> 

```shell
❯ python -m pytest -s -v -k TestValidateCLI
================================================================ test session starts =================================================================
platform linux -- Python 3.11.7, pytest-7.4.3, pluggy-1.3.0 -- /home/yoh/deb/gits/pkg-exppsy/pynwb/venvs/dev3.11/bin/python
cachedir: .pytest_cache
rootdir: /home/yoh/deb/gits/pkg-exppsy/pynwb
collected 603 items / 591 deselected / 12 selected                                                                                                   

tests/validation/test_validate.py::TestValidateCLI::test_validate_file_cached PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_cached_bad_ns PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_cached_core PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_cached_extension PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_cached_extension_pass_ns PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_cached_hdmf_common PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_cached_ignore PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_invalid PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_list_namespaces_core PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_list_namespaces_extension PASSED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_no_cache FAILED
tests/validation/test_validate.py::TestValidateCLI::test_validate_file_no_cache_bad_ns FAILED

====================================================================== FAILURES ======================================================================
____________________________________________________ TestValidateCLI.test_validate_file_no_cache _____________________________________________________

self = <tests.validation.test_validate.TestValidateCLI testMethod=test_validate_file_no_cache>

    def test_validate_file_no_cache(self):
        """Test that validating a file with no cached spec against the core namespace succeeds."""
        result = subprocess.run(["coverage", "run", "-p", "-m", "pynwb.validate",
                                 "tests/back_compat/1.0.2_nwbfile.nwb"], capture_output=True)
    
        stderr_regex = re.compile(
            r".*UserWarning: No cached namespaces found in tests/back_compat/1\.0\.2_nwbfile\.nwb\s*"
            r"warnings.warn\(msg\)\s*"
            r"The file tests/back_compat/1\.0\.2_nwbfile\.nwb has no cached namespace information\. "
            r"Falling back to PyNWB namespace information\.\s*"
        )
>       self.assertRegex(result.stderr.decode('utf-8'), stderr_regex)
E       AssertionError: Regex didn't match: '.*UserWarning: No cached namespaces found in tests/back_compat/1\\.0\\.2_nwbfile\\.nwb\\s*warnings.warn\\(msg\\)\\s*The file tests/back_compat/1\\.0\\.2_nwbfile\\.nwb has no cached namespace information\\. Falling back to PyNWB namespace information\\.\\s*' not found in 'The file tests/back_compat/1.0.2_nwbfile.nwb has no cached namespace information. Falling back to PyNWB namespace information.\n'

tests/validation/test_validate.py:37: AssertionError
_________________________________________________ TestValidateCLI.test_validate_file_no_cache_bad_ns _________________________________________________

self = <tests.validation.test_validate.TestValidateCLI testMethod=test_validate_file_no_cache_bad_ns>

    def test_validate_file_no_cache_bad_ns(self):
        """Test that validating a file with no cached spec against a specified, unknown namespace fails."""
        result = subprocess.run(["coverage", "run", "-p", "-m", "pynwb.validate", "tests/back_compat/1.0.2_nwbfile.nwb",
                                 "--ns", "notfound"], capture_output=True)
    
        stderr_regex = re.compile(
            r".*UserWarning: No cached namespaces found in tests/back_compat/1\.0\.2_nwbfile\.nwb\s*"
            r"warnings.warn\(msg\)\s*"
            r"The file tests/back_compat/1\.0\.2_nwbfile\.nwb has no cached namespace information\. "
            r"Falling back to PyNWB namespace information\.\s*"
            r"The namespace 'notfound' could not be found in PyNWB namespace information as only "
            r"\['core'\] is present\.\s*"
        )
>       self.assertRegex(result.stderr.decode('utf-8'), stderr_regex)
E       AssertionError: Regex didn't match: ".*UserWarning: No cached namespaces found in tests/back_compat/1\\.0\\.2_nwbfile\\.nwb\\s*warnings.warn\\(msg\\)\\s*The file tests/back_compat/1\\.0\\.2_nwbfile\\.nwb has no cached namespace information\\. Falling back to PyNWB namespace information\\.\\s*The namespace 'notfound' could not be found in PyNWB namespace information as only \\['core'\\] is present\\.\\s*" not found in "The file tests/back_compat/1.0.2_nwbfile.nwb has no cached namespace information. Falling back to PyNWB namespace information.\nThe namespace 'notfound' could not be found in PyNWB namespace information as only ['core'] is present.\n"

tests/validation/test_validate.py:57: AssertionError
============================================================== short test summary info ===============================================================
FAILED tests/validation/test_validate.py::TestValidateCLI::test_validate_file_no_cache - AssertionError: Regex didn't match: '.*UserWarning: No cached namespaces found in tests/back_compat/1\\.0\\.2_nwbfile\\.nwb\\s*warnings.warn\\(ms...
FAILED tests/validation/test_validate.py::TestValidateCLI::test_validate_file_no_cache_bad_ns - AssertionError: Regex didn't match: ".*UserWarning: No cached namespaces found in tests/back_compat/1\\.0\\.2_nwbfile\\.nwb\\s*warnings.warn\\(ms...
=================================================== 2 failed, 10 passed, 591 deselected in 32.49s ====================================================
python -m pytest -s -v -k TestValidateCLI  42.32s user 35.34s system 237% cpu 32.669 total
```
</details>

edit 1: doesn't for you it generate bunch of `.coverage.*` files you have to cleanup manually?  IMHO should be avoided (didn't check if avoidable or should just be cleaned up later)

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
