### PR TITLE
update default mock_NWBFile start time

### DIFF
--- a/src/pynwb/testing/mock/file.py
+++ b/src/pynwb/testing/mock/file.py
@@ -10,7 +10,7 @@ from .utils import name_generator
 def mock_NWBFile(
     session_description: str = 'session_description',
     identifier: Optional[str] = None,
-    session_start_time: datetime = datetime(1970, 1, 1, 12, tzinfo=tzutc()),
+    session_start_time: datetime = datetime(1970, 1, 1, tzinfo=tzutc()),
     **kwargs
 ):
     return NWBFile(

--- a/src/pynwb/testing/mock/file.py
+++ b/src/pynwb/testing/mock/file.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import uuid4
 from datetime import datetime
-from dateutil.tz import tzlocal
+from dateutil.tz import tzutc
 
 from ...file import NWBFile, Subject
 from .utils import name_generator
@@ -10,7 +10,7 @@ from .utils import name_generator
 def mock_NWBFile(
     session_description: str = 'session_description',
     identifier: Optional[str] = None,
-    session_start_time: datetime = datetime(1970, 1, 1, tzinfo=tzlocal()),
+    session_start_time: datetime = datetime(1970, 1, 1, 12, tzinfo=tzutc()),
     **kwargs
 ):
     return NWBFile(


### PR DESCRIPTION
## Motivation

Fix #2013. There was an error when creating a `mock_NWBFile` in specific time zones, where converting the default start time to local time would result in a time before the Unix epoch.

The default could also be updated to any later time, I left as 1970 for now in case that is used to indicate this is mock data.

I don't think these changes require a CHANGELOG update but can add if needed.

## How to test the behavior?
```python
from pynwb import NWBHDF5IO
from pynwb.testing.mock.file import mock_NWBFile

nwb = mock_NWBFile()

with NWBHDF5IO('test.nwb', mode='w') as io:
    io.write(nwbfile)
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
