### PR TITLE
Avoid having to set `rate=None` explitctly when passing timestamps in  `mock_ElectricalSeries`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## PyNWB 2.8.0 (Upcoming)
+
+### Enhancements and minor changes
+- Set rate default value inside `mock_ElectricalSeries` to avoid having to set `rate=None` explicitly when passing timestamps. @h-mayorquin [#1894](https://github.com/NeurodataWithoutBorders/pynwb/pull/1894)
+
 ## PyNWB 2.7.0 (May 2, 2024)
 
 ### Enhancements and minor changes
@@ -9,7 +14,6 @@
 - Modified `OptogeneticSeries` to allow 2D data, primarily in extensions of `OptogeneticSeries`. @rly [#1812](https://github.com/NeurodataWithoutBorders/pynwb/pull/1812)
 - Support `stimulus_template` as optional predefined column in `IntracellularStimuliTable`. @stephprince [#1815](https://github.com/NeurodataWithoutBorders/pynwb/pull/1815)
 - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
-- Set rate default value inside `mock_ElectricalSeries` to avoid having to set `rate=None` explicitly when passing timestamps. @h-mayorquin [#1894](https://github.com/NeurodataWithoutBorders/pynwb/pull/1894)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
 - Added `grid_spacing`, `grid_spacing_unit`, `origin_coords`, `origin_coords_unit` to `ImagingPlane` fields. @h-mayorquin [#1892](https://github.com/NeurodataWithoutBorders/pynwb/pull/1892)
 - Added `mock_Units` for generating Units tables. @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875) and [#1883](https://github.com/NeurodataWithoutBorders/pynwb/pull/1883)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Modified `OptogeneticSeries` to allow 2D data, primarily in extensions of `OptogeneticSeries`. @rly [#1812](https://github.com/NeurodataWithoutBorders/pynwb/pull/1812)
   - Support `stimulus_template` as optional predefined column in `IntracellularStimuliTable`. @stephprince [#1815](https://github.com/NeurodataWithoutBorders/pynwb/pull/1815)
   - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
-- Set rate default value inside `mock_ElectricalSeries` to avoid having to set `rate=None` explitctly when passing timestamps. @h-mayorquin [#1894](https://github.com/NeurodataWithoutBorders/pynwb/pull/1894)
+- Set rate default value inside `mock_ElectricalSeries` to avoid having to set `rate=None` explicitly when passing timestamps. @h-mayorquin [#1894](https://github.com/NeurodataWithoutBorders/pynwb/pull/1894)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
 - Added `mock_Units` for generating Units tables.  @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875) and [#1883](https://github.com/NeurodataWithoutBorders/pynwb/pull/1883)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Modified `OptogeneticSeries` to allow 2D data, primarily in extensions of `OptogeneticSeries`. @rly [#1812](https://github.com/NeurodataWithoutBorders/pynwb/pull/1812)
   - Support `stimulus_template` as optional predefined column in `IntracellularStimuliTable`. @stephprince [#1815](https://github.com/NeurodataWithoutBorders/pynwb/pull/1815)
   - Support `NWBDataInterface` and `DynamicTable` in `NWBFile.stimulus`. @rly [#1842](https://github.com/NeurodataWithoutBorders/pynwb/pull/1842)
+- Set rate default value inside `mock_ElectricalSeries` to avoid having to set `rate=None` explitctly when passing timestamps. @h-mayorquin [#1894](https://github.com/NeurodataWithoutBorders/pynwb/pull/1894)
 - Added support for python 3.12 and upgraded dependency versions. This also includes infrastructure updates for developers. @mavaylon1 [#1853](https://github.com/NeurodataWithoutBorders/pynwb/pull/1853)
 - Added `mock_Units` for generating Units tables.  @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875) and [#1883](https://github.com/NeurodataWithoutBorders/pynwb/pull/1883)
 

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -69,9 +69,9 @@ def mock_electrodes(
 def mock_ElectricalSeries(
     name: Optional[str] = None,
     description: str = "description",
-    data: Optional[np.ndarray] = None,
+    data=None,
     rate: Optional[float] = None,
-    timestamps: Optional[np.ndarray] = None,
+    timestamps=None,
     starting_time: Optional[float] = None,
     electrodes: Optional[DynamicTableRegion] = None,
     filtering: str = "filtering",

--- a/src/pynwb/testing/mock/ecephys.py
+++ b/src/pynwb/testing/mock/ecephys.py
@@ -69,9 +69,9 @@ def mock_electrodes(
 def mock_ElectricalSeries(
     name: Optional[str] = None,
     description: str = "description",
-    data=None,
-    rate: float = 30000.0,
-    timestamps=None,
+    data: Optional[np.ndarray] = None,
+    rate: Optional[float] = None,
+    timestamps: Optional[np.ndarray] = None,
     starting_time: Optional[float] = None,
     electrodes: Optional[DynamicTableRegion] = None,
     filtering: str = "filtering",
@@ -80,6 +80,10 @@ def mock_ElectricalSeries(
     conversion: float = 1.0,
     offset: float = 0.,
 ) -> ElectricalSeries:
+    
+    # Set a default rate if timestamps are not provided
+    rate = 30_000.0 if (timestamps is None and rate is None) else rate
+
     electrical_series = ElectricalSeries(
         name=name or name_generator("ElectricalSeries"),
         description=description,


### PR DESCRIPTION
## Motivation

Right now you get the following error when trying to pass timestamps to the `mock_ElectricalSeries` function. 

```python
from pynwb.testing.mock.ecephys import mock_ElectricalSeries


mock_ElectricalSeries(timestamps=np.arange(10))
ValueError: Specifying rate and timestamps is not supported.
```

This is because we have `rate=30,000.0` as a default value in the function signature. To make this work, the user has to explictly set rate=None, that is:

```python
from pynwb.testing.mock.ecephys import mock_ElectricalSeries


mock_ElectricalSeries(timestamps=np.arange(10), rate=None)
```

This is too cumbersome. This PR simplifies this so this is not necessary. To do this, it moves the logic of default values inside the function.

I also added some missing typing.

## How to test the behavior?
The code above should work.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
