### PR TITLE
Improve docs around waveforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## PyNWB 2.8.2 (Upcoming)
 
 ### Documentation and tutorial enhancements
-- Added pre-release pull request instructions to release process documentation @stephprince [#1928](https://github.com/NeurodataWithoutBorders/pynwb/pull/1928)
+- Added pre-release pull request instructions to release process documentation. @stephprince [#1928](https://github.com/NeurodataWithoutBorders/pynwb/pull/1928)
+- Improve docs for specifying waveforms in the Units table. @rly [#1936](https://github.com/NeurodataWithoutBorders/pynwb/pull/1936)
 
 ### Bug fixes
-- Fixed `can_read` method to return False if no nwbfile version can be found @stephprince [#1934](https://github.com/NeurodataWithoutBorders/pynwb/pull/1934)
+- Fixed `can_read` method to return False if no nwbfile version can be found. @stephprince [#1934](https://github.com/NeurodataWithoutBorders/pynwb/pull/1934)
 - Changed `epoch_tags` to be a NWBFile property instead of constructor argument. @stephprince [#1935](https://github.com/NeurodataWithoutBorders/pynwb/pull/1935)
 
 ## PyNWB 2.8.1 (July 3, 2024)

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -137,7 +137,7 @@ class Units(DynamicTable):
         'resolution'
     )
 
-    __waveforms_desc = (
+    __add_unit_waveforms_desc = (
         """
         Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension
         shows the response from different electrodes that all observe this unit simultaneously. In this
@@ -148,20 +148,21 @@ class Units(DynamicTable):
         Example usage::
 
             waveforms_list = [
-                [  # unit 1
-                    np.array([  # electrode 1
-                        [1, 2, 3, 4, 5],  # spike time 1 [sample 1, sample 2, ...]
-                        [2, 3, 4, 5, 6],  # spike time 2
-                    ]),
-                    np.array([  # electrode 2
-                        [3, 4, 5, 6, 7],  # spike time 1 [sample 1, sample 2, ...]
-                    ]),
-                ],
-                [  # unit 2
-                    np.array([  # electrode 1
+                np.array([  # unit 1
+                    [  # electrode 1
+                        [1, 2, 3, 4, 5],  # spike 1 [sample 1, sample 2, ...]
+                        [2, 3, 4, 5, 6],  # spike 2
+                    ],
+                    [  # electrode 2
+                        [3, 4, 5, 6, 7],  # spike 1 [sample 1, sample 2, ...]
+                        [2, 3, 4, 5, 6],  # spike 2
+                    ],
+                ]),
+                np.array([  # unit 2
+                    [  # electrode 1
                         [10, 20, 30, 40, 50],  # spike time 1 [sample 1, sample 2, ...]
-                    ]),
-                ],
+                    ],
+                ]),
             ]
             electrodes_list = [[1, 2], [3]]
             for unit_id in range(2):
@@ -182,7 +183,7 @@ class Units(DynamicTable):
         {'name': 'electrode_group', 'description': 'the electrode group that each spike unit came from'},
         {'name': 'waveform_mean', 'description': 'the spike waveform mean for each spike unit'},
         {'name': 'waveform_sd', 'description': 'the spike waveform standard deviation for each spike unit'},
-        {'name': 'waveforms', 'description': __waveforms_desc, 'index': 2}
+        {'name': 'waveforms', 'description': 'individual waveforms for each spike', 'index': 2}
     )
 
     @docval({'name': 'name', 'type': str, 'doc': 'Name of this Units interface', 'default': 'Units'},
@@ -226,7 +227,7 @@ class Units(DynamicTable):
              'default': None},
             {'name': 'waveform_sd', 'type': 'array_data', 'default': None,
              'doc': 'the spike waveform standard deviation for each unit. Shape is (time,) or (time, electrodes)'},
-            {'name': 'waveforms', 'type': 'array_data', 'default': None, 'doc': __waveforms_desc,
+            {'name': 'waveforms', 'type': 'array_data', 'default': None, 'doc': __add_unit_waveforms_desc,
              'shape': ((None, None), (None, None, None))},
             {'name': 'id', 'type': int, 'default': None, 'doc': 'the id for each unit'},
             allow_extra=True)

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -137,11 +137,42 @@ class Units(DynamicTable):
         'resolution'
     )
 
-    waveforms_desc = ('Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension '
-                      'shows the response from different electrodes that all observe this unit simultaneously. In this'
-                      ' case, the `electrodes` column of this Units table should be used to indicate which electrodes '
-                      'are associated with this unit, and the electrodes dimension here should be in the same order as'
-                      ' the electrodes referenced in the `electrodes` column of this table.')
+    __waveforms_desc = (
+        """
+        Individual waveforms for each spike. If the dataset is three-dimensional, the third dimension
+        shows the response from different electrodes that all observe this unit simultaneously. In this
+        case, the ``electrodes`` column of this Units table should be used to indicate which electrodes
+        are associated with this unit, and the electrodes dimension here should be in the same order as
+        the electrodes referenced in the ``electrodes`` column of this table.
+
+        Example usage::
+
+            waveforms_list = [
+                [  # unit 1
+                    np.array([  # electrode 1
+                        [1, 2, 3, 4, 5],  # spike time 1 [sample 1, sample 2, ...]
+                        [2, 3, 4, 5, 6],  # spike time 2
+                    ]),
+                    np.array([  # electrode 2
+                        [3, 4, 5, 6, 7],  # spike time 1 [sample 1, sample 2, ...]
+                    ]),
+                ],
+                [  # unit 2
+                    np.array([  # electrode 1
+                        [10, 20, 30, 40, 50],  # spike time 1 [sample 1, sample 2, ...]
+                    ]),
+                ],
+            ]
+            electrodes_list = [[1, 2], [3]]
+            for unit_id in range(2):
+                nwbfile.add_unit(
+                    id=unit_id,
+                    electrodes=electrodes_list[unit_id],
+                    waveforms=waveforms_list[unit_id]
+                )
+        """
+    )
+
     __columns__ = (
         {'name': 'spike_times', 'description': 'the spike times for each unit', 'index': True},
         {'name': 'obs_intervals', 'description': 'the observation intervals for each unit',
@@ -151,7 +182,7 @@ class Units(DynamicTable):
         {'name': 'electrode_group', 'description': 'the electrode group that each spike unit came from'},
         {'name': 'waveform_mean', 'description': 'the spike waveform mean for each spike unit'},
         {'name': 'waveform_sd', 'description': 'the spike waveform standard deviation for each spike unit'},
-        {'name': 'waveforms', 'description': waveforms_desc, 'index': 2}
+        {'name': 'waveforms', 'description': __waveforms_desc, 'index': 2}
     )
 
     @docval({'name': 'name', 'type': str, 'doc': 'Name of this Units interface', 'default': 'Units'},
@@ -195,7 +226,7 @@ class Units(DynamicTable):
              'default': None},
             {'name': 'waveform_sd', 'type': 'array_data', 'default': None,
              'doc': 'the spike waveform standard deviation for each unit. Shape is (time,) or (time, electrodes)'},
-            {'name': 'waveforms', 'type': 'array_data', 'default': None, 'doc': waveforms_desc,
+            {'name': 'waveforms', 'type': 'array_data', 'default': None, 'doc': __waveforms_desc,
              'shape': ((None, None), (None, None, None))},
             {'name': 'id', 'type': int, 'default': None, 'doc': 'the id for each unit'},
             allow_extra=True)


### PR DESCRIPTION
## Motivation

It is confusing to write Units waveforms with different numbers of electrodes and units. This PR improves the API docs for `Units.add_unit`.

<img width="553" alt="image" src="https://github.com/user-attachments/assets/495899e2-669b-4794-96c4-fab816563a95">

## How to test the behavior?
```
make clean && make html
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
