### PR TITLE
Add mock units table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   - Support `stimulus_template` as optional predefined column in `IntracellularStimuliTable`. @stephprince [#1815](https://github.com/NeurodataWithoutBorders/pynwb/pull/1815)
   - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
+- Added `mock_Units` for generating Units tables:  @h-mayorquin [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
 
 ### Bug fixes
 - Fix bug with reading file with linked `TimeSeriesReferenceVectorData` @rly [#1865](https://github.com/NeurodataWithoutBorders/pynwb/pull/1865)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Support `stimulus_template` as optional predefined column in `IntracellularStimuliTable`. @stephprince [#1815](https://github.com/NeurodataWithoutBorders/pynwb/pull/1815)
   - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
-- Added `mock_Units` for generating Units tables:  @h-mayorquin [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
+- Added `mock_Units` for generating Units tables.  @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875)
 
 ### Bug fixes
 - Fix bug with reading file with linked `TimeSeriesReferenceVectorData` @rly [#1865](https://github.com/NeurodataWithoutBorders/pynwb/pull/1865)

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -125,15 +125,13 @@ def mock_SpikeEventSeries(
 def mock_Units(
     num_units: int = 10,
     max_spikes_per_unit: int = 10,
-    seed: Optional[int] = None,
+    seed: int = 0,
     nwbfile: Optional[NWBFile] = None,
 ) -> Units:
 
     units_table = Units()
     units_table.add_column(name="unit_name", description="a readable identifier for the unit")
 
-    if seed is None:
-        seed = 0
     rng = np.random.default_rng(seed=seed)
 
     times = rng.random(size=(num_units, max_spikes_per_unit)).cumsum(axis=1)

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -140,7 +140,7 @@ def mock_Units(num_units: int = 10, max_spikes_per_unit: int = 10, seed: Optiona
     for unit_index in range(num_units):
 
         # Not all units have the same number of spikes
-        spike_times = times[unit_index, : spikes_per_unit[unit_index]]
+        spike_times = times[unit_index, :spikes_per_unit[unit_index]]
         unit_name = f"unit_{unit_index}"
         units_table.add_unit(spike_times=spike_times, unit_name=unit_name)
         

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -122,12 +122,15 @@ def mock_SpikeEventSeries(
     return spike_event_series
 
 
-def mock_Units(num_units: int = 10, max_spikes_per_unit: int = 10, seed: Optional[int] = None, nwbfile: NWBFile):
+def mock_Units(
+    num_units: int = 10,
+    max_spikes_per_unit: int = 10,
+    seed: Optional[int] = None,
+    nwbfile: Optional[NWBFile] = None,
+) -> Units:
 
     units_table = Units()
-    units_table.add_column(
-        name="unit_name", description="a readable identifier for the unit"
-    )
+    units_table.add_column(name="unit_name", description="a readable identifier for the unit")
 
     if seed is None:
         seed = 0
@@ -140,10 +143,10 @@ def mock_Units(num_units: int = 10, max_spikes_per_unit: int = 10, seed: Optiona
     for unit_index in range(num_units):
 
         # Not all units have the same number of spikes
-        spike_times = times[unit_index, :spikes_per_unit[unit_index]]
+        spike_times = times[unit_index, : spikes_per_unit[unit_index]]
         unit_name = f"unit_{unit_index}"
         units_table.add_unit(spike_times=spike_times, unit_name=unit_name)
-        
+
     if nwbfile is not None:
         nwbfile.units = units_table
 

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -133,7 +133,7 @@ def mock_Units(num_units: int = 10, max_spikes: int = 10, seed: Optional[int] = 
     )
 
     if seed is None:
-        seed = np.pi
+        seed = 0
     rng = np.random.default_rng(seed=seed)
 
     times = rng.random(size=(num_units, max_spikes)).cumsum(axis=1)

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -122,7 +122,7 @@ def mock_SpikeEventSeries(
     return spike_event_series
 
 
-def mock_Units(num_units: int = 10, max_spikes_per_unit: int = 10, seed: Optional[int] = None):
+def mock_Units(num_units: int = 10, max_spikes_per_unit: int = 10, seed: Optional[int] = None, nwbfile: NWBFile):
 
     units_table = Units()
     units_table.add_column(
@@ -143,5 +143,8 @@ def mock_Units(num_units: int = 10, max_spikes_per_unit: int = 10, seed: Optiona
         spike_times = times[unit_index, : spikes_per_unit[unit_index]]
         unit_name = f"unit_{unit_index}"
         units_table.add_unit(spike_times=spike_times, unit_name=unit_name)
+        
+    if nwbfile is not None:
+        nwbfile.units = units_table
 
     return units_table

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -9,6 +9,7 @@ from ...file import ElectrodeTable, NWBFile
 from ...ecephys import ElectricalSeries, ElectrodeGroup, SpikeEventSeries
 from .device import mock_Device
 from .utils import name_generator
+from ...misc import Units
 
 
 def mock_ElectrodeGroup(
@@ -121,11 +122,7 @@ def mock_SpikeEventSeries(
     return spike_event_series
 
 
-from pynwb.misc import Units
-import numpy as np 
-
-
-def mock_Units(num_units: int = 10, max_spikes: int = 10, seed: Optional[int] = None):
+def mock_Units(num_units: int = 10, max_spikes_per_unit: int = 10, seed: Optional[int] = None):
 
     units_table = Units()
     units_table.add_column(
@@ -136,8 +133,8 @@ def mock_Units(num_units: int = 10, max_spikes: int = 10, seed: Optional[int] = 
         seed = 0
     rng = np.random.default_rng(seed=seed)
 
-    times = rng.random(size=(num_units, max_spikes)).cumsum(axis=1)
-    spikes_per_unit = rng.integers(1, max_spikes, size=num_units)
+    times = rng.random(size=(num_units, max_spikes_per_unit)).cumsum(axis=1)
+    spikes_per_unit = rng.integers(1, max_spikes_per_unit, size=num_units)
 
     spike_times = []
     for unit_index in range(num_units):

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -119,3 +119,32 @@ def mock_SpikeEventSeries(
         nwbfile.add_acquisition(spike_event_series)
 
     return spike_event_series
+
+
+from pynwb.misc import Units
+import numpy as np 
+
+
+def mock_Units(num_units: int = 10, max_spikes: int = 10, seed: Optional[int] = None):
+
+    units_table = Units()
+    units_table.add_column(
+        name="unit_name", description="a readable identifier for the unit"
+    )
+
+    if seed is None:
+        seed = np.pi
+    rng = np.random.default_rng(seed=seed)
+
+    times = rng.random(size=(num_units, max_spikes)).cumsum(axis=1)
+    spikes_per_unit = rng.integers(1, max_spikes, size=num_units)
+
+    spike_times = []
+    for unit_index in range(num_units):
+
+        # Not all units have the same number of spikes
+        spike_times = times[unit_index, : spikes_per_unit[unit_index]]
+        unit_name = f"unit_{unit_index}"
+        units_table.add_unit(spike_times=spike_times, unit_name=unit_name)
+
+    return units_table

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -122,4 +122,3 @@ def test_name_generator():
     assert name_generator("TimeSeries") == "TimeSeries"
     assert name_generator("TimeSeries") == "TimeSeries2"
 
-

--- a/tests/unit/test_mock.py
+++ b/tests/unit/test_mock.py
@@ -35,6 +35,7 @@ from pynwb.testing.mock.ecephys import (
     mock_ElectrodeTable,
     mock_ElectricalSeries,
     mock_SpikeEventSeries,
+    mock_Units,
 )
 
 from pynwb.testing.mock.icephys import (
@@ -82,6 +83,7 @@ mock_functions = [
     mock_IntracellularElectrode,
     mock_CurrentClampStimulusSeries,
     mock_IntracellularRecordingsTable,
+    mock_Units,
 ]
 
 
@@ -119,3 +121,5 @@ def test_name_generator():
 
     assert name_generator("TimeSeries") == "TimeSeries"
     assert name_generator("TimeSeries") == "TimeSeries2"
+
+


### PR DESCRIPTION
## Motivation

Add a quick method to create mock units table
Is this something that would be of interest or useful to have?


## How to test the behavior?

Should we have tests for the mock methods?

```python
from pynwb.testing.mock.ecephys import mock_Units


units_table = mock_Units()
units_table.to_dataframe()
```

Produces the following output.

|   id | unit_name   | spike_times                                                                                                                                                                        |
|-----:|:------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
|    0 | unit_0      | [0.6369616873214543, 0.9067484010853246, 0.9477219250215193]                                                                                                                       |
|    1 | unit_1      | [0.8158535541215322, 0.8185920542916802, 1.6759963308792496, 1.709581906184714, 2.439237352614658]                                                                                 |
|    2 | unit_2      | [0.028319671145462966, 0.1526029476450269, 0.8232273623386572]                                                                                                                     |
|    3 | unit_3      | [0.6884467305709401, 1.0773681545500438, 1.212464659572455]                                                                                                                        |
|    4 | unit_4      | [0.5715298307297609, 0.8933992218057031, 1.4876992520053998, 1.825610477512533, 2.2172294780406943, 3.1075038300454865, 3.3346614235788663, 3.9578485682649087, 4.041863911847294] |
|    5 | unit_5      | [0.7870983074886834, 1.0264677504816355, 1.9029519812923392, 1.9615200160975337, 2.297637076643194, 2.447916543538033, 2.89825591018732, 3.694580180474614]                        |
|    6 | unit_6      | [0.4045518398215282, 0.6030648843307835]                                                                                                                                           |
|    7 | unit_7      | [0.6291081515397092, 1.5562627046075765, 1.9966398593233605, 2.9512303530140978, 3.4511261667017448, 3.8763547915508205, 4.496568243566198, 5.491664748801522, 6.440608423739287]  |
|    8 | unit_8      | [0.7577288453082914, 1.2551515407959104, 1.784463700992681, 2.5702494017064885, 2.9849052510621594, 3.7193888228508887, 4.430531700840638, 5.3625913874540165, 5.477524020734922]  |
|    9 | unit_9      | [0.9274239286245599, 1.8953501185492063, 1.9100564235145756]                                              

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
