### PR TITLE
Fix gh actions failures

### DIFF
--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -22,30 +22,30 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: linux-python3.9-minimum      , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-python3.10             , test-tox-env: test-py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
-          - { name: linux-python3.11             , test-tox-env: test-py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-opt         , test-tox-env: test-py311-optional  , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.12             , test-tox-env: test-py312           , build-tox-env: build-py312           , python-ver: "3.12", os: ubuntu-latest }
-          - { name: linux-python3.13             , test-tox-env: test-py313           , build-tox-env: build-py313           , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-upgraded    , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-prerelease  , test-tox-env: test-py313-prerelease, build-tox-env: build-py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
-          - { name: windows-python3.9-minimum    , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.10           , test-tox-env: test-py310           , build-tox-env: build-py310           , python-ver: "3.10", os: windows-latest }
-          - { name: windows-python3.11           , test-tox-env: test-py311           , build-tox-env: build-py311           , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11-opt       , test-tox-env: test-py311-optional  , build-tox-env: build-py311           , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.12           , test-tox-env: test-py312           , build-tox-env: build-py312           , python-ver: "3.12", os: windows-latest }
-          - { name: windows-python3.13           , test-tox-env: test-py313           , build-tox-env: build-py313           , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-upgraded  , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-prerelease, test-tox-env: test-py313-prerelease, build-tox-env: build-py313-prerelease, python-ver: "3.13", os: windows-latest }
-          - { name: macos-python3.9-minimum      , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: macos-13 }
-          - { name: macos-python3.10             , test-tox-env: test-py310           , build-tox-env: build-py310           , python-ver: "3.10", os: macos-latest }
-          - { name: macos-python3.11             , test-tox-env: test-py311           , build-tox-env: build-py311           , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.11-opt         , test-tox-env: test-py311-optional  , build-tox-env: build-py311           , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.12             , test-tox-env: test-py312           , build-tox-env: build-py312           , python-ver: "3.12", os: macos-latest }
-          - { name: macos-python3.13             , test-tox-env: test-py313           , build-tox-env: build-py313           , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-upgraded    , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-prerelease  , test-tox-env: test-py313-prerelease, build-tox-env: build-py313-prerelease, python-ver: "3.13", os: macos-latest }
+          - { name: linux-python3.9-minimum      , test-tox-env: test-py39-minimum         , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
+          - { name: linux-python3.10             , test-tox-env: test-py310-pinned         , build-tox-env: build-py310-pinned    , python-ver: "3.10", os: ubuntu-latest }
+          - { name: linux-python3.11             , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.11-opt         , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
+          - { name: linux-python3.12             , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: ubuntu-latest }
+          - { name: linux-python3.13             , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.13-upgraded    , test-tox-env: test-py313-upgraded       , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.13-prerelease  , test-tox-env: test-py313-prerelease     , build-tox-env: build-py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
+          - { name: windows-python3.9-minimum    , test-tox-env: test-py39-minimum         , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: windows-latest }
+          - { name: windows-python3.10           , test-tox-env: test-py310-pinned         , build-tox-env: build-py310-pinned    , python-ver: "3.10", os: windows-latest }
+          - { name: windows-python3.11           , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.11-opt       , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: windows-latest }
+          - { name: windows-python3.12           , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: windows-latest }
+          - { name: windows-python3.13           , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.13-upgraded  , test-tox-env: test-py313-upgraded       , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.13-prerelease, test-tox-env: test-py313-prerelease     , build-tox-env: build-py313-prerelease, python-ver: "3.13", os: windows-latest }
+          - { name: macos-python3.9-minimum      , test-tox-env: test-py39-minimum         , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: macos-13 }
+          - { name: macos-python3.10             , test-tox-env: test-py310-pinned         , build-tox-env: build-py310-pinned    , python-ver: "3.10", os: macos-latest }
+          - { name: macos-python3.11             , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.11-opt         , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: macos-latest }
+          - { name: macos-python3.12             , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: macos-latest }
+          - { name: macos-python3.13             , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-upgraded    , test-tox-env: test-py313-upgraded       , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-prerelease  , test-tox-env: test-py313-prerelease     , build-tox-env: build-py313-prerelease, python-ver: "3.13", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -139,10 +139,10 @@ jobs:
       matrix:
         include:
           - { name: conda-linux-python3.9-minimum    , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: conda-linux-python3.10           , test-tox-env: test-py310           , build-tox-env: build-py310           , python-ver: "3.10", os: ubuntu-latest }
-          - { name: conda-linux-python3.11           , test-tox-env: test-py311           , build-tox-env: build-py311           , python-ver: "3.11", os: ubuntu-latest }
-          - { name: conda-linux-python3.12           , test-tox-env: test-py312           , build-tox-env: build-py312           , python-ver: "3.12", os: ubuntu-latest }
-          - { name: conda-linux-python3.13           , test-tox-env: test-py313           , build-tox-env: build-py313           , python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-python3.10           , test-tox-env: test-py310-pinned    , build-tox-env: build-py310-pinned    , python-ver: "3.10", os: ubuntu-latest }
+          - { name: conda-linux-python3.11           , test-tox-env: test-py311-pinned    , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
+          - { name: conda-linux-python3.12           , test-tox-env: test-py312-pinned    , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: ubuntu-latest }
+          - { name: conda-linux-python3.13           , test-tox-env: test-py313-pinned    , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: ubuntu-latest }
           - { name: conda-linux-python3.13-upgraded  , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: ubuntu-latest }
           - { name: conda-linux-python3.13-prerelease, test-tox-env: test-py313-prerelease, build-tox-env: build-py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Documentation and tutorial enhancements
 - Updated `SpikeEventSeries`, `DecompositionSeries`, and `FilteredEphys` examples. @stephprince [#2012](https://github.com/NeurodataWithoutBorders/pynwb/pull/2012)
+- Replaced deprecated `scipy.misc.face` dataset in the images tutorial with another example. @stephprince [#2016](https://github.com/NeurodataWithoutBorders/pynwb/pull/2016)
 
 ## PyNWB 2.8.3 (November 19, 2024)
 

--- a/docs/gallery/domain/images.py
+++ b/docs/gallery/domain/images.py
@@ -296,30 +296,14 @@ nwbfile.add_acquisition(images)
 # :py:class:`~pynwb.image.IndexSeries` that indexes into the
 # :py:class:`~pynwb.base.Images`.
 
-from scipy import misc
-
 from pynwb.base import ImageReferences
 from pynwb.image import GrayscaleImage, Images, IndexSeries, RGBImage
 
-gs_face = GrayscaleImage(
-    name="gs_face",
-    data=misc.face(gray=True),
-    description="Grayscale version of a raccoon.",
-    resolution=35.433071,
-)
-
-rgb_face = RGBImage(
-    name="rgb_face",
-    data=misc.face(),
-    resolution=70.0,
-    description="RGB version of a raccoon.",
-)
-
 images = Images(
     name="raccoons",
-    images=[rgb_face, gs_face],
+    images=[rgb_logo, gs_logo],
     description="A collection of raccoons.",
-    order_of_images=ImageReferences("order_of_images", [rgb_face, gs_face]),
+    order_of_images=ImageReferences("order_of_images", [rgb_logo, gs_logo]),
 )
 
 idx_series = IndexSeries(

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -147,7 +147,7 @@ intersphinx_mapping = {
     'fsspec': ("https://filesystem-spec.readthedocs.io/en/latest/", None),
     'nwbwidgets': ("https://nwb-widgets.readthedocs.io/en/latest/", None),
     'nwb-overview': ("https://nwb-overview.readthedocs.io/en/latest/", None),
-    'zarr': ("https://zarr.readthedocs.io/en/stable/", None),
+    'zarr': ("https://zarr.readthedocs.io/en/v2.18.4/", None),  # TODO - update when hdmf-zarr supports Zarr 3.0
     'hdmf-zarr': ("https://hdmf-zarr.readthedocs.io/en/stable/", None),
     'numcodecs': ("https://numcodecs.readthedocs.io/en/latest/", None),
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -148,7 +148,7 @@ intersphinx_mapping = {
     'nwbwidgets': ("https://nwb-widgets.readthedocs.io/en/latest/", None),
     'nwb-overview': ("https://nwb-overview.readthedocs.io/en/latest/", None),
     'zarr': ("https://zarr.readthedocs.io/en/stable/", None),
-    'hdmf-zarr': ("https://hdmf-zarr.readthedocs.io/en/latest/", None),
+    'hdmf-zarr': ("https://hdmf-zarr.readthedocs.io/en/stable/", None),
     'numcodecs': ("https://numcodecs.readthedocs.io/en/latest/", None),
 }
 
@@ -161,7 +161,7 @@ extlinks = {
     'hdmf-docs': ('https://hdmf.readthedocs.io/en/stable/%s', '%s'),
     'dandi': ('https://www.dandiarchive.org/%s', '%s'),
     "nwbinspector": ("https://nwbinspector.readthedocs.io/en/dev/%s", "%s"),
-    'hdmf-zarr': ('https://hdmf-zarr.readthedocs.io/en/latest/%s', '%s'),
+    'hdmf-zarr': ('https://hdmf-zarr.readthedocs.io/en/stable/%s', '%s'),
 }
 
 nitpicky = True

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
+envlist = test-py{39,310,311,312,313}-pinned
 requires = pip >= 22.0
 
 [testenv]
@@ -32,8 +33,7 @@ commands =
     build:        python -m build
     wheelinstall: python -c "import pynwb"
 
-# list of pre-defined environments. (Technically environments not listed here
-# like build-py312 can also be used.)
+# list of pre-defined environments.
 [testenv:test-py313-upgraded]
 [testenv:test-py313-prerelease]
 [testenv:test-py311-optional-pinned]  # some optional reqs not compatible with py312 yet


### PR DESCRIPTION
## Motivation

This PR will fix a couple of our current workflow failures. These changes were originally included in https://github.com/NeurodataWithoutBorders/pynwb/pull/2015, but I have moved into a separate PR here so that we can merge into dev before the 3.0 release.

These changes will:
* Fix the daily `run_all_tests.yml` workflows that are failing due to some tox environment configuration errors introduced in https://github.com/NeurodataWithoutBorders/pynwb/pull/2007
* Fix the python 3.13 gallery test failures due to an import from a deprecated scipy dataset
* Fix the sphinx link check workflows failing due to an update to the hdmf-zarr docs

TODO
- [x] manually trigger `run_all_tests.yml` workflow to check that it runs successfully

## How to test the behavior?
Run the `run_all_tests.yml` workflow

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
