### PR TITLE
Add default `name="units"` to `Units` object in the `mock_Units` testing function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Support `stimulus_template` as optional predefined column in `IntracellularStimuliTable`. @stephprince [#1815](https://github.com/NeurodataWithoutBorders/pynwb/pull/1815)
   - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
-- Added `mock_Units` for generating Units tables.  @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875)
+- Added `mock_Units` for generating Units tables.  @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875) and [#1883](https://github.com/NeurodataWithoutBorders/pynwb/pull/1883)
 
 ### Bug fixes
 - Fix bug with reading file with linked `TimeSeriesReferenceVectorData` @rly [#1865](https://github.com/NeurodataWithoutBorders/pynwb/pull/1865)

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -129,7 +129,7 @@ def mock_Units(
     nwbfile: Optional[NWBFile] = None,
 ) -> Units:
 
-    units_table = Units()
+    units_table = Units(name="units")  # This is for nwbfile.units= mock_Units() to work
     units_table.add_column(name="unit_name", description="a readable identifier for the unit")
 
     rng = np.random.default_rng(seed=seed)


### PR DESCRIPTION
Related to this discussion here:
https://github.com/NeurodataWithoutBorders/pynwb/issues/1882

This is a quality of life small change that would allow two things to work:
* This part of the code:
https://github.com/h-mayorquin/pynwb/blob/ad6b0283c49ce8c391fd1b0e6ced3d0f6907c17d/src/pynwb/testing/mock/ecephys.py#L148-L150
* The following script for testing:

```python
from pynwb.testing.mock.file import mock_NWBFile
from pynwb.testing.mock.ecephys import mock_Units

nwbfile = mock_NWBFile()
units_table = mock_Units(num_units=5)
nwbfile.units = units_table
```

The only downside is that for `Units` object that are destined for some other places of the nwbfile (.e.g processing) this will not follow the best practices.  As these are functions that are mainly used for testing I think that this is not a big deal.