### PR TITLE
Fix `add_data_interface` functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## Upcoming
+
+### Bug fixes
+- Readd `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)
+
 ## PyNWB 3.0.0 (February 26, 2025)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 ### Bug fixes
-- Readd `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)
+- Fix `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)
 
 ## PyNWB 3.0.0 (February 26, 2025)
 

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -77,6 +77,7 @@ class ProcessingModule(MultiContainerInterface):
              'doc': 'the NWBDataInterface to add to this Module'})
     def add_data_interface(self, **kwargs):
         warn('add_data_interface is deprecated and will be removed in PyNWB 4.0. Use add instead.', DeprecationWarning)
+        self.add(kwargs['NWBDataInterface'])
 
     @docval({'name': 'data_interface_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})
     def get_data_interface(self, **kwargs):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -60,6 +60,8 @@ class TestProcessingModule(TestCase):
                                   exc_msg=msg
         ):
             self.pm.add_container(ts)
+            self.assertIn(ts.name, self.pm.containers)
+            self.assertIs(ts, self.pm.containers[ts.name])
 
     def test_get_data_interface(self):
         """Test adding a data interface to a ProcessingModule and retrieving it using get(...)."""

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -50,6 +50,8 @@ class TestProcessingModule(TestCase):
                                   exc_msg=msg
         ):
             self.pm.add_data_interface(ts)
+            self.assertIn(ts.name, self.pm.containers)
+            self.assertIs(ts, self.pm.containers[ts.name])
 
     def test_deprecated_add_container(self):
         ts = self._create_time_series()


### PR DESCRIPTION
## Motivation

Fix #2050. 

In #2011 I mistakenly removed the functionality of `add_data_interface` when updating the deprecation warning. I think `add_data_interface` should still operate as expected until the function is fully removed and replaced by `add`.


## How to test the behavior?
```python
from pynwb.testing.mock.file import mock_NWBFile
from pynwb.testing.mock.ecephys import mock_ElectricalSeries


nwbfile = mock_NWBFile()

# Create processing modules
ecephys_module = nwbfile.create_processing_module('ecephys', 'Example ecephys data')

electrical_series = mock_ElectricalSeries()
ecephys_module.add_data_interface(electrical_series)

assert len(nwbfile.processing["ecephys"].data_interfaces) == 1
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
