### PR TITLE
filter out warnings when validating against namespaces in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements and minor changes
 - Added support for numpy 2.0. @mavaylon1 [#1956](https://github.com/NeurodataWithoutBorders/pynwb/pull/1956)
+- Make `get_cached_namespaces_to_validate` a public function @stephprince [#1961](https://github.com/NeurodataWithoutBorders/pynwb/pull/1961)
 
 ### Documentation and tutorial enhancements
 - Added pre-release pull request instructions to release process documentation @stephprince [#1928](https://github.com/NeurodataWithoutBorders/pynwb/pull/1928)

--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -29,7 +29,7 @@ def _validate_helper(io: HDMFIO, namespace: str = CORE_NAMESPACE) -> list:
     return validator.validate(builder)
 
 
-def _get_cached_namespaces_to_validate(
+def get_cached_namespaces_to_validate(
     path: str, driver: Optional[str] = None, aws_region: Optional[str] = None,
 ) -> Tuple[List[str], BuildManager, Dict[str, str]]:
     """
@@ -40,9 +40,9 @@ def _get_cached_namespaces_to_validate(
     The following example illustrates how we can use this function to validate against namespaces
     cached in a file. This is useful, e.g., when a file was created using an extension
     >>> from pynwb import validate
-    >>> from pynwb.validate import _get_cached_namespaces_to_validate
+    >>> from pynwb.validate import get_cached_namespaces_to_validate
     >>> path = "my_nwb_file.nwb"
-    >>> validate_namespaces, manager, cached_namespaces = _get_cached_namespaces_to_validate(path)
+    >>> validate_namespaces, manager, cached_namespaces = get_cached_namespaces_to_validate(path)
     >>> with NWBHDF5IO(path, "r", manager=manager) as reader:
     >>>     errors = []
     >>>     for ns in validate_namespaces:
@@ -149,7 +149,7 @@ def validate(**kwargs):
         io_kwargs = dict(path=path, mode="r", driver=driver)
 
         if use_cached_namespaces:
-            cached_namespaces, manager, namespace_dependencies = _get_cached_namespaces_to_validate(
+            cached_namespaces, manager, namespace_dependencies = get_cached_namespaces_to_validate(
                 path=path, driver=driver
             )
             io_kwargs.update(manager=manager)
@@ -231,7 +231,7 @@ def validate_cli():
 
     if args.list_namespaces:
         for path in args.paths:
-            cached_namespaces, _, _ = _get_cached_namespaces_to_validate(path=path)
+            cached_namespaces, _, _ = get_cached_namespaces_to_validate(path=path)
             print("\n".join(cached_namespaces))
     else:
         validation_errors, validation_status = validate(

--- a/src/pynwb/validate.py
+++ b/src/pynwb/validate.py
@@ -39,14 +39,18 @@ def get_cached_namespaces_to_validate(
     -------
     The following example illustrates how we can use this function to validate against namespaces
     cached in a file. This is useful, e.g., when a file was created using an extension
-    >>> from pynwb import validate
-    >>> from pynwb.validate import get_cached_namespaces_to_validate
-    >>> path = "my_nwb_file.nwb"
-    >>> validate_namespaces, manager, cached_namespaces = get_cached_namespaces_to_validate(path)
-    >>> with NWBHDF5IO(path, "r", manager=manager) as reader:
-    >>>     errors = []
-    >>>     for ns in validate_namespaces:
-    >>>         errors += validate(io=reader, namespace=ns)
+
+    .. code-block:: python
+
+        from pynwb import validate
+        from pynwb.validate import get_cached_namespaces_to_validate
+        path = "my_nwb_file.nwb"
+        validate_namespaces, manager, cached_namespaces = get_cached_namespaces_to_validate(path)
+        with NWBHDF5IO(path, "r", manager=manager) as reader:
+            errors = []
+            for ns in validate_namespaces:
+                errors += validate(io=reader, namespace=ns)
+
     :param path: Path for the NWB file
     :return: Tuple with:
       - List of strings with the most specific namespace(s) to use for validation.

--- a/test.py
+++ b/test.py
@@ -179,7 +179,9 @@ def validate_nwbs():
                     if comp.returncode != 0:
                         return []
 
-                    return comp.stdout.split()
+                    output_lines = comp.stdout.split('\n')
+                    filtered_output = [line for line in output_lines if not re.search(r'warning', line, re.IGNORECASE) and line != '']
+                    return filtered_output
 
                 namespaces = get_namespaces(nwb)
 

--- a/test.py
+++ b/test.py
@@ -153,6 +153,7 @@ def validate_nwbs():
     examples_nwbs = glob.glob('*.nwb')
 
     import pynwb
+    from pynwb.validate import get_cached_namespaces_to_validate
 
     for nwb in examples_nwbs:
         try:
@@ -171,19 +172,7 @@ def validate_nwbs():
                         for err in errors:
                             print("Error: %s" % err)
 
-                def get_namespaces(nwbfile):
-                    comp = run(["python", "-m", "pynwb.validate",
-                               "--list-namespaces", nwbfile],
-                               stdout=PIPE, stderr=STDOUT, universal_newlines=True, timeout=30)
-
-                    if comp.returncode != 0:
-                        return []
-
-                    output_lines = comp.stdout.split('\n')
-                    filtered_output = [line for line in output_lines if not re.search(r'warning', line, re.IGNORECASE) and line != '']
-                    return filtered_output
-
-                namespaces = get_namespaces(nwb)
+                namespaces, _, _ = get_cached_namespaces_to_validate(nwb)
 
                 if len(namespaces) == 0:
                     FAILURES += 1

--- a/tests/integration/ros3/test_ros3.py
+++ b/tests/integration/ros3/test_ros3.py
@@ -1,6 +1,6 @@
 from pynwb import NWBHDF5IO
 from pynwb import validate
-from pynwb.validate import _get_cached_namespaces_to_validate
+from pynwb.validate import get_cached_namespaces_to_validate
 from pynwb.testing import TestCase
 import urllib.request
 import h5py
@@ -85,7 +85,7 @@ class TestRos3Streaming(TestCase):
                 )
             }
         }
-        found_namespaces, _, found_namespace_dependencies = _get_cached_namespaces_to_validate(
+        found_namespaces, _, found_namespace_dependencies = get_cached_namespaces_to_validate(
             path=self.s3_test_path, driver="ros3"
         )
 


### PR DESCRIPTION
## Motivation

When running the tests in test.py, the validation module was trying to validate against several invalid namespaces.

```
2024-09-05 18:22:05,083 - INFO - Namespace found: <frozen
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: runpy>:128:
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: RuntimeWarning:
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: 'pynwb.validate'
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: found
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: in
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: sys.modules
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: after
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: import
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: of
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: package
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: 'pynwb',
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: but
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: prior
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: to
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: execution
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: of
======================================================================
2024-09-05 18:22:05,083 - INFO - Namespace found: 'pynwb.validate';
```

The namespaces are retrieved from the stdout of `python -m pynwb.validate --list-namespaces`, which could still be error prone. Another option would be to replace the `get_namespaces` function in `test.py` entirely with:

```python
 from pynwb.validate import _get_cached_namespaces_to_validate
 namespaces, _, _ = _get_cached_namespaces_to_validate(nwb)
```

## How to test the behavior?
```
python test.py -v -w
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
