### PR TITLE
Exclude pynwb retinotopy from sphinx apidoc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -207,7 +207,13 @@ release = '{}'.format(get_versions()['version'])
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'test.py']
+exclude_patterns = ['_build', 'test.py', "../../src/pynwb/retinotopy.py",]
+
+# List of patterns, relative to source directory, of modules to be
+# excluded by apidoc when generating rst files.
+apidoc_exclude = [
+    "../../src/pynwb/retinotopy.py",
+]
 
 # # This value contains a list of modules to be mocked up. This is useful
 # # when some external dependencies are not met at build time and break the
@@ -410,11 +416,6 @@ latex_logo = 'figures/logo_pynwb_with_margin.png'
 #
 # see http://www.sphinx-doc.org/en/master/extdev/appapi.html
 #
-
-# paths to modules to be excluded by apidoc when generating rst files
-apidoc_exclude = [
-    "../../src/pynwb/retinotopy",
-]
 
 def run_apidoc(_):
     from sphinx.ext.apidoc import main as apidoc_main

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,6 +209,13 @@ release = '{}'.format(get_versions()['version'])
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', 'test.py']
 
+# This value contains a list of modules to be mocked up. This is useful
+# when some external dependencies are not met at build time and break the
+# building process.
+autodoc_mock_imports = [
+    'pynwb.retinotopy',
+]
+
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -209,12 +209,12 @@ release = '{}'.format(get_versions()['version'])
 # directories to ignore when looking for source files.
 exclude_patterns = ['_build', 'test.py']
 
-# This value contains a list of modules to be mocked up. This is useful
-# when some external dependencies are not met at build time and break the
-# building process.
-autodoc_mock_imports = [
-    'pynwb.retinotopy',
-]
+# # This value contains a list of modules to be mocked up. This is useful
+# # when some external dependencies are not met at build time and break the
+# # building process.
+# autodoc_mock_imports = [
+#     'pynwb.retinotopy',
+# ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None
@@ -411,6 +411,10 @@ latex_logo = 'figures/logo_pynwb_with_margin.png'
 # see http://www.sphinx-doc.org/en/master/extdev/appapi.html
 #
 
+apidoc_exclude = [
+    "../../src/pynwb/retinotopy.py",
+]
+
 def run_apidoc(_):
     from sphinx.ext.apidoc import main as apidoc_main
     import os
@@ -418,7 +422,7 @@ def run_apidoc(_):
     out_dir = os.path.dirname(__file__)
     src_dir = os.path.join(out_dir, '../../src')
     sys.path.append(src_dir)
-    apidoc_main(['-f', '-e', '--no-toc', '-o', out_dir, src_dir])
+    apidoc_main(['-f', '-e', '--no-toc', '-o', out_dir, src_dir, *apidoc_exclude])
 
 
 from abc import abstractproperty

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -207,20 +207,13 @@ release = '{}'.format(get_versions()['version'])
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['_build', 'test.py', "../../src/pynwb/retinotopy.py",]
+exclude_patterns = ['_build', 'test.py']
 
 # List of patterns, relative to source directory, of modules to be
 # excluded by apidoc when generating rst files.
 apidoc_exclude = [
     "../../src/pynwb/retinotopy.py",
 ]
-
-# # This value contains a list of modules to be mocked up. This is useful
-# # when some external dependencies are not met at build time and break the
-# # building process.
-# autodoc_mock_imports = [
-#     'pynwb.retinotopy',
-# ]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 # default_role = None
@@ -424,7 +417,8 @@ def run_apidoc(_):
     out_dir = os.path.dirname(__file__)
     src_dir = os.path.join(out_dir, '../../src')
     sys.path.append(src_dir)
-    apidoc_main(['-f', '-e', '--no-toc', '-o', out_dir, src_dir, *apidoc_exclude])
+    apidoc_exclude_abs = [os.path.join(out_dir, f) for f in apidoc_exclude]
+    apidoc_main(['-f', '-e', '--no-toc', '-o', out_dir, src_dir, *apidoc_exclude_abs])
 
 
 from abc import abstractproperty

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -411,8 +411,9 @@ latex_logo = 'figures/logo_pynwb_with_margin.png'
 # see http://www.sphinx-doc.org/en/master/extdev/appapi.html
 #
 
+# paths to modules to be excluded by apidoc when generating rst files
 apidoc_exclude = [
-    "../../src/pynwb/retinotopy.py",
+    "../../src/pynwb/retinotopy",
 ]
 
 def run_apidoc(_):


### PR DESCRIPTION
Deprecating`import pynwb.retinotopy` results in an `ImportError` during sphinx docs generation. This PR tries to exclude that module from sphinx processing