### PR TITLE
add nwb assistant to home page of docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 - Fixed missing `__nwbfields__` and `_fieldsname` for `NWBData` and its subclasses. @rly [#2082](https://github.com/NeurodataWithoutBorders/pynwb/pull/2082)
 - Fixed caching of the type map when using HDMF 4.1.0. @rly [#2087](https://github.com/NeurodataWithoutBorders/pynwb/pull/2087)
 
+### Documentation and tutorial enhancements
+- Added NWB AI assistant to the home page of the documentation. @magland [#2076](https://github.com/NeurodataWithoutBorders/pynwb/pull/2076)
+
 ## PyNWB 3.0.0 (February 26, 2025)
 
 ### Breaking changes

--- a/docs/source/_static/css/nwb_assistant.css
+++ b/docs/source/_static/css/nwb_assistant.css
@@ -1,0 +1,66 @@
+.assistant-toggle {
+    display: none;
+    position: fixed;
+    right: 20px;
+    top: 20px;
+    z-index: 1001;
+    padding: 8px 16px;
+    background-color: #2980b9;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 14px;
+}
+
+/* Hide button when assistant is open */
+.assistant-container.show ~ .assistant-toggle {
+    display: none !important;
+}
+
+.assistant-toggle:hover {
+    background-color: #3498db;
+}
+
+.assistant-container {
+    display: none;
+}
+
+@media (min-width: 1300px) {
+    .assistant-toggle {
+        display: block;
+    }
+
+    .assistant-container {
+        display: block;
+        visibility: hidden;
+        position: fixed;
+        right: 0;
+        top: 0;
+        width: calc(100vw - 1140px);
+        height: 100vh;
+        z-index: 1000;
+        transform: translateX(100%);
+        transition: transform 0.3s ease-in-out, visibility 0.3s ease-in-out;
+    }
+
+    .assistant-container.show {
+        visibility: visible;
+        transform: translateX(0);
+    }
+
+    .assistant-iframe {
+        width: 100%;
+        height: 100%;
+        border: none;
+        background: white;
+    }
+
+    .wy-nav-content {
+        transition: margin-right 0.3s ease-in-out;
+    }
+
+    .assistant-container.show ~ .wy-nav-content {
+        margin-right: calc(100vw - 1140px);
+    }
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -263,6 +263,7 @@ html_theme_options = {
 # or fully qualified paths (eg. https://...)
 html_css_files = [
     'css/custom.css',
+    'css/nwb_assistant.css'
 ]
 
 # The name for this set of Sphinx documents.  If None, it defaults to

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,30 @@ The NWB team consists of neuroscientists and software developers
 who recognize that adoption of a unified data format is an important step toward
 breaking down the barriers to data sharing in neuroscience.
 
+.. raw:: html
+
+   <div class="assistant-container">
+     <iframe class="assistant-iframe"></iframe>
+   </div>
+   <button class="assistant-toggle">Open Assistant</button>
+   <script>
+     document.addEventListener('DOMContentLoaded', function() {
+       const toggle = document.querySelector('.assistant-toggle');
+       const container = document.querySelector('.assistant-container');
+       const iframe = document.querySelector('.assistant-iframe');
+       let iframeLoaded = false;
+
+       toggle.addEventListener('click', function() {
+         const isShowing = container.classList.toggle('show');
+
+         // Load iframe content only when first opened
+         if (isShowing && !iframeLoaded) {
+           iframe.src = 'https://magland.github.io/nwb-assistant/chat';
+           iframeLoaded = true;
+         }
+       });
+     });
+   </script>
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
## Motivation

At the recent NWB Docathon I created [this AI assistant for NWB](https://magland.github.io/nwb-assistant/chat). This PR adds a button "Open Assistant" to the home page of the rendered docs, as shown:

![image](https://github.com/user-attachments/assets/a2719af8-b6e6-4499-9db5-036fa576bbcb)

When the user clicks the button, it opens NWB Assistant in an iframe, as shown:

![image](https://github.com/user-attachments/assets/4d16e7be-ef23-41f5-96e4-410c1ed85563)

For the user, the basic (cheaper) models are available for free. If they want to use the more advanced/expensive models, they need to put in their own openrouter key. There are instructions in the assistant app.

## How to test the behavior?

Build the docs using `cd docs && make html`. Then host locally via `python3 -m http.server 8000 --directory _build/html`.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
