### PR TITLE
get_nwbfile_version/get_nwb_version: Fix parsing pre-semver version specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## Unreleased
+
+- Fixed parsing of the nwb_version attribute which followed the previous suggestion to have  a `NWB-` prefix.
+  @t-b [#2116](https://github.com/NeurodataWithoutBorders/pynwb/pull/2116)
+
 ## PyNWB 3.1.1 (July 22, 2025)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 ## Unreleased
 
-- Fixed parsing of the nwb_version attribute which followed the previous suggestion to have  a `NWB-` prefix.
-  @t-b [#2116](https://github.com/NeurodataWithoutBorders/pynwb/pull/2116)
+### Fixed
+- Fixed parsing of the nwb_version attribute which followed the previous suggestion to have a `NWB-` prefix.
+  @t-b [#2118](https://github.com/NeurodataWithoutBorders/pynwb/pull/2118)
 
 ## PyNWB 3.1.1 (July 22, 2025)
 

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -297,7 +297,7 @@ def get_nwbfile_version(**kwargs):
         nwb_version_string = nwb_version_string.decode()
 
     # Parse the version string
-    nwb_version_parts = nwb_version_string.replace("-", ".").replace("_", ".").split(".")
+    nwb_version_parts = nwb_version_string.replace("NWB-", "").replace("-", ".").replace("_", ".").split(".")
     nwb_version = tuple([int(i) if i.isnumeric() else i
                          for i in nwb_version_parts])
     return nwb_version_string, nwb_version

--- a/src/pynwb/io/utils.py
+++ b/src/pynwb/io/utils.py
@@ -37,6 +37,8 @@ def get_nwb_version(builder: Builder, include_prerelease=False) -> Tuple[int, ..
             return (2, 0, 0)
         else:
             return (2, 0, 0, "b")
+
+    nwb_version = nwb_version.removeprefix("NWB-")
     nwb_version_match = re.match(r"(\d+\.\d+\.\d+)", nwb_version)[0]  # trim off any non-numeric symbols at end
     version_list = [int(i) for i in nwb_version_match.split(".")]
     if include_prerelease:

--- a/tests/integration/utils/test_io_utils.py
+++ b/tests/integration/utils/test_io_utils.py
@@ -57,6 +57,13 @@ class TestGetNWBVersion(TestCase):
         assert get_nwb_version(builder1) == (2, 0, 0)
         assert get_nwb_version(builder1, include_prerelease=True) == (2, 0, 0, "b")
 
+    def test_get_nwb_version_NWB_prefix(self):
+        """Get the NWB version from a builder where version == "NWB-2.1.3"."""
+        builder1 = GroupBuilder(name="root")
+        builder1.set_attribute(name="nwb_version", value="NWB-2.1.3")
+        assert get_nwb_version(builder1) == (2, 1, 3)
+        assert get_nwb_version(builder1, include_prerelease=False) == (2, 1, 3)
+
 class TestGetNWBBackend(TestCase):
     def setUp(self):
         self.nwbfile = NWBFile(session_description='a test NWB File',


### PR DESCRIPTION
In commit NeurodataWithoutBorders/nwb-schema@dba02ff (update YAML specs with 2.1.0 specs, 2019-08-19) the help for nwb_version was changed in the following regard:

```
--- a/core/nwb.file.yaml
+++ b/core/nwb.file.yaml
@@ -2,220 +2,231 @@ groups:
[...]
   - name: nwb_version dtype: text
-    doc: 'File version string. COMMENT: Eg, NWB-1.0.0. This will be the name of the
-      format with trailing major, minor and patch numbers.'
-    value: 2.0b
+    value: 2.0.2
+    doc: File version string. Use semantic versioning, e.g. 1.2.1. This will be the
+      name of the format with trailing major, minor and patch numbers.
```

While adopting semantic versioning for nwb_version is a good step, care needs to be taken to allow reading older files.

Versions of IPNWB prior to AllenInstitute/IPNWB@70c65d4 (Switch to newer NWB specification 2.2.4, 2020-04-15) did follow the old suggestion in prefixing nwb_version with `NWB-`.

Let's disregard that prefix as was previsously done with the suffix 'b' in 26538b3f (Fix handling of version 2.0b (#1651), 2023-02-24).

Close #2117 
