### PR TITLE
Use both pynwb and hdmf version for type map cache dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added unit tests to enhance coverage of `core.py`, `image.py`, `spec.py`, `icephys.py`, `epoch.py` and others. @oruebel [#2031](https://github.com/NeurodataWithoutBorders/pynwb/pull/2031)
 - Fixed missing `IndexSeries.indexed_images`. @rly [#2074](https://github.com/NeurodataWithoutBorders/pynwb/pull/2074)
 - Fixed missing `__nwbfields__` and `_fieldsname` for `NWBData` and its subclasses. @rly [#2082](https://github.com/NeurodataWithoutBorders/pynwb/pull/2082)
+- Fixed caching of the type map when using HDMF 4.1.0. @rly [#2087](https://github.com/NeurodataWithoutBorders/pynwb/pull/2087)
 
 ## PyNWB 3.0.0 (February 26, 2025)
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -10,6 +10,7 @@ from warnings import warn
 from platformdirs import PlatformDirs
 import h5py
 
+import hdmf
 from hdmf.spec import NamespaceCatalog
 from hdmf.utils import docval, getargs, popargs, get_docval
 from hdmf.backends.io import HDMFIO
@@ -72,7 +73,7 @@ def __get_resources() -> dict:
     __schema_dir = 'nwb-schema/core'
 
     # create a cache directory for the core typemap
-    dirs = PlatformDirs(appname="pynwb", version=__version__, ensure_exists=True)
+    dirs = PlatformDirs(appname="pynwb-hdmf", version=f"{__version__}-{hdmf.__version__}", ensure_exists=True)
     cache_dir = dirs.user_cache_path
     cached_core_typemap = cache_dir / 'pynwb_core_typemap.pkl'
 


### PR DESCRIPTION
## Motivation

Fix broken wheel installation in https://github.com/NeurodataWithoutBorders/pynwb/actions/runs/15316694085/job/43091793043

The core problem is that a type map is cached using hdmf 3.14.5 but then the wheel installation happens using hdmf 4.1.0, and in hdmf 4.1.0, we renamed ClassGenerator to ClassGeneratorManager. This breaks the loading of the pickled type map because ClassGenerator does not exist.

To remedy that, we will use both the pynwb and hdmf version to generate the name of the type map cache directory.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
