### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/source/install_users.rst
+++ b/docs/source/install_users.rst
@@ -34,7 +34,7 @@ This will automatically install the following required dependencies:
 Install release from Conda-forge
 --------------------------------
 
-`Conda-forge <https://conda-forge.org/#about>`_ is a community led collection of recipes, build infrastructure
+`Conda-forge <https://conda-forge.org>`_ is a community led collection of recipes, build infrastructure
 and distributions for the `conda <https://conda.io/docs/>`_ package manager.
 
 To install or update PyNWB distribution from conda-forge using conda simply run:

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -17,7 +17,7 @@ tested on all supported operating systems and python distributions. That way,
 as a contributor, you know if you introduced regressions or coding style
 inconsistencies.
 
-There are badges in the :pynwb:`README <#readme>` file which shows
+There are badges in the :pynwb:`README <blob/dev/README.rst>` file which shows
 the current condition of the dev branch.
 
 --------
@@ -25,7 +25,7 @@ Coverage
 --------
 
 Code coverage is computed and reported using the coverage_ tool. There are two coverage-related
-badges in the :pynwb:`README <#readme>` file. One shows the status of the :pynwb:`GitHub Action workflow <actions?query=workflow%3A%22Run+coverage%22>` which runs the coverage_ tool and uploads the report to
+badges in the :pynwb:`README <blob/dev/README.rst>` file. One shows the status of the :pynwb:`GitHub Action workflow <actions?query=workflow%3A%22Run+coverage%22>` which runs the coverage_ tool and uploads the report to
 codecov_, and the other badge shows the percentage coverage reported from codecov_. A detailed report can be found on
 codecov_, which shows line by line which lines are covered by the tests.
 


### PR DESCRIPTION
## Motivation

The conda-forge page changed and the #about anchor is gone. We should probably avoid linking to anchors since they change more frequently than base URLs.

Sphinx link-check cannot detect/resolve https://github.com/NeurodataWithoutBorders/pynwb#readme . It seems like GitHub dynamically generates this anchor. This code [sphinx-doc/sphinx@master/sphinx/builders/linkcheck.py#L616](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/builders/linkcheck.py?rgh-link-date=2024-01-10T07%3A52%3A18Z#L616) would normally detect it, but it looks like something changed with the GitHub layout a few days ago - there are now tabs on the main repo page for readme, code of conduct, and license.

This is minor enough not to need a changelog entry.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
