### PR TITLE
Avoid double nesting in `ProcessingModule` html repr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ _version.py
 core_typemap.pkl
 
 venv/
+uv.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 - Change UI of documentation assistant to be an accordion that is always visible. @bendichter [#2124](https://github.com/NeurodataWithoutBorders/pynwb/pull/2124)
 - Updated minimum HDMF version to 4.1.2 and updated tests accordingly. @rly [#2144](https://github.com/NeurodataWithoutBorders/pynwb/pull/2144)
+- Flattened `ProcessingModule` HTML representation to render data interfaces directly without the redundant `data_interfaces` wrapper. @h-mayorquin [#2149](https://github.com/NeurodataWithoutBorders/pynwb/pull/2149)
 
 
 ## PyNWB 3.1.2 (August 13, 2025)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -127,6 +127,22 @@ class ProcessingModule(MultiContainerInterface):
         """
         return self.data_interfaces.items()
 
+    def _generate_field_html(self, key, value, level, access_code):
+        """Override to flatten 'data_interfaces' rendering.
+
+        The 'data_interfaces' wrapper in ProcessingModule is redundant since the
+        ProcessingModule container itself already indicates it holds data interfaces.
+        This method renders the contained objects directly without that extra nesting level.
+        """
+        if key == 'data_interfaces':
+            # Render the contents directly without the wrapper
+            html_repr = ""
+            for item_key, item_value in value.items():
+                item_access_code = f"{access_code}['{item_key}']"
+                html_repr += super()._generate_field_html(item_key, item_value, level, item_access_code)
+            return html_repr
+        return super()._generate_field_html(key, value, level, access_code)
+
 
 @register_class('TimeSeries', CORE_NAMESPACE)
 class TimeSeries(NWBDataInterface):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -127,6 +127,16 @@ class TestProcessingModule(TestCase):
         items = self.pm.items()
         self.assertEqual(set(items), {("test_ts", ts), ("test_ts2", ts2)})
 
+    def test_repr_html_data_interfaces_flattened(self):
+        """Test that html representation flattens data_interfaces without extra nesting."""
+        ts = self._create_time_series()
+        self.pm.add(ts)
+        html = self.pm._repr_html_()
+        # The TimeSeries name should appear directly, not nested under 'data_interfaces'
+        self.assertIn('test_ts', html)
+        # 'data_interfaces' should not appear as a separate section header
+        self.assertNotIn('>data_interfaces<', html)
+
 
 class TestTimeSeries(TestCase):
     def test_init_no_parent(self):


### PR DESCRIPTION
Moved here from https://github.com/hdmf-dev/hdmf/pull/1354 at the request of @rly 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
