### PR TITLE
Change epoch tags to property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
 - Fixed `can_read` method to return False if no nwbfile version can be found @stephprince [#1934](https://github.com/NeurodataWithoutBorders/pynwb/pull/1934)
+- Changed `epoch_tags` to be a NWBFile property instead of constructor argument. @stephprince [#1935](https://github.com/NeurodataWithoutBorders/pynwb/pull/1935)
 
 ## PyNWB 2.8.1 (July 3, 2024)
 

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -273,7 +273,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
                      {'name': 'subject', 'child': True, 'required_name': 'subject'},
                      {'name': 'sweep_table', 'child': True, 'required_name': 'sweep_table'},
                      {'name': 'invalid_times', 'child': True, 'required_name': 'invalid_times'},
-                     'epoch_tags',
                      # icephys_filtering is temporary. /intracellular_ephys/filtering dataset will be deprecated
                      {'name': 'icephys_filtering', 'settable': False},
                      {'name': 'intracellular_recordings', 'child': True,
@@ -523,9 +522,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
         for key, val in args_to_set.items():
             setattr(self, key, val)
 
-        # set epoch_tags to set() on initialization
-        self.fields['epoch_tags'] = self.epoch_tags
-
         self.__obj = None
 
     def all_children(self):
@@ -620,7 +616,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
         See :py:meth:`~hdmf.common.table.DynamicTable.add_column` for more details
         """
         self.__check_epochs()
-        self.fields['epoch_tags'].update(kwargs.pop('tags', list()))
         self.epochs.add_column(**kwargs)
 
     def add_epoch_metadata_column(self, *args, **kwargs):
@@ -642,8 +637,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
         enclosure versus sleeping between explorations)
         """
         self.__check_epochs()
-        if kwargs['tags'] is not None:
-            self.fields['epoch_tags'].update(kwargs['tags'])
         self.epochs.add_interval(**kwargs)
 
     def __check_electrodes(self):

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -362,8 +362,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
              'doc': 'Stimulus template TimeSeries objects belonging to this NWBFile', 'default': None},
             {'name': 'epochs', 'type': TimeIntervals,
              'doc': 'Epoch objects belonging to this NWBFile', 'default': None},
-            {'name': 'epoch_tags', 'type': (tuple, list, set),
-             'doc': 'A sorted list of tags used across all epochs', 'default': set()},
             {'name': 'trials', 'type': TimeIntervals,
              'doc': 'A table containing trial data', 'default': None},
             {'name': 'invalid_times', 'type': TimeIntervals,
@@ -426,7 +424,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
             'stimulus_template',
             'keywords',
             'processing',
-            'epoch_tags',
             'electrodes',
             'electrode_groups',
             'devices',
@@ -526,6 +523,9 @@ class NWBFile(MultiContainerInterface, HERDManager):
         for key, val in args_to_set.items():
             setattr(self, key, val)
 
+        # set epoch_tags to set() on initialization
+        self.fields['epoch_tags'] = self.epoch_tags
+
         self.__obj = None
 
     def all_children(self):
@@ -554,6 +554,10 @@ class NWBFile(MultiContainerInterface, HERDManager):
     def modules(self):
         warn("NWBFile.modules has been replaced by NWBFile.processing.", DeprecationWarning)
         return self.processing
+
+    @property
+    def epoch_tags(self):
+        return set(self.epochs.tags[:]) if self.epochs is not None else set()
 
     @property
     def ec_electrode_groups(self):
@@ -616,7 +620,7 @@ class NWBFile(MultiContainerInterface, HERDManager):
         See :py:meth:`~hdmf.common.table.DynamicTable.add_column` for more details
         """
         self.__check_epochs()
-        self.epoch_tags.update(kwargs.pop('tags', list()))
+        self.fields['epoch_tags'].update(kwargs.pop('tags', list()))
         self.epochs.add_column(**kwargs)
 
     def add_epoch_metadata_column(self, *args, **kwargs):
@@ -639,7 +643,7 @@ class NWBFile(MultiContainerInterface, HERDManager):
         """
         self.__check_epochs()
         if kwargs['tags'] is not None:
-            self.epoch_tags.update(kwargs['tags'])
+            self.fields['epoch_tags'].update(kwargs['tags'])
         self.epochs.add_interval(**kwargs)
 
     def __check_electrodes(self):

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -135,10 +135,6 @@ Fields:
     name1 <class 'pynwb\.base\.TimeSeries'>,
     name2 <class 'pynwb\.base\.TimeSeries'>
   }
-  epoch_tags: {
-    tag1,
-    tag2
-  }
   epochs: epochs <class 'pynwb.epoch.TimeIntervals'>
   file_create_date: \[datetime.datetime\(.*\)\]
   identifier: identifier

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -142,6 +142,15 @@ class NWBFileTest(TestCase):
         tags = self.nwbfile.epoch_tags
         self.assertEqual(set(expected_tags), set(tags))
 
+    def test_epoch_tags_single_string(self):
+        tags1 = 't1'
+        tags2 = 't2'
+        expected_tags = set([tags1, tags2])
+        self.nwbfile.add_epoch(0.0, 1.0, tags=tags1)
+        self.nwbfile.add_epoch(1.0, 2.0, tags=tags2)
+        tags = self.nwbfile.epoch_tags
+        self.assertEqual(expected_tags, tags)
+
     def test_add_acquisition(self):
         self.nwbfile.add_acquisition(TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                                                 'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -151,6 +151,9 @@ class NWBFileTest(TestCase):
         tags = self.nwbfile.epoch_tags
         self.assertEqual(expected_tags, tags)
 
+    def test_epoch_tags_no_table(self):
+        self.assertEqual(set(), self.nwbfile.epoch_tags)
+
     def test_add_acquisition(self):
         self.nwbfile.add_acquisition(TimeSeries('test_ts', [0, 1, 2, 3, 4, 5],
                                                 'grams', timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5]))


### PR DESCRIPTION
## Motivation

* Fix https://github.com/NeurodataWithoutBorders/pynwb/issues/1901.
* Fix https://github.com/NeurodataWithoutBorders/pynwb/issues/1449.

`epoch_tags` could be assigned in the `NWBFile` constructor, but it was never written to disk. It could also be out of sync with the epochs table. It seems that it was maybe originally meant to be a shortcut for getting all of the unique epoch tags from the `epochs` table.

As a side effect of this change, `epoch_tags` would no longer be displayed by `__repr__` or `_repr_html_` (I looked a little into getting it to display, but if we include properties in the reprs it makes several other different datatype print outs less clean).

See related discussion about deprecating here: https://github.com/NeurodataWithoutBorders/pynwb/pull/1521#issuecomment-1204314770

## How to test the behavior?
```python
from datetime import datetime
from dateutil.tz import tzlocal
from pynwb import NWBFile, NWBHDF5IO

nwbfile = NWBFile(
    session_id='test',
    session_description='test',
    identifier='12345',
    session_start_time=(
        datetime.now(tzlocal())
    ),
)
nwbfile.add_epoch(start_time=1.0, stop_time=10.0, tags=["tag1", "tag2"])
nwbfile.add_epoch(start_time=10.0, stop_time=20.0, tags=["tag1", "tag3"])
nwbfile.add_epoch(start_time=1.0, stop_time=10.0, tags="tag4")
print(f'memory: {nwbfile.epoch_tags}').  # memory: {'tag3', 'tag1', 'tag4', 'tag2'}

path = 'test1.nwb'
with NWBHDF5IO(path, 'w') as io:
    io.write(nwbfile)

with NWBHDF5IO(path, 'r') as io:
    nwb_read = io.read()
    print(f'disk: {nwb_read.epoch_tags}'). # disk: {'tag3', 'tag1', 'tag4', 'tag2'}
```


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
