### PR TITLE
fix link check badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,8 @@ Overall Health
 .. image:: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/ruff.yml/badge.svg
     :target: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/ruff.yml
 
-.. image:: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/check_external_links.yml/badge.svg
-    :target: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/check_external_links.yml
+.. image:: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/check_sphinx_links.yml/badge.svg
+    :target: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/check_sphinx_links.yml
 
 .. image:: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/run_inspector_tests.yml/badge.svg
     :target: https://github.com/NeurodataWithoutBorders/pynwb/actions/workflows/run_inspector_tests.yml


### PR DESCRIPTION
## Motivation

The link checker badge is currently broken in the README, because it points to an old workflow name.

![Screenshot 2024-03-25 at 12 20 08 PM](https://github.com/NeurodataWithoutBorders/pynwb/assets/40640337/06948c58-9ee2-4b32-adaa-f1d3b638d931)

## How to test the behavior?

View updated README.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
