### PR TITLE
Close open file in sphinx gallery and try deleting it

### DIFF
--- a/docs/gallery/general/plot_read_basics.py
+++ b/docs/gallery/general/plot_read_basics.py
@@ -283,3 +283,10 @@ for time in stim_on_times_landscapes.iloc[:3]:
 # object and accessing its attributes, but it may be useful to explore the data in a
 # more interactive, visual way. See :ref:`analysistools-explore` for an updated list of programs for
 # exploring NWB files.
+
+####################
+# Close the open NWB file
+# -----------------------
+# It is good practice, especially on Windows, to close any files that you have opened.
+
+io.close()

--- a/test.py
+++ b/test.py
@@ -276,7 +276,7 @@ def clean_up_tests():
         "processed_data.nwb",
         "raw_data.nwb",
         "scratch_analysis.nwb",
-        # "sub-P11HMH_ses-20061101_ecephys+image.nwb",  # TODO cannot delete this file on windows for some reason
+        "sub-P11HMH_ses-20061101_ecephys+image.nwb",
         "test_edit.nwb",
         "test_edit2.nwb",
         "test_cortical_surface.nwb",


### PR DESCRIPTION
One of the opened NWB files was not closed in a tutorial, which probably prevented it from being deleted in the post-tests cleanup process. Here we try to close and delete the file.