### PR TITLE
update ruff linter settings

### DIFF
--- a/docs/gallery/advanced_io/plot_linking_data.py
+++ b/docs/gallery/advanced_io/plot_linking_data.py
@@ -268,8 +268,8 @@ io2.close()
 # -------------------------------------------------------------------
 #
 # For extremely large datasets it can be useful to split data across multiple files, e.g., in cases where
-# the file stystem does not allow for large files. While we can
-# achieve this by writing different components (e.g., :py:meth:`~pynwb.base.TimeSeries`) to different files as described above,
+# the file stystem does not allow for large files. While we can achieve this by writing different
+# components (e.g., :py:meth:`~pynwb.base.TimeSeries`)  to different files as described above,
 # this option does not allow splitting data from single datasets. An alternative option is to use the
 # ``family`` driver in ``h5py`` to automatically split the NWB file into a collection of many HDF5 files.
 # The ``family`` driver stores the file on disk as a series of fixed-length chunks (each in its own file).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ exclude = [
   "dist/",
   "src/nwb-schema",
   "docs/source/conf.py",
+  "docs/notebooks/*",
   "src/pynwb/_due.py",
   "test.py" # remove when pytest comes along
 ]
@@ -108,7 +109,6 @@ line-length = 120
 [tool.ruff.lint.per-file-ignores]
 "tests/read_dandi/*" = ["T201"]
 "docs/gallery/*" = ["E402", "T201"]
-"docs/notebooks/*" = ["E402", "T201"]
 "src/*/__init__.py" = ["F401"]
 "src/pynwb/_version.py" = ["T201"]
 "src/pynwb/validate.py" = ["T201"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ omit = [
 ]
 
 [tool.ruff]
-select = ["E", "F", "T100", "T201", "T203"]
+lint.select = ["E", "F", "T100", "T201", "T203"]
 exclude = [
   ".git",
   ".tox",
@@ -105,7 +105,7 @@ exclude = [
 ]
 line-length = 120
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/read_dandi/*" = ["T201"]
 "docs/gallery/*" = ["E402", "T201"]
 "src/*/__init__.py" = ["F401"]
@@ -115,6 +115,6 @@ line-length = 120
 
 # "test_gallery.py" = ["T201"] # Uncomment when test_gallery.py is created
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 17
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ line-length = 120
 [tool.ruff.lint.per-file-ignores]
 "tests/read_dandi/*" = ["T201"]
 "docs/gallery/*" = ["E402", "T201"]
+"docs/notebooks/*" = ["E402", "T201"]
 "src/*/__init__.py" = ["F401"]
 "src/pynwb/_version.py" = ["T201"]
 "src/pynwb/validate.py" = ["T201"]


### PR DESCRIPTION
## Motivation

The top-level linter settings in ruff were deprecated and the `pyproject.toml` file needed to be updated.

I don't think this needs a `CHANGELOG.md` update.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
