### PR TITLE
Clarify DeviceModel and Device relationship in optogenetics docs

### DIFF
--- a/docs/gallery/domain/ogen.py
+++ b/docs/gallery/domain/ogen.py
@@ -37,9 +37,12 @@ nwbfile = NWBFile(
 # The :py:mod:`~pynwb.ogen` module contains two data types that you will need to write optogenetics data,
 # :py:class:`~pynwb.ogen.OptogeneticStimulusSite`, which contains metadata about the stimulus site, and
 # :py:class:`~pynwb.ogen.OptogeneticSeries`, which contains the power applied by the laser over time, in watts.
+#
 # In pynwb, device-related metadata is split into two levels:
-# ``DeviceModel`` stores metadata shared across devices of the same type (e.g., manufacturer, model number),
-# while ``Device`` represents the specific physical device used in an experiment.
+# :py:class:`~pynwb.device.DeviceModel` stores metadata shared across devices of the same type (e.g., manufacturer,
+# model number), while :py:class:`~pynwb.device.Device` represents the specific physical device used in an
+# experiment.
+#
 # First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`
 # to represent the optogenetic stimulation system. It is recommended to add as much metadata about the
 # system/device as possible to inform others using the data. A :py:class:`~pynwb.device.Device` object has

--- a/docs/gallery/domain/ogen.py
+++ b/docs/gallery/domain/ogen.py
@@ -37,7 +37,9 @@ nwbfile = NWBFile(
 # The :py:mod:`~pynwb.ogen` module contains two data types that you will need to write optogenetics data,
 # :py:class:`~pynwb.ogen.OptogeneticStimulusSite`, which contains metadata about the stimulus site, and
 # :py:class:`~pynwb.ogen.OptogeneticSeries`, which contains the power applied by the laser over time, in watts.
-# 
+# In pynwb, device-related metadata is split into two levels:
+# ``DeviceModel`` stores metadata shared across devices of the same type (e.g., manufacturer, model number),
+# while ``Device`` represents the specific physical device used in an experiment.
 # First, you need to create a :py:class:`~pynwb.device.Device` object linked to the :py:class:`~pynwb.file.NWBFile`
 # to represent the optogenetic stimulation system. It is recommended to add as much metadata about the
 # system/device as possible to inform others using the data. A :py:class:`~pynwb.device.Device` object has


### PR DESCRIPTION
Motivation

This PR improves the optogenetics documentation by clearly explaining the difference between DeviceModel (shared device metadata) and Device (the specific physical device used in an experiment). This makes the docs easier to understand and aligns them with current usage.

How to test the behavior?

This is a documentation-only change.
Read the updated optogenetics documentation to verify that the DeviceModel and Device relationship is clearer.
Docs build was attempted locally; full sphinx-gallery execution may require additional optional dependencies on Windows.
