### PR TITLE
Add `grid_spacing` and `origin_coords` to the fields of `ImagingPlane`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
   - Support `stimulus_template` as optional predefined column in `IntracellularStimuliTable`. @stephprince [#1815](https://github.com/NeurodataWithoutBorders/pynwb/pull/1815)
   - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
-- Added `reference_frame`, `grid_spacing`, `grid_spacing_unit`, `origin_coords`, `origin_coords_unit` to `ImagingPlane` fields. @h-mayorquin [#1892](https://github.com/NeurodataWithoutBorders/pynwb/pull/1892)
+- Added `grid_spacing`, `grid_spacing_unit`, `origin_coords`, `origin_coords_unit` to `ImagingPlane` fields. @h-mayorquin [#1892](https://github.com/NeurodataWithoutBorders/pynwb/pull/1892)
 - Added `mock_Units` for generating Units tables. @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875) and [#1883](https://github.com/NeurodataWithoutBorders/pynwb/pull/1883)
 - Allow datetimes without a timezone and without a time. @rly [#1886](https://github.com/NeurodataWithoutBorders/pynwb/pull/1886)
 - No longer automatically set the timezone to the local timezone when not provided. [#1886](https://github.com/NeurodataWithoutBorders/pynwb/pull/1886)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
 - Added `mock_Units` for generating Units tables.  @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875) and [#1883](https://github.com/NeurodataWithoutBorders/pynwb/pull/1883)
+- Added `reference_frame`, `grid_spacing`, `grid_spacing_unit`, `origin_coords`, `origin_coords_unit` to `ImagingPlane` fields @h-mayorquin [#1892](https://github.com/NeurodataWithoutBorders/pynwb/pull/1892)
 
 ### Bug fixes
 - Fix bug with reading file with linked `TimeSeriesReferenceVectorData` @rly [#1865](https://github.com/NeurodataWithoutBorders/pynwb/pull/1865)

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -46,7 +46,7 @@ class ImagingPlane(NWBContainer):
                      'reference_frame',
                      'grid_spacing',
                      'grid_spacing_unit',
-                     'origin_coords'
+                     'origin_coords',
                      'origin_coords_unit'
                      )
 

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -43,7 +43,12 @@ class ImagingPlane(NWBContainer):
                      'manifold',
                      'conversion',
                      'unit',
-                     'reference_frame')
+                     'reference_frame',
+                     'grid_spacing',
+                     'grid_spacing_unit',
+                     'origin_coords'
+                     'origin_coords_unit'
+                     )
 
     @docval(*get_docval(NWBContainer.__init__, 'name'),  # required
             {'name': 'optical_channel', 'type': (list, OpticalChannel),  # required


### PR DESCRIPTION
## Motivation

This should fix #1885 

I discussed this with @rly and it seems that it was just an omission.  This PR tries to address this. So far, this seems to work for `grid_spacing` but for some reason that escapes me it seems that `origin_coords` is not added to the fields. 

![image](https://github.com/NeurodataWithoutBorders/pynwb/assets/6429509/5ea3ea40-3cc2-43d0-a49e-c119ae4b9e6f)


```python
from pynwb.testing.mock.ophys import mock_ImagingPlane

imaging_plane = mock_ImagingPlane(grid_spacing=[1.0, 1.0], origin_coords=[0.0, 0.0])
imaging_plane.origin_coords
list(imaging_plane.fields.keys())

```


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
