### PR TITLE
docs: Update device tutorials to use DeviceModel instead of deprecate…

### DIFF
--- a/docs/gallery/domain/ogen.py
+++ b/docs/gallery/domain/ogen.py
@@ -38,12 +38,20 @@ nwbfile = NWBFile(
 # :py:class:`~pynwb.ogen.OptogeneticStimulusSite`, which contains metadata about the stimulus site, and
 # :py:class:`~pynwb.ogen.OptogeneticSeries`, which contains the power applied by the laser over time, in watts.
 #
-# First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`:
+# First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`.
+# The :py:class:`~pynwb.device.DeviceModel` object stores information about the device model, which can be useful
+# when searching a set of NWB files or a data archive for all files that use a specific device model.
+# The fields ``manufacturer``, ``model_number``, and ``description`` are optional, but recommended.
 
+device_model = nwbfile.create_device_model(
+    name="Optogenetic Device Model",
+    manufacturer="Example Manufacturer",
+    description="Example optogenetic stimulation device",
+)
 device = nwbfile.create_device(
     name="device",
     description="description of device",
-    manufacturer="optional but recommended",
+    model=device_model,
 )
 
 ####################

--- a/docs/gallery/domain/ogen.py
+++ b/docs/gallery/domain/ogen.py
@@ -37,12 +37,15 @@ nwbfile = NWBFile(
 # The :py:mod:`~pynwb.ogen` module contains two data types that you will need to write optogenetics data,
 # :py:class:`~pynwb.ogen.OptogeneticStimulusSite`, which contains metadata about the stimulus site, and
 # :py:class:`~pynwb.ogen.OptogeneticSeries`, which contains the power applied by the laser over time, in watts.
-#
-# First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`.
-# The :py:class:`~pynwb.device.DeviceModel` object stores information about the device model, which can be useful
-# when searching a set of NWB files or a data archive for all files that use a specific device model.
-# The fields ``manufacturer``, ``model_number``, and ``description`` are optional, but recommended.
-
+## First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`
+   # to represent the optogenetic stimulation system. It is recommended to add as much metadata about the
+   # system/device as possible to inform others using the data. A :py:class:`~pynwb.device.Device` object has
+   # an optional ``model`` field that points to a :py:class:`~pynwb.device.DeviceModel` object, which stores
+   # information about the device model. This can be useful when searching a set of NWB files or a data archive
+   # for all files that use a specific device model, or expressing that multiple devices in a session use the
+   # same device model. The fields ``description`` and ``model_number`` for
+   # :py:class:`~pynwb.device.DeviceModel` and the fields ``description``, ``model``, and ``serial_number`` for
+   # :py:class:`~pynwb.device.Device` are optional, but recommended. ``DeviceModel.manufacturer`` is required.
 device_model = nwbfile.create_device_model(
     name="Optogenetic Device Model",
     manufacturer="Example Manufacturer",

--- a/docs/gallery/domain/ogen.py
+++ b/docs/gallery/domain/ogen.py
@@ -37,15 +37,15 @@ nwbfile = NWBFile(
 # The :py:mod:`~pynwb.ogen` module contains two data types that you will need to write optogenetics data,
 # :py:class:`~pynwb.ogen.OptogeneticStimulusSite`, which contains metadata about the stimulus site, and
 # :py:class:`~pynwb.ogen.OptogeneticSeries`, which contains the power applied by the laser over time, in watts.
-## First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`
-   # to represent the optogenetic stimulation system. It is recommended to add as much metadata about the
-   # system/device as possible to inform others using the data. A :py:class:`~pynwb.device.Device` object has
-   # an optional ``model`` field that points to a :py:class:`~pynwb.device.DeviceModel` object, which stores
-   # information about the device model. This can be useful when searching a set of NWB files or a data archive
-   # for all files that use a specific device model, or expressing that multiple devices in a session use the
-   # same device model. The fields ``description`` and ``model_number`` for
-   # :py:class:`~pynwb.device.DeviceModel` and the fields ``description``, ``model``, and ``serial_number`` for
-   # :py:class:`~pynwb.device.Device` are optional, but recommended. ``DeviceModel.manufacturer`` is required.
+# First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`
+# to represent the optogenetic stimulation system. It is recommended to add as much metadata about the
+# system/device as possible to inform others using the data. A :py:class:`~pynwb.device.Device` object has
+# an optional ``model`` field that points to a :py:class:`~pynwb.device.DeviceModel` object, which stores
+# information about the device model. This can be useful when searching a set of NWB files or a data archive
+# for all files that use a specific device model, or expressing that multiple devices in a session use the
+# same device model. The fields ``description`` and ``model_number`` for
+# :py:class:`~pynwb.device.DeviceModel` and the fields ``description``, ``model``, and ``serial_number`` for
+# :py:class:`~pynwb.device.Device` are optional, but recommended. ``DeviceModel.manufacturer`` is required.
 device_model = nwbfile.create_device_model(
     name="Thorlabs M470F3 Model",
     description="470nm fiber-coupled LED, 17.2mW output for channelrhodopsin activation",

--- a/docs/gallery/domain/ogen.py
+++ b/docs/gallery/domain/ogen.py
@@ -37,6 +37,7 @@ nwbfile = NWBFile(
 # The :py:mod:`~pynwb.ogen` module contains two data types that you will need to write optogenetics data,
 # :py:class:`~pynwb.ogen.OptogeneticStimulusSite`, which contains metadata about the stimulus site, and
 # :py:class:`~pynwb.ogen.OptogeneticSeries`, which contains the power applied by the laser over time, in watts.
+# 
 # First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`
 # to represent the optogenetic stimulation system. It is recommended to add as much metadata about the
 # system/device as possible to inform others using the data. A :py:class:`~pynwb.device.Device` object has

--- a/docs/gallery/domain/ogen.py
+++ b/docs/gallery/domain/ogen.py
@@ -47,14 +47,17 @@ nwbfile = NWBFile(
    # :py:class:`~pynwb.device.DeviceModel` and the fields ``description``, ``model``, and ``serial_number`` for
    # :py:class:`~pynwb.device.Device` are optional, but recommended. ``DeviceModel.manufacturer`` is required.
 device_model = nwbfile.create_device_model(
-    name="Optogenetic Device Model",
-    manufacturer="Example Manufacturer",
-    description="Example optogenetic stimulation device",
+    name="Thorlabs M470F3 Model",
+    description="470nm fiber-coupled LED, 17.2mW output for channelrhodopsin activation",
+    manufacturer="Thorlabs",
+    model_number="M470F3",
 )
+
 device = nwbfile.create_device(
-    name="device",
-    description="description of device",
+    name="Thorlabs M470F3",
+    description="470nm fiber-coupled LED used for optogenetic stimulation",
     model=device_model,
+    serial_number="SN-00123456",
 )
 
 ####################

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -91,18 +91,7 @@ nwbfile = NWBFile(
 # :py:class:`~pynwb.device.DeviceModel` object stores information about the device model, which can be useful
 # when searching a set of NWB files or a data archive for all files that use a specific device model
 # (e.g., specific microscope model).
-device_model = nwbfile.create_device_model(
-    name="Loki 1.0",
-    manufacturer="Loki Labs",
-    model_number="ABC-123",
-    description="Two-photon microscope model",
-)
-device = nwbfile.create_device(
-    name="Microscope",
-    description="My two-photon microscope",
-    serial_number="1234567890",
-    model=device_model,
-)
+
 optical_channel = OpticalChannel(
     name="OpticalChannel",
     description="an optical channel",

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -87,16 +87,21 @@ nwbfile = NWBFile(
 #
 # Create a :py:class:`~pynwb.device.Device` named ``"Microscope"`` in the :py:class:`~pynwb.file.NWBFile` object. Then
 # create an  :py:class:`~pynwb.ophys.OpticalChannel` named ``"OpticalChannel"``. The fields
-# ``description``, ``manufacturer``, ``model_number``, ``model_name``, and ``serial_number`` are optional, but
-# recommended.
-
+# ``description``, ``serial_number``, and ``model`` are optional, but recommended. The
+# :py:class:`~pynwb.device.DeviceModel` object stores information about the device model, which can be useful
+# when searching a set of NWB files or a data archive for all files that use a specific device model
+# (e.g., specific microscope model).
+device_model = nwbfile.create_device_model(
+    name="Loki 1.0",
+    manufacturer="Loki Labs",
+    model_number="ABC-123",
+    description="Two-photon microscope model",
+)
 device = nwbfile.create_device(
     name="Microscope",
     description="My two-photon microscope",
-    manufacturer="Loki Labs",
-    model_number="ABC-123",
-    model_name="Loki 1.0",
     serial_number="1234567890",
+    model=device_model,
 )
 optical_channel = OpticalChannel(
     name="OpticalChannel",

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -92,6 +92,20 @@ nwbfile = NWBFile(
 # when searching a set of NWB files or a data archive for all files that use a specific device model
 # (e.g., specific microscope model).
 
+device_model = nwbfile.create_device_model(
+    name="Thorlabs Bergamo II Model",
+    description="Two-photon microscope for in vivo imaging",
+    manufacturer="Thorlabs",
+    model_number="Bergamo II",
+)
+
+device = nwbfile.create_device(
+    name="Thorlabs Bergamo II",
+    description="Two-photon microscope for in vivo imaging",
+    model=device_model,
+    serial_number="SN-123456789",
+)
+
 optical_channel = OpticalChannel(
     name="OpticalChannel",
     description="an optical channel",

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -85,13 +85,13 @@ nwbfile = NWBFile(
 #     :alt: imaging plane UML diagram
 #     :align: center
 #
-# Create a :py:class:`~pynwb.device.Device` named ``"Thorlabs Bergamo II"`` in the :py:class:`~pynwb.file.NWBFile` object.
-# The fields
+# Create a :py:class:`~pynwb.device.Device` named ``"Thorlabs Bergamo II"`` in the
+# :py:class:`~pynwb.file.NWBFile` object. The fields
 # ``description``, ``serial_number``, and ``model`` are optional, but recommended. The
 # :py:class:`~pynwb.device.DeviceModel` object stores information about the device model, which can be useful
 # when searching a set of NWB files or a data archive for all files that use a specific device model
 # (e.g., specific microscope model).
-# Then create an :py:class:`~pynwb.ophys.OpticalChannel` named ``"OpticalChannel"``. 
+# Then create an :py:class:`~pynwb.ophys.OpticalChannel` named ``"OpticalChannel"``.
 
 device_model = nwbfile.create_device_model(
     name="Thorlabs Bergamo II Model",

--- a/docs/gallery/domain/ophys.py
+++ b/docs/gallery/domain/ophys.py
@@ -85,12 +85,13 @@ nwbfile = NWBFile(
 #     :alt: imaging plane UML diagram
 #     :align: center
 #
-# Create a :py:class:`~pynwb.device.Device` named ``"Microscope"`` in the :py:class:`~pynwb.file.NWBFile` object. Then
-# create an  :py:class:`~pynwb.ophys.OpticalChannel` named ``"OpticalChannel"``. The fields
+# Create a :py:class:`~pynwb.device.Device` named ``"Thorlabs Bergamo II"`` in the :py:class:`~pynwb.file.NWBFile` object.
+# The fields
 # ``description``, ``serial_number``, and ``model`` are optional, but recommended. The
 # :py:class:`~pynwb.device.DeviceModel` object stores information about the device model, which can be useful
 # when searching a set of NWB files or a data archive for all files that use a specific device model
 # (e.g., specific microscope model).
+# Then create an :py:class:`~pynwb.ophys.OpticalChannel` named ``"OpticalChannel"``. 
 
 device_model = nwbfile.create_device_model(
     name="Thorlabs Bergamo II Model",


### PR DESCRIPTION
Updates the device tutorials (`ogen.py` and `ophys.py`) to use the modern `DeviceModel` approach instead of the deprecated `manufacturer`, `model_number`, and `model_name` fields on `Device`.

- Updated `ophys.py` tutorial to use DeviceModel pattern (create DeviceModel first, then link to Device)
- Updated `ogen.py` tutorial to use DeviceModel pattern
- Fixes deprecation warnings when following tutorials
- All tutorials now follow modern DeviceModel convention

This addresses the issue where users get `DeprecationWarning` when specifying manufacturer field on Device. The modern approach uses `DeviceModel` to store manufacturer, model_number, and model information, then links the DeviceModel to the Device.

## Motivation

The `Device.manufacturer`, `Device.model_number`, and `Device.model_name` fields were deprecated in PyNWB 3.1.0 (introduced via [#2088](https://github.com/NeurodataWithoutBorders/pynwb/pull/2088)) in favor of the new `DeviceModel` class. However, the tutorials were still using the deprecated approach, causing users following the documentation to encounter deprecation warnings. 

The modern approach separates device instance information (stored in `Device`) from device model information (stored in `DeviceModel`), which provides better organization and makes it easier to search across multiple NWB files for all devices of a specific model. This change ensures the tutorials reflect current best practices and don't mislead users into using deprecated functionality.

## How to test the behavior?

1. Run the updated tutorials:sh
   cd pynwb/docs/gallery/domain
   python ogen.py
   python ophys.py
   