### PR TITLE
Update coverage call, don't install in editable mode in testing

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -224,7 +224,7 @@ jobs:
       - name: Install run dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install -e .
+          pip install .
           conda info
           conda list
           pip list
@@ -271,7 +271,7 @@ jobs:
       - name: Install run dependencies
         run: |
           pip install matplotlib
-          pip install -e .
+          pip install .
           pip list
 
       - name: Conda reporting

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -53,20 +53,20 @@ jobs:
 
       - name: Install package
         run: |
-          python -m pip install -e .  # must install in editable mode for coverage to find sources
+          python -m pip install .
           python -m pip list
 
       - name: Run unit tests and generate coverage report
         run: |
           python -m coverage run test.py --pynwb
           python -m coverage xml  # codecov uploader requires xml format
-          python -m coverage report -m
+          python -m coverage report
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           flags: unit
-          files: coverage.xml
+          file: coverage.xml
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
@@ -77,13 +77,13 @@ jobs:
           # validation CLI tests generate separate .coverage files that need to be merged
           python -m coverage combine
           python -m coverage xml  # codecov uploader requires xml format
-          python -m coverage report -m
+          python -m coverage report
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           flags: integration
-          files: coverage.xml
+          file: coverage.xml
           fail_ci_if_error: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install dandi fsspec requests aiohttp pytest
           python -m pip uninstall -y pynwb  # uninstall pynwb
-          python -m pip install -e .
+          python -m pip install .
           python -m pip list
 
       - name: Conda reporting

--- a/.github/workflows/run_inspector_tests.yml
+++ b/.github/workflows/run_inspector_tests.yml
@@ -34,8 +34,7 @@ jobs:
           git clone https://github.com/NeurodataWithoutBorders/nwbinspector.git
           cd nwbinspector
           python -m pip install -r requirements.txt pytest
-          # must install in editable mode for coverage to find sources
-          python -m pip install -e .  # this might install a pinned version of pynwb instead of the current one
+          python -m pip install .  # this might install a pinned version of pynwb instead of the current one
           cd ..
           python -m pip uninstall -y pynwb  # uninstall the pinned version of pynwb
           python -m pip install .  # reinstall current branch of pynwb

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -200,7 +200,7 @@ jobs:
       - name: Install run dependencies
         run: |
           pip install -r requirements-dev.txt
-          pip install -e .
+          pip install .
           conda info
           conda list
           pip list
@@ -245,7 +245,7 @@ jobs:
       - name: Install run dependencies
         run: |
           pip install matplotlib
-          pip install -e .
+          pip install .
           pip list
 
       - name: Conda reporting

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `mock_Units` for generating Units tables. @h-mayorquin [#1875](https://github.com/NeurodataWithoutBorders/pynwb/pull/1875) and [#1883](https://github.com/NeurodataWithoutBorders/pynwb/pull/1883)
 - Allow datetimes without a timezone and without a time. @rly [#1886](https://github.com/NeurodataWithoutBorders/pynwb/pull/1886)
 - No longer automatically set the timezone to the local timezone when not provided. [#1886](https://github.com/NeurodataWithoutBorders/pynwb/pull/1886)
+- Updated testing to not install in editable mode and not run `coverage` by default. [#1897](https://github.com/NeurodataWithoutBorders/pynwb/pull/1897)
 
 ### Bug fixes
 - Fix bug with reading file with linked `TimeSeriesReferenceVectorData` @rly [#1865](https://github.com/NeurodataWithoutBorders/pynwb/pull/1865)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ ignore-words-list = "optin,potatos"
 
 [tool.coverage.run]
 branch = true
-source = ["src"]
+source = ["pynwb"]
 
 [tool.coverage.report]
 exclude_lines = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,27 +58,23 @@ version-file = "src/pynwb/_version.py"
 [tool.hatch.build.targets.wheel]
 packages = ["src/pynwb"]
 
-# [tool.pytest.ini_options] # TODO: uncomment when pytest is integrated
-# # Addopts creates a shortcut for pytest. For example below, running `pytest` will actually run `pytest --cov --cov-report html`.
-# addopts = "--cov --cov-report html" # generates coverage report in html format without showing anything on the terminal.
-
 [tool.codespell]
 skip = "htmlcov,.git,.mypy_cache,.pytest_cache,.coverage,*.pdf,*.svg,venvs,.tox,nwb-schema,./docs/_build/*,*.ipynb"
 ignore-words-list = "optin,potatos"
 
 [tool.coverage.run]
 branch = true
-source = ["src/"]
-omit = [
-    "src/pynwb/_due.py",
-    "src/pynwb/testing/*",
-    "src/pynwb/legacy/*"
-]
+source = ["src"]
 
 [tool.coverage.report]
 exclude_lines = [
     "pragma: no cover",
     "@abstract"
+]
+omit = [
+    "*/pynwb/_due.py",
+    "*/pynwb/testing/*",
+    "*/pynwb/legacy/*"
 ]
 
 [tool.ruff]

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ requires = pip >= 22.0
 
 [testenv]
 download = True
-usedevelop = True
 setenv =
   PYTHONDONTWRITEBYTECODE = 1
   VIRTUALENV_PIP = 23.3.1
@@ -112,7 +111,7 @@ install_command =
 deps =
     -rrequirements.txt
 commands =
-    python -m pip install -e .
+    python -m pip install .
     python -m pip install -r requirements-doc.txt  # NOTE: allensdk (requirements-doc.txt) requires pynwb
     python -m pip check
     python -m pip list
@@ -144,7 +143,7 @@ basepython = python3.12
 deps =
     -rrequirements-dev.txt
 commands =
-    python -m pip install -U -e .
+    python -m pip install -U .
     python -m pip install -r requirements-doc.txt  # NOTE: allensdk (requirements-doc.txt) requires pynwb
     python -m pip check
     python -m pip list
@@ -156,7 +155,7 @@ basepython = python3.12
 deps =
     -rrequirements-dev.txt
 commands =
-    python -m pip install -U --pre -e .
+    python -m pip install -U --pre .
     python -m pip install -r requirements-doc.txt  # NOTE: allensdk (requirements-doc.txt) requires pynwb
     python -m pip check
     python -m pip list


### PR DESCRIPTION
## Motivation

Follow-up to https://github.com/NeurodataWithoutBorders/nwbinspector/pull/450#discussion_r1583475196

https://setuptools.pypa.io/en/latest/userguide/development_mode.html says
> Editable installs are not a perfect replacement for regular installs in a test environment. When in doubt, please test your projects as installed via a regular wheel. There are tools in the Python ecosystem, like [tox](https://pypi.org/project/tox) or [nox](https://pypi.org/project/nox), that can help you with that (when used with appropriate configuration).

We use editable installs in testing in a couple places, mostly to help `coverage` find the sources, but we can configure that in `pyproject.toml` instead.

## How to test the behavior?
Run GitHub actions

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
