### PR TITLE
Remove references to region references/builders for HDMF 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Enhancements and minor changes
 * Added `NWBHDF5IO.read_nwb` convenience method to simplify reading an NWB file. @h-mayorquin [#1979](https://github.com/NeurodataWithoutBorders/pynwb/pull/1979)
+* Removed unused references to region references and builders in preparation for changes in HDMF 4.0. @rly [#1991](https://github.com/NeurodataWithoutBorders/pynwb/pull/1991)
 
 ### Documentation and tutorial enhancements
 - Added documentation example for `SpikeEventSeries`. @stephprince [#1983](https://github.com/NeurodataWithoutBorders/pynwb/pull/1983)

--- a/docs/source/overview_software_architecture.rst
+++ b/docs/source/overview_software_architecture.rst
@@ -69,7 +69,7 @@ Builder
    * :py:class:`~hdmf.build.builders.GroupBuilder` - represents a collection of objects
    * :py:class:`~hdmf.build.builders.DatasetBuilder` - represents data
    * :py:class:`~hdmf.build.builders.LinkBuilder` - represents soft-links
-   * :py:class:`~hdmf.build.builders.RegionBuilder` - represents a slice into data (Subclass of :py:class:`~hdmf.build.builders.DatasetBuilder`)
+   * :py:class:`~hdmf.build.builders.ReferenceBuilder` - represents a reference to another group or dataset
 
 * **Main Module:** :py:mod:`hdmf.build.builders`
 

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -1,4 +1,4 @@
-from hdmf.build import ObjectMapper, RegionBuilder
+from hdmf.build import ObjectMapper
 from hdmf.common import VectorData
 from hdmf.utils import getargs, docval
 from hdmf.spec import AttributeSpec
@@ -38,19 +38,6 @@ class ScratchDataMap(NWBContainerMapper):
     def __init__(self, spec):
         super().__init__(spec)
         self.map_spec('description', spec.get_attribute('notes'))
-
-
-class NWBTableRegionMap(NWBDataMap):
-
-    @ObjectMapper.constructor_arg('table')
-    def carg_table(self, builder, manager):
-        return manager.construct(builder.data.builder)
-
-    @ObjectMapper.constructor_arg('region')
-    def carg_region(self, builder, manager):
-        if not isinstance(builder.data, RegionBuilder):
-            raise ValueError("'builder' must be a RegionBuilder")
-        return builder.data.region
 
 
 @register_map(VectorData)


### PR DESCRIPTION
## Motivation

HDMF 4.0 and hdmf-schema-language 3.0 are removing support for region references. There is an **unused** IO objectmapper class that refers to `RegionBuilder`, and a docs page that refers to `RegionBuilder`. This PR removes those.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
