### PR TITLE
Enhance 'age' parameter documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Fixed
 - Fixed invalid CSS properties in documentation assistant toggle that prevented proper positioning on displays ≥1400px wide. @rly [#2151](https://github.com/NeurodataWithoutBorders/pynwb/pull/2151)
-- 
+- Expanded documentation for the 'age' parameter to include age range examples and clarify usage. @rly [#2161](https://github.com/NeurodataWithoutBorders/pynwb/pull/2161)
+
 
 ## PyNWB 3.1.3 (December 9, 2025)
 

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -78,8 +78,14 @@ class Subject(NWBContainer):
         {
             "name": "age",
             "type": (str, timedelta),
-            "doc": 'The age of the subject. The ISO 8601 Duration format is recommended, e.g., "P90D" for 90 days old.'
-                   'A timedelta will automatically be converted to The ISO 8601 Duration format.',
+            "doc": (
+              'The age of the subject. The ISO 8601 Duration format is recommended, e.g., "P90D" for 90 days old.'
+              'A timedelta will automatically be converted to The ISO 8601 Duration format. '
+              'If the precise age is unknown, an age range can be given by "[lower bound]/[upper bound]" e.g. '
+              '"P10D/P20D" would mean that the age is in between 10 and 20 days. If only the lower bound is known, '
+              'then including only the slash after that lower bound can be used to indicate a missing bound. '
+              'For instance, "P90Y/" would indicate that the age is 90 years or older.'
+            ),
             "default": None,
         },
         {


### PR DESCRIPTION
Expanded documentation for the 'age' parameter to include age range examples and clarify usage. 

Copied from https://nwbinspector.readthedocs.io/en/dev/best_practices/nwbfile_metadata.html#subject

## Motivation

I received a question in a direct message: "I had a question about the age requirement for publishing to DANDI using NWB. If the user does not know the exact date of birth, can the user provide age as "3-8 months old" for the age of the subject during a given experiment? I've asked the researcher and he said that he doesn't record the date of birth since he doesn't view it as relevant for his experiments."

This could be better documented in pynwb, so I am adding that here. I will submit a separate PR for improving the schema doc.

## How to test the behavior?
```
View API docs
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
