### PR TITLE
add AnnotationSeries example to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Documentation and tutorial enhancements
 - Added documentation example for `SpikeEventSeries`. @stephprince [#1983](https://github.com/NeurodataWithoutBorders/pynwb/pull/1983)
+- Added documentation example for `AnnotationSeries`. @stephprince [#1989](https://github.com/NeurodataWithoutBorders/pynwb/pull/1989)
 
 ### Performance
 - Cache global type map to speed import 3X. @sneakers-the-rat [#1931](https://github.com/NeurodataWithoutBorders/pynwb/pull/1931)

--- a/docs/gallery/general/plot_file.py
+++ b/docs/gallery/general/plot_file.py
@@ -131,6 +131,7 @@ from dateutil import tz
 from pynwb import NWBHDF5IO, NWBFile, TimeSeries
 from pynwb.behavior import Position, SpatialSeries
 from pynwb.file import Subject
+from pynwb.misc import AnnotationSeries
 
 ####################
 # .. _basics_nwbfile:
@@ -285,6 +286,27 @@ nwbfile.acquisition["test_timeseries"]
 # or using the method :py:meth:`.NWBFile.get_acquisition`:
 nwbfile.get_acquisition("test_timeseries")
 
+####################
+# Other Types of Time Series
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^
+#
+# As mentioned previously, there are many subtypes of :py:class:`~pynwb.base.TimeSeries` that are used to store
+# different kinds of data. One example is :py:class:`~pynwb.misc.AnnotationSeries`, a subclass of 
+# :py:class:`~pynwb.base.TimeSeries` that stores text-based records about the experiment. Similarly to our
+# :py:class:`~pynwb.base.TimeSeries` example above, we can create an :py:class:`~pynwb.misc.AnnotationSeries` 
+# object with text information about a stimulus and add it to the stimulus group in 
+# the :py:class:`~pynwb.file.NWBFile`. 
+
+annotations = AnnotationSeries(name='airpuffs',
+                               data=['Left Airpuff', 'Right Airpuff', 'Right Airpuff'],
+                               description='Airpuff events delivered to the animal',
+                               timestamps=[1.0, 3.0, 8.0])
+
+nwbfile.add_stimulus(annotations)
+
+####################
+# This approach of creating a :py:class:`~pynwb.base.TimeSeries` object and adding it to the appropriate 
+# :py:class:`~pynwb.file.NWBFile` group can be used for all subtypes of :py:class:`~pynwb.base.TimeSeries` data.
 
 ####################
 # .. _basic_spatialseries:


### PR DESCRIPTION
## Motivation

We are aiming for 100% coverage of all Neurodata types in our documentation. There is no example demonstrating the use of `AnnotationSeries` in the docs.

## How to test the behavior?
```
cd docs
make clean && make html
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
