### PR TITLE
Ignore config cache warnings in sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,6 +168,8 @@ nitpicky = True
 nitpick_ignore = [('py:class', 'Intracomm'),
                   ('py:class', 'BaseStorageSpec')]
 
+suppress_warnings = ["config.cache"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 


### PR DESCRIPTION
## Motivation

Fix #1891.

The `sphinx_gallery_conf` configuration contains classes that are unpickleable and will now warn the user.

We could just ignore these warnings for now, or if we want to change the config I think we will have to wait on some serialization updates from sphinx. 

## How to test the behavior?
Update sphinx and run the following:
```
cd docs
make clean && make html
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
