### PR TITLE
[Documentation] Clarify that 'add_units` expects `spike_times` in seconds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added dictionary-like operations directly on `ProcessingModule` objects (e.g., `len(processing_module)`). @bendichter [#2020](https://github.com/NeurodataWithoutBorders/pynwb/pull/2020)
 - When an external file is detected when initializing an ImageSeries and no format is provided, automatically set format to "external" instead of raising an error. @stephprince [#2060](https://github.com/NeurodataWithoutBorders/pynwb/pull/2060)
 - Added mask_type option to `mock_PlaneSegmentation`. @pauladkisson [#2067](https://github.com/NeurodataWithoutBorders/pynwb/pull/2067)
+- Improved the documentation of the `spike_times` in the Units table methods @h-mayorquin [#2085](https://github.com/NeurodataWithoutBorders/pynwb/pull/2085)
 
 ### Bug fixes
 - Fixed `add_data_interface` functionality that was mistakenly removed in PyNWB 3.0. @stephprince [#2052](https://github.com/NeurodataWithoutBorders/pynwb/pull/2052)

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -191,7 +191,7 @@ class Units(DynamicTable):
             self.__has_spike_times = False
         self.__electrode_table = electrode_table
 
-    @docval({'name': 'spike_times', 'type': 'array_data', 'doc': 'the spike times for each unit',
+    @docval({'name': 'spike_times', 'type': 'array_data', 'doc': 'the spike times for each unit (in seconds)',
              'default': None, 'shape': (None,)},
             {'name': 'obs_intervals', 'type': 'array_data',
              'doc': 'the observation intervals (valid times) for each unit. All spike_times for a given unit ' +

--- a/src/pynwb/misc.py
+++ b/src/pynwb/misc.py
@@ -153,7 +153,7 @@ class Units(DynamicTable):
                       'are associated with this unit, and the electrodes dimension here should be in the same order as'
                       ' the electrodes referenced in the `electrodes` column of this table.')
     __columns__ = (
-        {'name': 'spike_times', 'description': 'the spike times for each unit', 'index': True},
+        {'name': 'spike_times', 'description': 'the spike times for each unit in seconds', 'index': True},
         {'name': 'obs_intervals', 'description': 'the observation intervals for each unit',
          'index': True},
         {'name': 'electrodes', 'description': 'the electrodes that each spike unit came from',
@@ -191,7 +191,7 @@ class Units(DynamicTable):
             self.__has_spike_times = False
         self.__electrode_table = electrode_table
 
-    @docval({'name': 'spike_times', 'type': 'array_data', 'doc': 'the spike times for each unit (in seconds)',
+    @docval({'name': 'spike_times', 'type': 'array_data', 'doc': 'the spike times for each unit in seconds',
              'default': None, 'shape': (None,)},
             {'name': 'obs_intervals', 'type': 'array_data',
              'doc': 'the observation intervals (valid times) for each unit. All spike_times for a given unit ' +


### PR DESCRIPTION
## Motivation

The documentation for adding `add_units` does not state that spike times is on seconds. This PR clarifies that.



## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
