### PR TITLE
Template lint instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,6 +12,6 @@ Show how to reproduce the new behavior (can be a bug fix or a new feature)
 - [ ] Did you update CHANGELOG.md with your changes?
 - [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
 - [ ] Have you ensured the PR clearly describes the problem and the solution?
-- [ ] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
+- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
 - [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
 - [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.


### PR DESCRIPTION
## Motivation

was doing a PR, noticed the template instructions differ from the developer docs and the tests.

## Description

seems like this section should be in there too.

this PR changes the PR template to reflect the instructions in [`CONTRIBUTING.rst`](https://github.com/NeurodataWithoutBorders/pynwb/blob/20c5d75a6ce0b2deb729b81803c9c6440cff029c/docs/CONTRIBUTING.rst?plain=1#L163-L164)

## How to test the behavior?
```
uhhhhhhhhaaaaaaaaaidk
```

## Additional Comments

- alternatively we could just remove the line since CI checks it either way <3
- sorry about the commit messages, squash this, i tried to amend and failed

## Checklist

- [DID NOT] Did you update CHANGELOG.md with your changes? (i don't think this is a changelog thing)
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [EXTREMELY] Is your contribution compliant with our coding style? This can be checked running `flake8` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
