### PR TITLE
Add core namespace to NamespaceCatalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added mask_type option to `mock_PlaneSegmentation`. @pauladkisson [#2067](https://github.com/NeurodataWithoutBorders/pynwb/pull/2067)
 - Improved the documentation of the `spike_times` in the Units table methods @h-mayorquin [#2085](https://github.com/NeurodataWithoutBorders/pynwb/pull/2085)
 - Removed core namespace warning unless cached version is newer. @stephprince [#2077](https://github.com/NeurodataWithoutBorders/pynwb/pull/2077)
+- Bumped minimum HDMF version to 4.1.0. @stephprince [#2077](https://github.com/NeurodataWithoutBorders/pynwb/pull/2077)
 
 ### Bug fixes
 - Fixed `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added dictionary-like operations directly on `ProcessingModule` objects (e.g., `len(processing_module)`). @bendichter [#2020](https://github.com/NeurodataWithoutBorders/pynwb/pull/2020)
 - When an external file is detected when initializing an ImageSeries and no format is provided, automatically set format to "external" instead of raising an error. @stephprince [#2060](https://github.com/NeurodataWithoutBorders/pynwb/pull/2060)
 - Added mask_type option to `mock_PlaneSegmentation`. @pauladkisson [#2067](https://github.com/NeurodataWithoutBorders/pynwb/pull/2067)
+- Removed core namespace warning unless cached version is newer. @stephprince [#2077](https://github.com/NeurodataWithoutBorders/pynwb/pull/2077)
 
 ### Bug fixes
 - Fix `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python==3.13
   - h5py==3.12.1
-  - hdmf==3.14.5
+  - hdmf==4.1.0
   - matplotlib==3.9.2
   - numpy==2.1.3
   - pandas==2.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "h5py>=3.2.0",
-    "hdmf>=3.14.5,<5",
+    "hdmf>=4.1.0,<5",
     "numpy>=1.24.0",
     "pandas>=1.2.0",
     "python-dateutil>=2.8.2",

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # minimum versions of package dependencies for installing PyNWB
 h5py==3.2.0
-hdmf==3.14.5
+hdmf==4.1.0
 numpy==1.24.0
 pandas==1.2.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
 h5py==3.12.1
-hdmf==3.14.5
+hdmf==4.1.0
 numpy==2.1.1; python_version > "3.9"  # numpy 2.1+ is not compatible with py3.9
 numpy==2.0.2; python_version == "3.9"
 pandas==2.2.3

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -87,7 +87,12 @@ def __get_resources() -> dict:
 # a global type map
 global __TYPE_MAP
 
-__ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace, core_namespaces=[CORE_NAMESPACE])
+try:
+    __ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace, core_namespaces=[CORE_NAMESPACE])
+except TypeError:
+    # Fall back to the old signature if core_namespaces is not supported
+    # TODO: remove this when HDMF 4.0.1 is the minimum
+    __ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace)
 
 hdmf_typemap = hdmf.common.get_type_map()
 __TYPE_MAP = TypeMap(__ns_catalog)

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -91,7 +91,7 @@ try:
     __ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace, core_namespaces=[CORE_NAMESPACE])
 except TypeError:
     # Fall back to the old signature if core_namespaces is not supported
-    # TODO: remove this when HDMF 4.0.1 is the minimum
+    # TODO: remove this when HDMF 4.1.0 is the minimum
     __ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace)
 
 hdmf_typemap = hdmf.common.get_type_map()

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -87,7 +87,7 @@ def __get_resources() -> dict:
 # a global type map
 global __TYPE_MAP
 
-__ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace)
+__ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace, core_namespaces=[CORE_NAMESPACE])
 
 hdmf_typemap = hdmf.common.get_type_map()
 __TYPE_MAP = TypeMap(__ns_catalog)

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -88,12 +88,7 @@ def __get_resources() -> dict:
 # a global type map
 global __TYPE_MAP
 
-try:
-    __ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace, core_namespaces=[CORE_NAMESPACE])
-except TypeError:
-    # Fall back to the old signature if core_namespaces is not supported
-    # TODO: remove this when HDMF 4.1.0 is the minimum
-    __ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace)
+__ns_catalog = NamespaceCatalog(NWBGroupSpec, NWBDatasetSpec, NWBNamespace, core_namespaces=[CORE_NAMESPACE])
 
 hdmf_typemap = hdmf.common.get_type_map()
 __TYPE_MAP = TypeMap(__ns_catalog)

--- a/tests/back_compat/test_read.py
+++ b/tests/back_compat/test_read.py
@@ -39,8 +39,7 @@ class TestReadOldVersions(TestCase):
 
     def get_io(self, path):
         """Get an NWBHDF5IO object for the given path."""
-        with warnings.catch_warnings():
-            return NWBHDF5IO(str(path), 'r')
+        return NWBHDF5IO(str(path), 'r')
 
     def test_read(self):
         """Test reading and validating all NWB files in the same folder as this file.

--- a/tests/back_compat/test_read.py
+++ b/tests/back_compat/test_read.py
@@ -40,11 +40,6 @@ class TestReadOldVersions(TestCase):
     def get_io(self, path):
         """Get an NWBHDF5IO object for the given path."""
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=r"Ignoring cached namespace .*",
-                category=UserWarning,
-            )
             return NWBHDF5IO(str(path), 'r')
 
     def test_read(self):

--- a/tests/integration/ros3/test_ros3.py
+++ b/tests/integration/ros3/test_ros3.py
@@ -30,11 +30,6 @@ class TestRos3Streaming(TestCase):
     def test_read(self):
         s3_path = 'https://dandiarchive.s3.amazonaws.com/ros3test.nwb'
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=r"Ignoring cached namespace .*",
-                category=UserWarning,
-            )
             with NWBHDF5IO(s3_path, mode='r', driver='ros3') as io:
                 nwbfile = io.read()
                 test_data = nwbfile.acquisition['ts_name'].data[:]
@@ -42,11 +37,6 @@ class TestRos3Streaming(TestCase):
 
     def test_dandi_read(self):
         with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=r"Ignoring cached namespace .*",
-                category=UserWarning,
-            )
             with NWBHDF5IO(path=self.s3_test_path, mode='r', driver='ros3') as io:
                 nwbfile = io.read()
                 test_data = nwbfile.acquisition['TestData'].data[:]

--- a/tests/unit/test_extension.py
+++ b/tests/unit/test_extension.py
@@ -1,11 +1,12 @@
 import os
 import random
 import string
+import warnings
 from datetime import datetime
 from dateutil.tz import tzlocal
 from tempfile import gettempdir
 
-from hdmf.spec import RefSpec
+from hdmf.spec import RefSpec, NamespaceCatalog
 from hdmf.utils import get_docval, docval, popargs
 from pynwb import get_type_map, TimeSeries, NWBFile, register_class, load_namespaces, get_class
 from pynwb.spec import NWBNamespaceBuilder, NWBGroupSpec, NWBAttributeSpec, NWBDatasetSpec
@@ -143,6 +144,10 @@ class TestCatchDupNS(TestCase):
         self.ext_source2 = '%s_extension2.yaml' % self.prefix
         self.ns_path2 = '%s_namespace2.yaml' % self.prefix
 
+        self.ns_catalog = get_type_map().namespace_catalog
+        self.core_ns = 'core'
+        self.core_ns_version = self.ns_catalog.get_namespace(self.core_ns)['version']
+
     def tearDown(self):
         files = (self.ext_source1,
                  self.ns_path1,
@@ -169,3 +174,48 @@ class TestCatchDupNS(TestCase):
         ns_builder2.export(self.ns_path2, outdir=self.tempdir)
         type_map = get_type_map(extensions=os.path.join(self.tempdir, self.ns_path1))
         type_map.load_namespaces(os.path.join(self.tempdir, self.ns_path2))
+
+    def test_catch_dup_name_core_newer(self):
+        new_ns_version = '100.0.0'
+        ns_builder1 = NWBNamespaceBuilder('Extension for us in my Lab', self.core_ns, version=new_ns_version)
+        ext1 = NWBGroupSpec('A custom ElectricalSeries for my lab',
+                            attributes=[NWBAttributeSpec(name='trode_id', doc='the tetrode id', dtype='int')],
+                            neurodata_type_inc='ElectricalSeries',
+                            neurodata_type_def='TetrodeSeries')
+        ns_builder1.add_spec(self.ext_source1, ext1)
+        ns_builder1.export(self.ns_path1, outdir=self.tempdir)
+
+        # create new catalog and merge the loaded core namespace catalog
+        ns_catalog = NamespaceCatalog()
+        ns_catalog.merge(self.ns_catalog)
+
+        # test loading newer namespace than one already loaded will warn
+        msg = (f'Ignoring the following cached namespace(s) because another version is already loaded:\n'
+               f'{self.core_ns} - cached version: {new_ns_version}, loaded version: {self.core_ns_version}\n'
+               f'Please update to the latest package versions.')
+        with self.assertWarnsWith(UserWarning, msg):
+            ns_catalog.load_namespaces(os.path.join(self.tempdir, self.ns_path1))
+
+    def test_catch_dup_name_core_older(self):
+        new_ns_version = '0.0.0'
+        ns_builder1 = NWBNamespaceBuilder('Extension for us in my Lab', self.core_ns, version=new_ns_version)
+        ext1 = NWBGroupSpec('A custom ElectricalSeries for my lab',
+                            attributes=[NWBAttributeSpec(name='trode_id', doc='the tetrode id', dtype='int')],
+                            neurodata_type_inc='ElectricalSeries',
+                            neurodata_type_def='TetrodeSeries')
+        ns_builder1.add_spec(self.ext_source1, ext1)
+        ns_builder1.export(self.ns_path1, outdir=self.tempdir)
+
+        # create new catalog and merge the loaded core namespace catalog
+        ns_catalog = NamespaceCatalog()
+        ns_catalog.merge(self.ns_catalog)
+
+        # test no warning if loading older namespace than one already loaded
+        msg = (f'Ignoring the following cached namespace(s) because another version is already loaded:\n'
+               f'{self.core_ns} - cached version: {new_ns_version}, loaded version: {self.core_ns_version}\n'
+               f'Please update to the latest package versions.')
+        with warnings.catch_warnings(record=True) as ws:
+            ns_catalog.load_namespaces(os.path.join(self.tempdir, self.ns_path1))
+        for w in ws:
+            self.assertTrue(str(w.message) != msg)
+            warnings.warn(str(w.message), w.category)

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -4,7 +4,6 @@ import os
 import sys
 from unittest.mock import patch
 from io import StringIO
-import warnings
 
 from pynwb.testing import TestCase
 from pynwb import validate, NWBHDF5IO

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -202,13 +202,7 @@ class TestValidateFunction(TestCase):
 
     def get_io(self, path):
         """Get an NWBHDF5IO object for the given path, ignoring the warning about ignoring cached namespaces."""
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore",
-                message=r"Ignoring cached namespace .*",
-                category=UserWarning,
-            )
-            return NWBHDF5IO(str(path), 'r')
+        return NWBHDF5IO(str(path), 'r')
 
     def test_validate_io_no_cache(self):
         """Test that validating a file with no cached spec against the core namespace succeeds."""


### PR DESCRIPTION
## Motivation

Fix #2064.

These changes will update the conditions in which the "ignore cached namespaces" warning is displayed and will only warn for core namespaces if the cached version is newer than the loaded version.

After HDMF 4.1.0 is released, this can be fully tested and merged.

## How to test the behavior?
```python
from pynwb import NWBHDF5IO

io = NWBHDF5IO("tests/back_compat/2.1.0_nwbfile_with_extension.nwb", "r")
io.read()  # no warnings should be raised
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
