### PR TITLE
Remove processing module creation from `mock_ImagingPlane`

### DIFF
--- a/src/pynwb/testing/mock/ophys.py
+++ b/src/pynwb/testing/mock/ophys.py
@@ -76,8 +76,6 @@ def mock_ImagingPlane(
     )
 
     if nwbfile is not None:
-        if "ophys" not in nwbfile.processing:
-            nwbfile.create_processing_module("ophys", "ophys")
         nwbfile.add_imaging_plane(imaging_plane)
 
     return imaging_plane


### PR DESCRIPTION
## Motivation

The `mock_ImagingPlane` is creating a processing module but then it does not do anythign with it. This seems like a side effect that should not be there.



## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [ ] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [ ] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
