### PR TITLE
Fix `channel_conversion` use in `TimeSeries.get_data_in_units`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - Simplified the introduction to NWB tutorial. @rly [#1914](https://github.com/NeurodataWithoutBorders/pynwb/pull/1914)
 - Simplified the ecephys and ophys tutorials. [#1915](https://github.com/NeurodataWithoutBorders/pynwb/pull/1915)
 
+### Bug fixes
+- Fixed use of `channel_conversion` in `TimeSeries` `get_data_in_units`. @rohanshah [1923](https://github.com/NeurodataWithoutBorders/pynwb/pull/1923)
+
 
 ## PyNWB 2.8.0 (May 28, 2024)
 

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -357,7 +357,7 @@ class TimeSeries(NWBDataInterface):
 
         """
         if "channel_conversion" in self.fields:
-            scale_factor = self.conversion * self.channel_conversion[:, np.newaxis]
+            scale_factor = self.conversion * self.channel_conversion
         else:
             scale_factor = self.conversion
         return np.asarray(self.data) * scale_factor + self.offset

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -132,7 +132,7 @@ class ElectricalSeriesConstructor(TestCase):
 
         data_in_units = electrical_series.get_data_in_units()
 
-        for channel_index in range(len(channel_conversion)):
+        for channel_index in range(channels):
             np.testing.assert_almost_equal(
                 data_in_units[:, channel_index],
                 np.ones(samples) * conversion * channel_conversion[channel_index] + offset

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -117,22 +117,26 @@ class ElectricalSeriesConstructor(TestCase):
                    ) in str(w[-1].message)
 
     def test_get_data_in_units(self):
-
-        data = np.asarray([[1, 1, 1, 1, 1], [1, 1, 1, 1, 1]])
-        conversion = 1.0
+        samples = 100
+        channels = 2
+        conversion = 10.0
         offset = 3.0
-        channel_conversion = np.asarray([2.0, 2.0])
+        channel_conversion = np.random.rand(channels)
+
         electrical_series = mock_ElectricalSeries(
-            data=data,
+            data=np.ones((samples, channels)),
             conversion=conversion,
             offset=offset,
             channel_conversion=channel_conversion,
         )
 
         data_in_units = electrical_series.get_data_in_units()
-        expected_data = data * conversion * channel_conversion[:, np.newaxis] + offset
 
-        np.testing.assert_almost_equal(data_in_units, expected_data)
+        for channel_index in range(len(channel_conversion)):
+            np.testing.assert_almost_equal(
+                data_in_units[:, channel_index],
+                np.ones(samples) * conversion * channel_conversion[channel_index] + offset
+            )
 
 
 class SpikeEventSeriesConstructor(TestCase):


### PR DESCRIPTION
## Motivation

Fixes issue discussed here: https://github.com/NeurodataWithoutBorders/helpdesk/discussions/83

## How to test the behavior?
Updated unit test to reflect functional change

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
