### PR TITLE
Return can_read as False if no nwbfile version is found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Documentation and tutorial enhancements
 - Added pre-release pull request instructions to release process documentation @stephprince [#1928](https://github.com/NeurodataWithoutBorders/pynwb/pull/1928)
 
+### Bug fixes
+- Fixed `can_read` method to return False if no nwbfile version can be found @stephprince [#1934](https://github.com/NeurodataWithoutBorders/pynwb/pull/1934)
+
 ## PyNWB 2.8.1 (July 3, 2024)
 
 ### Documentation and tutorial enhancements

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -4,6 +4,7 @@ for reading and writing data in NWB format
 import os.path
 from pathlib import Path
 from copy import deepcopy
+from warnings import warn
 import h5py
 
 from hdmf.spec import NamespaceCatalog
@@ -271,9 +272,13 @@ class NWBHDF5IO(_HDF5IO):
             with h5py.File(path, "r") as file:   # path is HDF5 file
                 version_info = get_nwbfile_version(file)
                 if version_info[0] is None:
+                    warn("Cannot read because missing NWB version in the HDF5 file. The file is not a valid NWB file.")
+                    return False
+                elif version_info[1][0] < 2:    # Major versions of NWB < 2 not supported
+                    warn("Cannot read because PyNWB supports NWB files version 2 and above.")
                     return False
                 else:
-                    return version_info[1][0] >= 2    # Major version of NWB >= 2
+                    return True
         except IOError:
             return False
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -269,7 +269,11 @@ class NWBHDF5IO(_HDF5IO):
             return False
         try:
             with h5py.File(path, "r") as file:   # path is HDF5 file
-                return get_nwbfile_version(file)[1][0] >= 2    # Major version of NWB >= 2
+                version_info = get_nwbfile_version(file)
+                if version_info[0] is None:
+                    return False
+                else:
+                    return version_info[1][0] >= 2    # Major version of NWB >= 2
         except IOError:
             return False
 

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -554,7 +554,7 @@ class TestNWBHDF5IO(TestCase):
         # write the example file
         with NWBHDF5IO(self.path, 'w') as io:
             io.write(self.nwbfile)
-        # remove the version attribute
+        # set the version attribute <2.0
         with File(self.path, mode='a') as io:
             io.attrs['nwb_version'] = "1.0.5"
         self.assertFalse(NWBHDF5IO.can_read(self.path))

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -547,8 +547,11 @@ class TestNWBHDF5IO(TestCase):
         # remove the version attribute
         with File(self.path, mode='a') as io:
             del io.attrs['nwb_version']
-        # assert can_read returns False
-        self.assertFalse(NWBHDF5IO.can_read(self.path))
+
+        # assert can_read returns False and warning raised
+        warn_msg = "Cannot read because missing NWB version in the HDF5 file. The file is not a valid NWB file."
+        with self.assertWarnsWith(UserWarning, warn_msg):
+            self.assertFalse(NWBHDF5IO.can_read(self.path))
 
     def test_can_read_file_old_version(self):
         # write the example file
@@ -557,7 +560,11 @@ class TestNWBHDF5IO(TestCase):
         # set the version attribute <2.0
         with File(self.path, mode='a') as io:
             io.attrs['nwb_version'] = "1.0.5"
-        self.assertFalse(NWBHDF5IO.can_read(self.path))
+
+        # assert can_read returns False and warning raised
+        warn_msg = "Cannot read because PyNWB supports NWB files version 2 and above."
+        with self.assertWarnsWith(UserWarning, warn_msg):
+            self.assertFalse(NWBHDF5IO.can_read(self.path))
 
     def test_can_read_file_invalid_hdf5_file(self):
         # current file is not an HDF5 file

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -550,7 +550,7 @@ class TestNWBHDF5IO(TestCase):
         # assert can_read returns False
         self.assertFalse(NWBHDF5IO.can_read(self.path))
 
-    def can_read_file_old_version(self):
+    def test_can_read_file_old_version(self):
         # write the example file
         with NWBHDF5IO(self.path, 'w') as io:
             io.write(self.nwbfile)

--- a/tests/integration/hdf5/test_io.py
+++ b/tests/integration/hdf5/test_io.py
@@ -531,3 +531,34 @@ class TestNWBHDF5IO(TestCase):
         with NWBHDF5IO(pathlib_path, 'r') as io:
             read_file = io.read()
             self.assertContainerEqual(read_file, self.nwbfile)
+
+    def test_can_read_current_nwb_file(self):
+        with NWBHDF5IO(self.path, 'w') as io:
+            io.write(self.nwbfile)
+        self.assertTrue(NWBHDF5IO.can_read(self.path))
+
+    def test_can_read_file_does_not_exits(self):
+        self.assertFalse(NWBHDF5IO.can_read('not_a_file.nwb'))
+
+    def test_can_read_file_no_version(self):
+        # write the example file
+        with NWBHDF5IO(self.path, 'w') as io:
+            io.write(self.nwbfile)
+        # remove the version attribute
+        with File(self.path, mode='a') as io:
+            del io.attrs['nwb_version']
+        # assert can_read returns False
+        self.assertFalse(NWBHDF5IO.can_read(self.path))
+
+    def can_read_file_old_version(self):
+        # write the example file
+        with NWBHDF5IO(self.path, 'w') as io:
+            io.write(self.nwbfile)
+        # remove the version attribute
+        with File(self.path, mode='a') as io:
+            io.attrs['nwb_version'] = "1.0.5"
+        self.assertFalse(NWBHDF5IO.can_read(self.path))
+
+    def test_can_read_file_invalid_hdf5_file(self):
+        # current file is not an HDF5 file
+        self.assertFalse(NWBHDF5IO.can_read(__file__))


### PR DESCRIPTION
## Motivation

Fix #1919. The `can_read` method would previously throw a TypeError if no nwbfile version was found. It now returns`False` instead.

I also added additional tests for `can_read` to improve code coverage.

## How to test the behavior?
```python
from h5py import File
from pynwb import NWBHDF5IO
from pynwb.testing.mock.file import mock_NWBFile

nwbfile = mock_NWBFile()
path = 'test.nwb'

with NWBHDF5IO(path, 'w') as io:
    io.write(nwbfile)
    
with File(path, mode='a') as io:
    del io.attrs['nwb_version']

print(f'{NWBHDF5IO.can_read(path) = }')
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
