### PR TITLE
Make SpatialSeries reference_frame optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Bug fixes
 - Fixed bug in how `ElectrodeGroup.__init__` validates its `position` argument. @oruebel [#1770](https://github.com/NeurodataWithoutBorders/pynwb/pull/1770)
+- Changed `SpatialSeries.reference_frame` from required to optional as specified in the schema. @rly [#1986](https://github.com/NeurodataWithoutBorders/pynwb/pull/1986)
 
 ## PyNWB 2.8.2 (September 9, 2024)
 

--- a/src/pynwb/behavior.py
+++ b/src/pynwb/behavior.py
@@ -28,8 +28,8 @@ class SpatialSeries(TimeSeries):
                      'or 3 columns, which represent x, y, and z.')},
             {'name': 'bounds', 'type': list, 'shape': ((1, 2), (2, 2), (3, 2)), 'default': None,
              'doc': 'The boundary range (min, max) for each dimension of data.'},
-            {'name': 'reference_frame', 'type': str,   # required
-             'doc': 'description defining what the zero-position is'},
+            {'name': 'reference_frame', 'type': str,
+             'doc': 'description defining what the zero-position is', 'default': None},
             {'name': 'unit', 'type': str, 'doc': 'The base unit of measurement (should be SI unit)',
              'default': 'meters'},
             *get_docval(TimeSeries.__init__, 'conversion', 'resolution', 'timestamps', 'starting_time', 'rate',

--- a/tests/integration/hdf5/test_behavior.py
+++ b/tests/integration/hdf5/test_behavior.py
@@ -15,3 +15,14 @@ class TestSpatialSeriesIO(AcquisitionH5IOMixin, TestCase):
             reference_frame='reference_frame',
             timestamps=[1., 2., 3.]
         )
+
+
+class TestSpatialSeriesMinIO(AcquisitionH5IOMixin, TestCase):
+
+    def setUpContainer(self):
+        """ Return the test TimeSeries to read/write """
+        return SpatialSeries(
+            name='test_sS',
+            data=np.ones((3, 2)),
+            timestamps=[1., 2., 3.]
+        )

--- a/tests/unit/test_behavior.py
+++ b/tests/unit/test_behavior.py
@@ -21,6 +21,15 @@ class SpatialSeriesConstructor(TestCase):
         self.assertEqual(sS.bounds, [(-1,1),(-1,1),(-1,1)])
         self.assertEqual(sS.reference_frame, 'reference_frame')
 
+    def test_init_minimum(self):
+        sS = SpatialSeries(
+            name='test_sS',
+            data=np.ones((3, 2)),
+            timestamps=[1., 2., 3.]
+        )
+        assert sS.bounds is None
+        assert sS.reference_frame is None
+
     def test_set_unit(self):
         sS = SpatialSeries(
             name='test_sS',


### PR DESCRIPTION
## Motivation

Fix #1985 

## How to test the behavior?
```
ss = SpatialSeries(name="a", data=[1, 2, 3], timestamps=[1, 2, 3])
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
