### PR TITLE
Improve get_data_in_units docstring

### DIFF
--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -343,14 +343,17 @@ class TimeSeries(NWBDataInterface):
         .. math::
             out = data * conversion + offset
 
-        If the field 'channel_conversion' is present, the conversion factor is applied to each channel separately:
+        If the field 'channel_conversion' is present, the conversion factor for each channel is additionally applied 
+        to each channel:
 
         .. math::
-            out_{channel} = data * conversion_{channel} + offset
+            out_{channel} = data * conversion * conversion_{channel} + offset
+
+        NOTE: This will read the entire dataset into memory.
 
         Returns
         -------
-        np.ndarray
+        np.array
 
         """
         if "channel_conversion" in self.fields:

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -353,7 +353,7 @@ class TimeSeries(NWBDataInterface):
 
         Returns
         -------
-        np.array
+        :class:`numpy.ndarray`
 
         """
         if "channel_conversion" in self.fields:


### PR DESCRIPTION
Follow-up to #1878 to fix a broken link and clarify the docstring further to reflect the behavior of `channel_conversion`.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
