### PR TITLE
Update HDMF pin to 4.1.2 and shape error test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Changed
 - Change UI of documentation assistant to be an accordion that is always visible. @bendichter [#2124](https://github.com/NeurodataWithoutBorders/pynwb/pull/2124)
+- Updated minimum HDMF version to 4.1.2 and updated tests accordingly. @rly []()
 
 
 ## PyNWB 3.1.2 (August 13, 2025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Changed
 - Change UI of documentation assistant to be an accordion that is always visible. @bendichter [#2124](https://github.com/NeurodataWithoutBorders/pynwb/pull/2124)
-- Updated minimum HDMF version to 4.1.2 and updated tests accordingly. @rly []()
+- Updated minimum HDMF version to 4.1.2 and updated tests accordingly. @rly [#2144](https://github.com/NeurodataWithoutBorders/pynwb/pull/2144)
 
 
 ## PyNWB 3.1.2 (August 13, 2025)

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python==3.13
   - h5py==3.12.1
-  - hdmf==4.1.0
+  - hdmf==4.1.2
   - matplotlib==3.9.2
   - numpy==2.1.3
   - pandas==2.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "h5py>=3.2.0",
-    "hdmf>=4.1.0,<5",
+    "hdmf>=4.1.2,<5",
     "numpy>=1.24.0",
     "pandas>=1.2.0",
     "python-dateutil>=2.8.2",

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # minimum versions of package dependencies for installing PyNWB
 h5py==3.2.0
-hdmf==4.1.1
+hdmf==4.1.2
 numpy==1.24.0
 pandas==1.2.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
 h5py==3.12.1
-hdmf==4.1.1
+hdmf==4.1.2
 numpy==2.1.1; python_version > "3.9"  # numpy 2.1+ is not compatible with py3.9
 numpy==2.0.2; python_version == "3.9"
 pandas==2.2.3

--- a/tests/unit/test_ecephys.py
+++ b/tests/unit/test_ecephys.py
@@ -86,8 +86,11 @@ class ElectricalSeriesConstructor(TestCase):
 
     def test_invalid_data_shape(self):
         table, region = self._create_table_and_region()
-        with self.assertRaisesWith(ValueError, ("ElectricalSeries.__init__: incorrect shape for 'data' (got '(2, 2, 2, "
-                                                "2)', expected '((None,), (None, None), (None, None, None))')")):
+        msg = (
+            "ElectricalSeries.__init__: incorrect shape for data: got (2, 2, 2, 2), "
+            "and expected (*,) or (*, *) or (*, *, *)"
+        )
+        with self.assertRaisesWith(ValueError, msg):
             ElectricalSeries(name='test_ts1', data=np.ones((2, 2, 2, 2)), electrodes=region,
                              timestamps=[0.0, 0.1, 0.2, 0.3, 0.4, 0.5])
 


### PR DESCRIPTION
## Motivation

Adjust a test for changes in HDMF 4.1.2 from https://github.com/hdmf-dev/hdmf/pull/787

Waiting for HDMF 4.1.2 release

## How to test the behavior?
```
python test.py
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
