### PR TITLE
Add function to clear cached type map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements and minor changes
 - Automatically add timezone information to timestamps reference time if no timezone information is specified. @stephprince [#2056](https://github.com/NeurodataWithoutBorders/pynwb/pull/2056)
 - Added option to disable typemap caching and updated type map cache location. @stephprince [#2057](https://github.com/NeurodataWithoutBorders/pynwb/pull/2057)
+- Added function to clear the type map cache (`pynwb.clear_cached_typemap`). @rly [#2080](https://github.com/NeurodataWithoutBorders/pynwb/pull/2080)
 - Added dictionary-like operations directly on `ProcessingModule` objects (e.g., `len(processing_module)`). @bendichter [#2020](https://github.com/NeurodataWithoutBorders/pynwb/pull/2020)
 - When an external file is detected when initializing an ImageSeries and no format is provided, automatically set format to "external" instead of raising an error. @stephprince [#2060](https://github.com/NeurodataWithoutBorders/pynwb/pull/2060)
 - Added mask_type option to `mock_PlaneSegmentation`. @pauladkisson [#2067](https://github.com/NeurodataWithoutBorders/pynwb/pull/2067)
@@ -19,7 +20,7 @@
 - Fixed shape check in `SpikeEventSeries.__init__` to support `AbstractDataChunkIterator` for timestamps/data. @oruebel [#2031](https://github.com/NeurodataWithoutBorders/pynwb/pull/2031)
 - Added unit tests to enhance coverage of `core.py`, `image.py`, `spec.py`, `icephys.py`, `epoch.py` and others. @oruebel [#2031](https://github.com/NeurodataWithoutBorders/pynwb/pull/2031)
 - Fix missing `IndexSeries.indexed_images`. @rly [#2074](https://github.com/NeurodataWithoutBorders/pynwb/pull/2074)
- 
+
 ## PyNWB 3.0.0 (February 26, 2025)
 
 ### Breaking changes
@@ -27,7 +28,7 @@
    - The behavior of `pynwb.validate(io=...)` now matches the behavior of `pynwb.validate(path=...)`. In previous pynwb versions, `pynwb.validate(io=...)` did not use the cached namespaces during validation. To obtain the same behavior as in previous versions, you can update the function call to `pynwb.validate(io=..., use_cached_namespaces=False)`
    - `pynwb.validate` will return only a list of validation errors instead of a tuple: (list of validation_errors, status code)
    - the `pynwb.validate(path=...)` argument has been added as a replacement for `pynwb.validate(paths=[...])`, which will be deprecated in a future major release [#2024](https://github.com/NeurodataWithoutBorders/pynwb/pull/2024)
-   - The validate module has been renamed to `validation.py`. The validate method can be 
+   - The validate module has been renamed to `validation.py`. The validate method can be
    imported using `import pynwb; pynwb.validate` or `from pynwb import validate`
 
 ### Deprecations
@@ -43,7 +44,7 @@
   - ``ImageSeries.format`` is fixed to 'external' if an external file is provided.
   - ``ImageSeries.bits_per_pixel`` is deprecated.
   - ``ImagingPlane.manifold``, ``ImagingPlane.conversion`` and ``ImagingPlane.unit`` are deprecated. Use ``ImagingPlane.origin_coords`` and ``ImagingPlane.grid_spacing`` instead.
-  - ``IndexSeries.unit`` is fixed to "N\A". 
+  - ``IndexSeries.unit`` is fixed to "N\A".
   - ``IndexSeries.indexed_timeseries`` is deprecated. Use ``IndexSeries.indexed_images`` instead.
 - The following deprecated methods have been removed:
   - ``NWBFile.add_ic_electrode`` is removed. Use ``NWBFile.add_icephys_electrode`` instead.
@@ -54,7 +55,7 @@
 ### Enhancements and minor changes
 - Added `__all__` to modules. @bendichter [#2021](https://github.com/NeurodataWithoutBorders/pynwb/pull/2021)
 - Added `pynwb.read_nwb` convenience method to simplify reading an NWBFile written with any backend @h-mayorquin [#1994](https://github.com/NeurodataWithoutBorders/pynwb/pull/1994)
-- Constrained `hdmf<5` to prevent future compatibility issues. [#2040](https://github.com/NeurodataWithoutBorders/pynwb/pull/2040)   
+- Constrained `hdmf<5` to prevent future compatibility issues. [#2040](https://github.com/NeurodataWithoutBorders/pynwb/pull/2040)
 
 ### Bug fixes
 - Made distance, orientation, and field_of_view optional in OpticalSeries to match schema @bendichter [#2023](https://github.com/NeurodataWithoutBorders/pynwb/pull/2023)
@@ -75,7 +76,7 @@
 - Updated `SpikeEventSeries`, `DecompositionSeries`, and `FilteredEphys` examples. @stephprince [#2012](https://github.com/NeurodataWithoutBorders/pynwb/pull/2012)
 - Replaced deprecated `scipy.misc.face` dataset in the images tutorial with another example. @stephprince [#2016](https://github.com/NeurodataWithoutBorders/pynwb/pull/2016)
 - Removed Allen Brain Observatory example which was unnecessary and difficult to maintain. @rly [#2026](https://github.com/NeurodataWithoutBorders/pynwb/pull/2026)
- 
+
 ## PyNWB 2.8.3 (November 19, 2024)
 
 ### Enhancements and minor changes

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -83,7 +83,6 @@ def __get_resources() -> dict:
     return ret
 
 
-
 # a global type map
 global __TYPE_MAP
 
@@ -95,6 +94,15 @@ __TYPE_MAP.merge(hdmf_typemap, ns_catalog=True)
 
 # load the core namespace, i.e. base NWB specification
 __resources = __get_resources()
+
+def clear_cached_typemap():
+    """
+    Clear the cached typemap from the user cache directory.
+    """
+    try:
+        os.remove(__resources['cached_typemap_path'])
+    except (OSError, PermissionError) as e:
+        warn(f'Could not clear cached typemap: {e}', UserWarning)
 
 
 @docval({'name': 'extensions', 'type': (str, TypeMap, list),
@@ -537,7 +545,7 @@ class NWBHDF5IO(_HDF5IO):
         # Retrieve the filepath
         path = popargs('path', kwargs)
         file = popargs('file', kwargs)
-        
+
         path = str(path) if path is not None else None
 
         # Streaming case
@@ -555,18 +563,18 @@ class NWBHDF5IO(_HDF5IO):
 
         return nwbfile
 
-@docval({'name': 'path', 'type': (str, Path), 
+@docval({'name': 'path', 'type': (str, Path),
          'doc': 'Path to the NWB file. Can be either a local filesystem path to '
-                'an HDF5 (.nwb) or Zarr (.zarr) file.'}, 
+                'an HDF5 (.nwb) or Zarr (.zarr) file.'},
         is_method=False)
 def read_nwb(**kwargs):
     """Read an NWB file from a local path.
 
-    High-level interface for reading NWB files. Automatically handles both HDF5 
-    and Zarr formats. For advanced use cases (parallel I/O, custom namespaces), 
+    High-level interface for reading NWB files. Automatically handles both HDF5
+    and Zarr formats. For advanced use cases (parallel I/O, custom namespaces),
     use NWBHDF5IO or NWBZarrIO.
 
-    See also 
+    See also
         * :py:class:`~pynwb.NWBHDF5IO`: Core I/O class for HDF5 files with advanced options.
         * :py:class:`~hdmf_zarr.nwb.NWBZarrIO`: Core I/O class for Zarr files with advanced options.
 
@@ -584,17 +592,17 @@ def read_nwb(**kwargs):
             * Write or append modes
             * Pre-opened HDF5 file objects or Zarr stores
             * Remote file access configuration
- 
+
     Example usage reading a local NWB file:
 
     .. code-block:: python
 
         from pynwb import read_nwb
-        nwbfile = read_nwb("path/to/file.nwb")    
+        nwbfile = read_nwb("path/to/file.nwb")
 
     :Returns: pynwb.NWBFile The loaded NWB file object.
     """
-    
+
     path = popargs('path', kwargs)
     # HDF5 is always available so we try that first
     backend_is_hdf5 = NWBHDF5IO.can_read(path=path)
@@ -606,18 +614,18 @@ def read_nwb(**kwargs):
             from hdmf_zarr import NWBZarrIO
             backend_is_zarr = NWBZarrIO.can_read(path=path)
             if backend_is_zarr:
-                return NWBZarrIO.read_nwb(path=path) 
+                return NWBZarrIO.read_nwb(path=path)
             else:
                 raise ValueError(
                     f"Unable to read file: '{path}'. The file is not recognized as "
                     "either a valid HDF5 or Zarr NWB file. Please ensure the file exists and contains valid NWB data."
-                )     
+                )
         except ImportError:
             raise ValueError(
                 f"Unable to read file: '{path}'. The file is not recognized as an HDF5 NWB file. "
                 "If you are trying to read a Zarr file, please install hdmf-zarr using: pip install hdmf-zarr"
             )
-    
+
 
 
 from . import io as __io  # noqa: F401,E402
@@ -641,7 +649,7 @@ __all__ = [
     # Functions
     'get_type_map',
     'get_manager',
-    'load_namespaces', 
+    'load_namespaces',
     'available_namespaces',
     'clear_cache_dir',
     'register_class',
@@ -652,11 +660,11 @@ __all__ = [
     'unload_type_config',
     'read_nwb',
     'get_nwbfile_version',
-    
+
     # Classes
     'NWBHDF5IO',
     'NWBContainer',
-    'NWBData', 
+    'NWBData',
     'TimeSeries',
     'ProcessingModule',
     'NWBFile',

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -1,0 +1,17 @@
+import os
+import unittest
+from platformdirs import PlatformDirs
+from pynwb import __version__
+from pynwb import clear_cached_typemap
+
+@unittest.skipIf(
+    os.getenv("PYNWB_NO_CACHE_DIR") == "1",
+    reason="PYNWB_NO_CACHE_DIR is set to 1, skipping test"
+)
+def test_clear_cached_typemap():
+    dirs = PlatformDirs(appname="pynwb", version=__version__, ensure_exists=True)
+    cache_dir = dirs.user_cache_path
+    assert (cache_dir / 'pynwb_core_typemap.pkl').exists()
+
+    clear_cached_typemap()
+    assert not (cache_dir / 'pynwb_core_typemap.pkl').exists()


### PR DESCRIPTION
## Motivation

It is not obvious where the cached type map is stored on the user system. It would be convenient to add a function to pynwb to clear (delete) the cached type map.

## How to test the behavior?
```
import pynwb
pynwb.clear_cached_typemap()
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
