### PR TITLE
Expose cache_spec option in NWBHDF5IO.export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug fixes
 - Fixed `can_read` method to return False if no nwbfile version can be found @stephprince [#1934](https://github.com/NeurodataWithoutBorders/pynwb/pull/1934)
 - Changed `epoch_tags` to be a NWBFile property instead of constructor argument. @stephprince [#1935](https://github.com/NeurodataWithoutBorders/pynwb/pull/1935)
+- Exposed option to not cache the spec in `NWBHDF5IO.export`. @rly [#1959](https://github.com/NeurodataWithoutBorders/pynwb/pull/1959)
 
 ## PyNWB 2.8.1 (July 3, 2024)
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -368,7 +368,9 @@ class NWBHDF5IO(_HDF5IO):
              'default': None},
             {'name': 'write_args', 'type': dict,
              'doc': 'arguments to pass to :py:meth:`~hdmf.backends.io.HDMFIO.write_builder`',
-             'default': None})
+             'default': None},
+            {'name': 'cache_spec', 'type': bool, 'doc': 'whether to cache the specification to file',
+             'default': True})
     def export(self, **kwargs):
         """
         Export an NWB file to a new NWB file using the HDF5 backend.


### PR DESCRIPTION
## Motivation

Right now, `NWBHDF5IO.export` always caches the spec. The option to change that is not exposed. This PR exposes that keyword argument. Ref: https://github.com/hdmf-dev/hdmf/issues/1187

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
