### PR TITLE
Exclude artifacts from sdist and wheel

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,0 @@
-include license.txt Legal.txt src/pynwb/_due.py
-include requirements.txt requirements-dev.txt requirements-doc.txt requirements-min.txt environment-ros3.yml
-include test.py tox.ini
-
-graft tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ version-file = "src/pynwb/_version.py"
 [tool.hatch.build.targets.sdist]
 exclude = [
     ".git*",
-    ".codespellrc",
+    ".codecov.yml",
     ".readthedocs.yaml",
 ]
 
@@ -66,7 +66,7 @@ exclude = [
 packages = ["src/pynwb"]
 exclude = [
     ".git*",
-    ".codespellrc",
+    ".codecov.yml",
     ".readthedocs.yaml",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,20 @@ source = "vcs"
 # src/pynwb/__init__.py to set `__version__` (from _version.py).
 version-file = "src/pynwb/_version.py"
 
+[tool.hatch.build.targets.sdist]
+exclude = [
+    ".git*",
+    ".codespellrc",
+    ".readthedocs.yaml",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/pynwb"]
+exclude = [
+    ".git*",
+    ".codespellrc",
+    ".readthedocs.yaml",
+]
 
 [tool.codespell]
 skip = "htmlcov,.git,.mypy_cache,.pytest_cache,.coverage,*.pdf,*.svg,venvs,.tox,nwb-schema,./docs/_build/*,*.ipynb"


### PR DESCRIPTION
Building the wheel from the PyPI sdist will include those files and
directories otherwise. They are also distributed in the uploaded wheel.
