### PR TITLE
allow for TimeSeries with just timestamps specified

### DIFF
--- a/src/pynwb/testing/mock/base.py
+++ b/src/pynwb/testing/mock/base.py
@@ -15,7 +15,7 @@ def mock_TimeSeries(
     conversion: float = 1.0,
     timestamps=None,
     starting_time: Optional[float] = None,
-    rate: Optional[float] = 10.0,
+    rate: Optional[float] = None,
     comments: str = "no comments",
     description: str = "no description",
     control=None,
@@ -24,6 +24,8 @@ def mock_TimeSeries(
     nwbfile: Optional[NWBFile] = None,
     offset=0.,
 ) -> TimeSeries:
+    if timestamps is None and rate is None:
+        rate = 10.0  # Hz
     time_series = TimeSeries(
         name=name or name_generator("TimeSeries"),
         data=data if data is not None else np.array([1, 2, 3, 4]),

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -90,6 +90,17 @@ def test_mock(mock_function):
     mock_function()
 
 
+def test_mock_TimeSeries_w_timestamps():
+    ts = mock_TimeSeries(timestamps=[0, 1, 2, 3])
+    assert ts.timestamps is not None
+    assert len(ts.timestamps) == 4
+
+
+def test_mock_TimeSeries_w_no_time():
+    ts = mock_TimeSeries()
+    assert ts.rate == 10.0
+
+
 @pytest.mark.parametrize("mock_function", mock_functions)
 def test_mock_write(mock_function, tmp_path):
     if mock_function is mock_NWBFile:


### PR DESCRIPTION
## Motivation

Previously, if you wanted to use `mock_TimeSeries` while specifying `timestamps`, you would also need to set `rate=None`. 

```python
from pynwb.testing.mock.base import mock_TimeSeries

mock_TimeSeries(timestamps=[1,2,3,4])  # this used to fail
```

You had to specify `rate=None` explicitly, which is not ideal

```python
mock_TimeSeries(timestamps=[1,2,3,4], rate=None)  # this was the fix
```

Now, you don't need to.

```python
from pynwb.testing.mock.base import mock_TimeSeries

mock_TimeSeries()  # this works
mock_TimeSeries(timestamps=[1,2,3,4])  # this works
mock_TimeSeries(rate=10.0)  # this works
mock_TimeSeries(timestamps=[1,2,3,4], rate=10.0)  # this rightfully fails
```


