### PR TITLE
Remove "testing" from TestImportStructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Fixed incorrect warning for path not ending in `.nwb` when no path argument was provided. @t-b [#2130](https://github.com/NeurodataWithoutBorders/pynwb/pull/2130)
-
+- Fixed import structure test. @rly [#2136](https://github.com/NeurodataWithoutBorders/pynwb/pull/2136)
 ### Documentation and tutorial enhancements
 - Change UI of assistant to be an accordion that is always visible. [#2124](https://github.com/NeurodataWithoutBorders/pynwb/pull/2124)
 

--- a/tests/back_compat/test_import_structure.py
+++ b/tests/back_compat/test_import_structure.py
@@ -73,7 +73,6 @@ class TestImportStructure(TestCase):
             "register_class",
             "register_map",
             "spec",
-            "testing",
             "validate",
         ]
         for member in expected_structure:


### PR DESCRIPTION
## Motivation

I found this strange behavior today.
`pytest tests/back_compat/test_import_structure.py` fails with error
`AssertionError: 'testing' not found in ['BuildManager', 'CORE_NAMESPACE', ...`

because `testing` is not part of the `pynwb` module when you run just `import pynwb`. That's correct.

However, this test succeeds when we run the full test suite (`pytest` or `python test.py`) because other tests have `from pynwb.testing import TestCase` which adds `testing` to the `pynwb` module. 

So the `test_import_structure` test should be corrected to not include "testing" in the checks because it is technically not part of the `pynwb` module.

## How to test the behavior?
```python
pytest tests/back_compat/test_import_structure.py
# or python -m unittest tests/back_compat/test_import_structure.py
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
