### PR TITLE
Tell codespell to ignore "assertIn"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,7 +327,7 @@
 
 ### Tutorial enhancements:
 - Added new tutorial for intracellular electrophysiology to describe the use of the new metadata tables
-  and declared the previous tutoral using ``SweepTable`` as deprecated.  @oruebel (#1349)
+  and declared the previous tutorial using ``SweepTable`` as deprecated.  @oruebel (#1349)
 - Added new tutorial for querying intracellular electrophysiology metadata
   (``docs/gallery/domain/plot_icephys_pandas.py``). @oruebel (#1349, #1383)
 - Added thumbnails for tutorials to improve presentation of online docs.  @oruebel (#1349)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ exclude = [
 
 [tool.codespell]
 skip = "htmlcov,.git,.mypy_cache,.pytest_cache,.coverage,*.pdf,*.svg,venvs,.tox,nwb-schema,./docs/_build/*,*.ipynb"
-ignore-words-list = "optin,potatos"
+ignore-words-list = "optin,potatos,assertin"
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
## Motivation

The latest version of codespell causes 10+ new check failures because it introduced the check/correction `assertIn ==> asserting, assert in, assertion`. We use `assertIn` in tests.
This PR tells codespell to ignore the word "assertIn".

See https://github.com/codespell-project/codespell/issues/3430

This is super minor and I think it does not merit a changelog entry.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
