### PR TITLE
Automatically set format to external on ImageSeries if external file provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Bug fixes
 - Fix `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)
 
+### Enhancements and minor changes
+- When an external file is detected when initializing an ImageSeries, automatically set format to "external" instead of raising an error if no format was provided. @stephprince
+
 ## PyNWB 3.0.0 (February 26, 2025)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fix `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)
 
 ### Enhancements and minor changes
-- When an external file is detected when initializing an ImageSeries, automatically set format to "external" instead of raising an error if no format was provided. @stephprince
+- When an external file is detected when initializing an ImageSeries, automatically set format to "external" instead of raising an error if no format was provided. @stephprince [#2060](https://github.com/NeurodataWithoutBorders/pynwb/pull/2060)
 
 ## PyNWB 3.0.0 (February 26, 2025)
 

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -105,11 +105,7 @@ class ImageSeries(TimeSeries):
         for key, val in args_to_set.items():
             setattr(self, key, val)
 
-        if self._change_external_file_format():
-            self._error_on_new_warn_on_construct(error_msg=f"{self.__class__.__name__} '{self.name}': "
-                                                "The value for 'format' has been changed to 'external'. "
-                                                "If an external file is detected, setting a value for "
-                                                "'format' other than 'external' is deprecated.")
+        self._change_external_file_format()
 
         error_msg = self._check_image_series_dimension()
         if error_msg:
@@ -137,9 +133,6 @@ class ImageSeries(TimeSeries):
             and self.format is None
         ):
             self.format = "external"
-            return True
-
-        return False
 
     def _check_time_series_dimension(self):
         """Override _check_time_series_dimension to do nothing.

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -249,25 +249,14 @@ class ImageSeriesConstructor(TestCase):
 
     def test_external_file_default_format(self):
         """Test that format is set to 'external' if not provided, when external_file is provided."""
-        msg = (
-            "ImageSeries 'test_iS': The value for 'format' has been changed to 'external'. "
-            "If an external file is detected, setting a value for "
-            "'format' other than 'external' is deprecated."
-        )
+
         kwargs = dict(name="test_iS",
                 external_file=["external_file", "external_file2"],
                 unit="n.a.",
                 starting_frame=[0, 10],
                 rate=0.2,)
         
-        # create object with deprecated argument
-        with self.assertRaisesWith(ValueError, msg):
-            ImageSeries(**kwargs)
-
-        # create object in construct mode, modeling the behavior of the ObjectMapper on read
-        iS = ImageSeries.__new__(ImageSeries, in_construct_mode=True)
-        with self.assertWarnsWith(warn_type=UserWarning, exc_msg=msg):
-            iS.__init__(**kwargs)
+        iS = ImageSeries(**kwargs)
         self.assertEqual(iS.format, "external")
 
     def test_external_file_with_correct_format(self):


### PR DESCRIPTION
## Motivation

Fix #2041 

## How to test the behavior?
```python
from pynwb.image import ImageSeries

iS = ImageSeries(name="test_iS",
                 external_file=["external_file", "external_file2"],
                 unit="n.a.",
                 starting_frame=[0, 10],
                 rate=0.2)
print(iS.format)  # external
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
