### PR TITLE
Allow timezone-naive timestamps reference time on read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Upcoming
 
 ### Enhancements and minor changes
-- Allow files with a timestamps reference time that has no timezone information to be read. @stephprince [#2056](https://github.com/NeurodataWithoutBorders/pynwb/pull/2056)
+- Automatically add timezone information to timestamps reference time if no timezone information is specified. @stephprince [#2056](https://github.com/NeurodataWithoutBorders/pynwb/pull/2056)
 - Added option to disable typemap caching and updated type map cache location. @stephprince [#2057](https://github.com/NeurodataWithoutBorders/pynwb/pull/2057)
 - Added dictionary-like operations directly on `ProcessingModule` objects (e.g., `len(processing_module)`). @bendichter [#2020](https://github.com/NeurodataWithoutBorders/pynwb/pull/2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## Upcoming
+
+### Enhancements and minor changes
+- Allow files with a timestamps reference time that has no timezone information to be read. @stephprince [#2056](https://github.com/NeurodataWithoutBorders/pynwb/pull/2056)
+
 ## PyNWB 3.0.0 (February 26, 2025)
 
 ### Breaking changes

--- a/docs/gallery/general/plot_read_basics.py
+++ b/docs/gallery/general/plot_read_basics.py
@@ -82,7 +82,7 @@ download("https://api.dandiarchive.org/api/assets/0f57f0b0-f021-42bb-8eaa-56cd48
 # .. seealso::
 #
 #   Learn about all the different ways you can download data from the DANDI Archive
-#   `here <https://docs.dandiarchive.org/12_download/>`_
+#   `here <https://docs.dandiarchive.org/user-guide-using/accessing-data/downloading/>`_
 #
 # .. seealso:: Streaming data
 #

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -491,7 +491,9 @@ class NWBFile(MultiContainerInterface, HERDManager):
         if timestamps_reference_time is None:
             args_to_set['timestamps_reference_time'] = args_to_set['session_start_time']
         elif timestamps_reference_time.tzinfo is None:
-            raise ValueError("'timestamps_reference_time' must be a timezone-aware datetime object.")
+            self._error_on_new_warn_on_construct(
+                    error_msg="'timestamps_reference_time' must be a timezone-aware datetime object."
+                )
 
         # convert file_create_date to list and add timezone if missing
         file_create_date = args_to_set['file_create_date']

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -491,7 +491,7 @@ class NWBFile(MultiContainerInterface, HERDManager):
         if timestamps_reference_time is None:
             args_to_set['timestamps_reference_time'] = args_to_set['session_start_time']
         elif timestamps_reference_time.tzinfo is None:
-            self._error_on_new_warn_on_construct(
+            self._error_on_new_pass_on_construct(
                     error_msg="'timestamps_reference_time' must be a timezone-aware datetime object."
                 )
 

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -491,9 +491,7 @@ class NWBFile(MultiContainerInterface, HERDManager):
         if timestamps_reference_time is None:
             args_to_set['timestamps_reference_time'] = args_to_set['session_start_time']
         elif timestamps_reference_time.tzinfo is None:
-            self._error_on_new_pass_on_construct(
-                    error_msg="'timestamps_reference_time' must be a timezone-aware datetime object."
-                )
+            args_to_set['timestamps_reference_time'] = _add_missing_timezone(timestamps_reference_time)
 
         # convert file_create_date to list and add timezone if missing
         file_create_date = args_to_set['file_create_date']

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -705,6 +705,14 @@ class TestTimestampsRefAware(TestCase):
                     self.start_time,
                     timestamps_reference_time=self.ref_time_notz)
 
+    def test_reftime_tzaware_warn_on_construct(self):
+        with self.assertWarnsWith(UserWarning, "'timestamps_reference_time' must be a timezone-aware datetime object."):
+            nwbfile = NWBFile.__new__(NWBFile, in_construct_mode=True)
+            nwbfile.__init__('test session description',
+                            'TEST124',
+                            self.start_time,
+                            timestamps_reference_time=self.ref_time_notz)
+            self.assertEqual(nwbfile.timestamps_reference_time, self.ref_time_notz)
 
 class TestTimezone(TestCase):
     def test_raise_warning__add_missing_timezone(self):

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -698,20 +698,14 @@ class TestTimestampsRefAware(TestCase):
         self.ref_time_notz = datetime(1979, 1, 1, 0, 0, 0)
 
     def test_reftime_tzaware(self):
-        with self.assertRaises(ValueError):
-            # 'timestamps_reference_time' must be a timezone-aware datetime
-            NWBFile('test session description',
-                    'TEST124',
-                    self.start_time,
-                    timestamps_reference_time=self.ref_time_notz)
+        with self.assertWarnsWith(UserWarning, "Date is missing timezone information. Updating to local timezone."):
+            nwbfile = NWBFile('test session description',
+                              'TEST124',
+                              self.start_time,
+                              timestamps_reference_time=self.ref_time_notz)
 
-    def test_reftime_tzaware_pass_on_construct(self):
-        nwbfile = NWBFile.__new__(NWBFile, in_construct_mode=True)
-        nwbfile.__init__('test session description',
-                        'TEST124',
-                        self.start_time,
-                        timestamps_reference_time=self.ref_time_notz)
-        self.assertEqual(nwbfile.timestamps_reference_time, self.ref_time_notz)
+        # test time zone is automatically added to timestamps_reference_time
+        self.assertEqual(nwbfile.timestamps_reference_time, self.ref_time_notz.replace(tzinfo=tzlocal()))
 
 class TestTimezone(TestCase):
     def test_raise_warning__add_missing_timezone(self):

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -706,13 +706,12 @@ class TestTimestampsRefAware(TestCase):
                     timestamps_reference_time=self.ref_time_notz)
 
     def test_reftime_tzaware_warn_on_construct(self):
-        with self.assertWarnsWith(UserWarning, "'timestamps_reference_time' must be a timezone-aware datetime object."):
-            nwbfile = NWBFile.__new__(NWBFile, in_construct_mode=True)
-            nwbfile.__init__('test session description',
-                            'TEST124',
-                            self.start_time,
-                            timestamps_reference_time=self.ref_time_notz)
-            self.assertEqual(nwbfile.timestamps_reference_time, self.ref_time_notz)
+        nwbfile = NWBFile.__new__(NWBFile, in_construct_mode=True)
+        nwbfile.__init__('test session description',
+                        'TEST124',
+                        self.start_time,
+                        timestamps_reference_time=self.ref_time_notz)
+        self.assertEqual(nwbfile.timestamps_reference_time, self.ref_time_notz)
 
 class TestTimezone(TestCase):
     def test_raise_warning__add_missing_timezone(self):

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -705,7 +705,7 @@ class TestTimestampsRefAware(TestCase):
                     self.start_time,
                     timestamps_reference_time=self.ref_time_notz)
 
-    def test_reftime_tzaware_warn_on_construct(self):
+    def test_reftime_tzaware_pass_on_construct(self):
         nwbfile = NWBFile.__new__(NWBFile, in_construct_mode=True)
         nwbfile.__init__('test session description',
                         'TEST124',


### PR DESCRIPTION
## Motivation

Fix #2054. Allow files with a timestamps reference time that is not timezone-aware to be read. 

## How to test the behavior?
In MATLAB:

```Matlab
nwb = NwbFile( ...
    'session_description', 'Simple demo file', ...
    'identifier', 'test_file', ...
    'session_start_time', datetime("now"), ...
    'timestamps_reference_time', datetime("now"));
nwbExport(nwb, 'temp.nwb')
```

In python:

```python
from pynwb import NWBHDF5IO

io = NWBHDF5IO('temp.nwb', mode="r")
nwbfile = io.read()
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
