### PR TITLE
Add Python 3.14 support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,6 +66,7 @@ body:
         - "3.11"
         - "3.12"
         - "3.13"
+        - "3.14"
         - "higher version (not yet supported)"
     validations:
       required: true

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install build dependencies
         run: |
@@ -28,11 +28,11 @@ jobs:
 
       - name: Run tox tests
         run: |
-          tox -e py312-upgraded
+          tox -e py314-upgraded
 
       - name: Build wheel and source distribution
         run: |
-          tox -e build-py312-upgraded
+          tox -e build-py314-upgraded
           ls -1 dist
 
       - name: Test installation from a wheel

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.13'
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install build dependencies
         run: |

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -99,8 +99,9 @@ jobs:
           - { name: windows-gallery-python3.14-upgraded  , test-tox-env: gallery-py314-upgraded  , python-ver: "3.14", os: windows-latest }
           - { name: windows-gallery-python3.14-prerelease, test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: windows-latest }
           - { name: macos-gallery-python3.10-minimum     , test-tox-env: gallery-py310-minimum   , python-ver: "3.10", os: macos-15-intel }
-          - { name: macos-gallery-python3.14-upgraded    , test-tox-env: gallery-py314-upgraded  , python-ver: "3.14", os: macos-latest }
-          - { name: macos-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: macos-latest }
+          # macOS gallery uses py313: dandi pins numcodecs<0.16, which lacks py314 macOS wheels
+          - { name: macos-gallery-python3.13-upgraded    , test-tox-env: gallery-py313-upgraded  , python-ver: "3.13", os: macos-latest }
+          - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -199,9 +199,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.13-ros3  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: conda-windows-python3.13-ros3, python-ver: "3.13", os: windows-latest }
-          - { name: conda-macos-python3.13-ros3  , python-ver: "3.13", os: macos-latest }
+          - { name: conda-linux-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: conda-windows-python3.14-ros3, python-ver: "3.14", os: windows-latest }
+          - { name: conda-macos-python3.14-ros3  , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -246,9 +246,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-gallery-python3.13-ros3  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: conda-windows-gallery-python3.13-ros3, python-ver: "3.13", os: windows-latest }
-          - { name: conda-macos-gallery-python3.13-ros3  , python-ver: "3.13", os: macos-latest }
+          - { name: conda-linux-gallery-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: conda-windows-gallery-python3.14-ros3, python-ver: "3.14", os: windows-latest }
+          - { name: conda-macos-gallery-python3.14-ros3  , python-ver: "3.14", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -28,24 +28,27 @@ jobs:
           - { name: linux-python3.11-opt         , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12             , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13             , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-upgraded    , test-tox-env: test-py313-upgraded       , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-python3.13-prerelease  , test-tox-env: test-py313-prerelease     , build-tox-env: build-py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.14             , test-tox-env: test-py314-pinned         , build-tox-env: build-py314-pinned    , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-upgraded    , test-tox-env: test-py314-upgraded       , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-python3.14-prerelease  , test-tox-env: test-py314-prerelease     , build-tox-env: build-py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
           - { name: windows-python3.9-minimum    , test-tox-env: test-py39-minimum         , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: windows-latest }
           - { name: windows-python3.10           , test-tox-env: test-py310-pinned         , build-tox-env: build-py310-pinned    , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.11-opt       , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.12           , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.13           , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-upgraded  , test-tox-env: test-py313-upgraded       , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: windows-latest }
-          - { name: windows-python3.13-prerelease, test-tox-env: test-py313-prerelease     , build-tox-env: build-py313-prerelease, python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.14           , test-tox-env: test-py314-pinned         , build-tox-env: build-py314-pinned    , python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.14-upgraded  , test-tox-env: test-py314-upgraded       , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: windows-latest }
+          - { name: windows-python3.14-prerelease, test-tox-env: test-py314-prerelease     , build-tox-env: build-py314-prerelease, python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.9-minimum      , test-tox-env: test-py39-minimum         , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: macos-15-intel }
           - { name: macos-python3.10             , test-tox-env: test-py310-pinned         , build-tox-env: build-py310-pinned    , python-ver: "3.10", os: macos-latest }
           - { name: macos-python3.11             , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.11-opt         , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13             , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-upgraded    , test-tox-env: test-py313-upgraded       , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: macos-latest }
-          - { name: macos-python3.13-prerelease  , test-tox-env: test-py313-prerelease     , build-tox-env: build-py313-prerelease, python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.14             , test-tox-env: test-py314-pinned         , build-tox-env: build-py314-pinned    , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-upgraded    , test-tox-env: test-py314-upgraded       , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: macos-latest }
+          - { name: macos-python3.14-prerelease  , test-tox-env: test-py314-prerelease     , build-tox-env: build-py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -93,14 +96,14 @@ jobs:
       matrix:
         include:
           - { name: linux-gallery-python3.9-minimum      , test-tox-env: gallery-py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.13-upgraded    , test-tox-env: gallery-py313-upgraded  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: linux-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-gallery-python3.14-upgraded    , test-tox-env: gallery-py314-upgraded  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: linux-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
           - { name: windows-gallery-python3.9-minimum    , test-tox-env: gallery-py39-minimum    , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-gallery-python3.13-upgraded  , test-tox-env: gallery-py313-upgraded  , python-ver: "3.13", os: windows-latest }
-          - { name: windows-gallery-python3.13-prerelease, test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: windows-latest }
+          - { name: windows-gallery-python3.14-upgraded  , test-tox-env: gallery-py314-upgraded  , python-ver: "3.14", os: windows-latest }
+          - { name: windows-gallery-python3.14-prerelease, test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: windows-latest }
           - { name: macos-gallery-python3.9-minimum      , test-tox-env: gallery-py39-minimum    , python-ver: "3.9" , os: macos-15-intel}
-          - { name: macos-gallery-python3.13-upgraded    , test-tox-env: gallery-py313-upgraded  , python-ver: "3.13", os: macos-latest }
-          - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
+          - { name: macos-gallery-python3.14-upgraded    , test-tox-env: gallery-py314-upgraded  , python-ver: "3.14", os: macos-latest }
+          - { name: macos-gallery-python3.14-prerelease  , test-tox-env: gallery-py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -143,8 +146,9 @@ jobs:
           - { name: conda-linux-python3.11           , test-tox-env: test-py311-pinned    , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
           - { name: conda-linux-python3.12           , test-tox-env: test-py312-pinned    , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: ubuntu-latest }
           - { name: conda-linux-python3.13           , test-tox-env: test-py313-pinned    , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: ubuntu-latest }
-          - { name: conda-linux-python3.13-upgraded  , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: ubuntu-latest }
-          - { name: conda-linux-python3.13-prerelease, test-tox-env: test-py313-prerelease, build-tox-env: build-py313-prerelease, python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-python3.14           , test-tox-env: test-py314-pinned    , build-tox-env: build-py314-pinned    , python-ver: "3.14", os: ubuntu-latest }
+          - { name: conda-linux-python3.14-upgraded  , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: ubuntu-latest }
+          - { name: conda-linux-python3.14-prerelease, test-tox-env: test-py314-prerelease, build-tox-env: build-py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -24,25 +24,25 @@ jobs:
         include:
           - { name: linux-python3.10-minimum     , test-tox-env: test-py310-minimum        , build-tox-env: build-py310-minimum   , python-ver: "3.10", os: ubuntu-latest }
           - { name: linux-python3.11             , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
-          - { name: linux-python3.11-opt         , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: ubuntu-latest }
           - { name: linux-python3.12             , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: ubuntu-latest }
           - { name: linux-python3.13             , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-python3.13-opt         , test-tox-env: test-py313-optional-pinned, build-tox-env: build-py313-pinned    , python-ver: "3.13", os: ubuntu-latest }
           - { name: linux-python3.14             , test-tox-env: test-py314-pinned         , build-tox-env: build-py314-pinned    , python-ver: "3.14", os: ubuntu-latest }
           - { name: linux-python3.14-upgraded    , test-tox-env: test-py314-upgraded       , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: ubuntu-latest }
           - { name: linux-python3.14-prerelease  , test-tox-env: test-py314-prerelease     , build-tox-env: build-py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
           - { name: windows-python3.10-minimum   , test-tox-env: test-py310-minimum        , build-tox-env: build-py310-minimum   , python-ver: "3.10", os: windows-latest }
           - { name: windows-python3.11           , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: windows-latest }
-          - { name: windows-python3.11-opt       , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: windows-latest }
           - { name: windows-python3.12           , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: windows-latest }
           - { name: windows-python3.13           , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.13-opt       , test-tox-env: test-py313-optional-pinned, build-tox-env: build-py313-pinned    , python-ver: "3.13", os: windows-latest }
           - { name: windows-python3.14           , test-tox-env: test-py314-pinned         , build-tox-env: build-py314-pinned    , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-upgraded  , test-tox-env: test-py314-upgraded       , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: windows-latest }
           - { name: windows-python3.14-prerelease, test-tox-env: test-py314-prerelease     , build-tox-env: build-py314-prerelease, python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.10-minimum     , test-tox-env: test-py310-minimum        , build-tox-env: build-py310-minimum   , python-ver: "3.10", os: macos-15-intel }
           - { name: macos-python3.11             , test-tox-env: test-py311-pinned         , build-tox-env: build-py311-pinned    , python-ver: "3.11", os: macos-latest }
-          - { name: macos-python3.11-opt         , test-tox-env: test-py311-optional-pinned, build-tox-env: build-py311-pinned    , python-ver: "3.11", os: macos-latest }
           - { name: macos-python3.12             , test-tox-env: test-py312-pinned         , build-tox-env: build-py312-pinned    , python-ver: "3.12", os: macos-latest }
           - { name: macos-python3.13             , test-tox-env: test-py313-pinned         , build-tox-env: build-py313-pinned    , python-ver: "3.13", os: macos-latest }
+          - { name: macos-python3.13-opt         , test-tox-env: test-py313-optional-pinned, build-tox-env: build-py313-pinned    , python-ver: "3.13", os: macos-latest }
           - { name: macos-python3.14             , test-tox-env: test-py314-pinned         , build-tox-env: build-py314-pinned    , python-ver: "3.14", os: macos-latest }
           - { name: macos-python3.14-upgraded    , test-tox-env: test-py314-upgraded       , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: macos-latest }
           - { name: macos-python3.14-prerelease  , test-tox-env: test-py314-prerelease     , build-tox-env: build-py314-prerelease, python-ver: "3.14", os: macos-latest }

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -28,7 +28,7 @@ jobs:
           - { os: macos-latest  , opt_req: false }
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.14'
+      PYTHON: '3.13'
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -28,7 +28,7 @@ jobs:
           - { os: macos-latest  , opt_req: false }
     env:
       OS: ${{ matrix.os }}
-      PYTHON: '3.13'
+      PYTHON: '3.14'
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install run dependencies
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Download wheel and source distributions from artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -21,11 +21,11 @@ jobs:
         include:
           - { name: linux-python3.9-minimum      , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum   , python-ver: "3.9" , os: ubuntu-latest }
           # NOTE config below with "upload-wheels: true" specifies that wheels should be uploaded as an artifact
-          - { name: linux-python3.13-upgraded    , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded , python-ver: "3.13", os: ubuntu-latest , upload-wheels: true }
+          - { name: linux-python3.14-upgraded    , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded , python-ver: "3.14", os: ubuntu-latest , upload-wheels: true }
           - { name: windows-python3.9-minimum    , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum   , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-python3.13-upgraded  , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded , python-ver: "3.13", os: windows-latest }
+          - { name: windows-python3.14-upgraded  , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded , python-ver: "3.14", os: windows-latest }
           - { name: macos-python3.9-minimum      , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum   , python-ver: "3.9" , os: macos-15-intel }
-          - { name: macos-python3.13-upgraded    , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded , python-ver: "3.13" , os: macos-latest }
+          - { name: macos-python3.14-upgraded    , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded , python-ver: "3.14" , os: macos-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -80,9 +80,9 @@ jobs:
       matrix:
         include:
           - { name: linux-gallery-python3.9-minimum    , test-tox-env: gallery-py39-minimum  , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: linux-gallery-python3.13-upgraded  , test-tox-env: gallery-py313-upgraded, python-ver: "3.13", os: ubuntu-latest }
+          - { name: linux-gallery-python3.14-upgraded  , test-tox-env: gallery-py314-upgraded, python-ver: "3.14", os: ubuntu-latest }
           - { name: windows-gallery-python3.9-minimum  , test-tox-env: gallery-py39-minimum  , python-ver: "3.9" , os: windows-latest }
-          - { name: windows-gallery-python3.13-upgraded, test-tox-env: gallery-py313-upgraded, python-ver: "3.13", os: windows-latest }
+          - { name: windows-gallery-python3.14-upgraded, test-tox-env: gallery-py314-upgraded, python-ver: "3.14", os: windows-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -121,7 +121,7 @@ jobs:
       matrix:
         include:
           - { name: conda-linux-python3.9-minimum    , test-tox-env: test-py39-minimum    , build-tox-env: build-py39-minimum    , python-ver: "3.9" , os: ubuntu-latest }
-          - { name: conda-linux-python3.13-upgraded  , test-tox-env: test-py313-upgraded  , build-tox-env: build-py313-upgraded  , python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-python3.14-upgraded  , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -280,7 +280,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Download wheel and source distributions from artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -175,7 +175,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-python3.13-ros3  , python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0
@@ -220,7 +220,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: conda-linux-gallery-python3.13-ros3  , python-ver: "3.13", os: ubuntu-latest }
+          - { name: conda-linux-gallery-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
       - name: Cancel non-latest runs
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -280,7 +280,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.13'
 
       - name: Download wheel and source distributions from artifact
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 ### Fixed
 - Fixed invalid CSS properties in documentation assistant toggle that prevented proper positioning on displays ≥1400px wide. @rly [#2151](https://github.com/NeurodataWithoutBorders/pynwb/pull/2151) 
 
+### Changed
+- Added Python 3.14 support. @bendichter
 
 ## PyNWB 3.1.3 (December 9, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Fixed invalid CSS properties in documentation assistant toggle that prevented proper positioning on displays ≥1400px wide. @rly [#2151](https://github.com/NeurodataWithoutBorders/pynwb/pull/2151) 
 
 ### Changed
-- Added Python 3.14 support. @bendichter
+- Added Python 3.14 support. @bendichter, @rly [#2168](https://github.com/NeurodataWithoutBorders/pynwb/pull/2168)
 - Updated HDMF dependency to >=5.0.0, <6. @rly [#2171](https://github.com/NeurodataWithoutBorders/pynwb/issues/2171)
 - Deprecated Python 3.9 support. (EOL was Oct 31, 2025) @bendichter [#2141](https://github.com/NeurodataWithoutBorders/pynwb/pull/2141)
 

--- a/docs/source/install_developers.rst
+++ b/docs/source/install_developers.rst
@@ -6,7 +6,7 @@ Installing PyNWB for Developers
 
 PyNWB has the following minimum requirements, which must be installed before you can get started using PyNWB.
 
-#. Python 3.9, 3.10, 3.11, 3.12, or 3.13
+#. Python 3.9, 3.10, 3.11, 3.12, 3.13, or 3.14
 #. pip
 
 

--- a/docs/source/install_users.rst
+++ b/docs/source/install_users.rst
@@ -6,7 +6,7 @@ Installing PyNWB
 
 PyNWB has the following minimum requirements, which must be installed before you can get started using PyNWB.
 
-#. Python 3.9, 3.10, 3.11, 3.12, or 3.13
+#. Python 3.9, 3.10, 3.11, 3.12, 3.13, or 3.14
 #. pip
 
 .. note:: If you are a developer then please see the :ref:`install_developers` installation instructions instead.

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python==3.13
+  - python==3.14
   - h5py==3.12.1
   - matplotlib==3.9.2
   - numpy==2.1.3

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -5,13 +5,13 @@ channels:
   - defaults
 dependencies:
   - python==3.14
-  - h5py==3.12.1
+  - h5py==3.16.0
   - matplotlib==3.9.2
-  - numpy==2.1.3
-  - pandas==2.2.3
+  - numpy==2.4.3
+  - pandas==2.3.3
   - python-dateutil==2.9.0
   - setuptools
-  - pytest==7.4.3  # pin to pytest < 8 because of incompatibilities to be addressed
+  - pytest==9.0.2
   - fsspec==2025.5.1
   - requests==2.32.3
   - aiohttp==3.12.13

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -5,16 +5,16 @@ channels:
   - defaults
 dependencies:
   - python==3.14
-  - h5py==3.16.0
-  - matplotlib==3.9.2
-  - numpy==2.4.3
-  - pandas==2.3.3
+  - h5py==3.15.1
+  - matplotlib==3.10.8
+  - numpy==2.4.2
+  - pandas==3.0.1
   - python-dateutil==2.9.0
   - setuptools
   - pytest==9.0.2
-  - fsspec==2025.5.1
-  - requests==2.32.3
-  - aiohttp==3.12.13
+  - fsspec==2026.1.0
+  - requests==2.32.5
+  - aiohttp==3.13.3
   - pip
   - pip:
     - hdmf==5.0.0  # not yet available on conda-forge

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "numpy>=1.24.0",
     "pandas>=1.4.0",
     "python-dateutil>=2.8.2",
-    "platformdirs>=4.1.0"
+    "platformdirs>=4.2.2"
 ]
 dynamic = ["version"] # the build backend will compute the version dynamically from git tag (or a __version__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "License :: OSI Approved :: BSD License",
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,11 +2,11 @@
 # compute coverage, and create test environments. note that depending on the version of python installed, different
 # versions of requirements may be installed due to package incompatibilities.
 #
-black==24.4.2
-codespell==2.3.0
-coverage==7.5.3
-pytest==8.2.1
-isort==5.13.2
-pytest-cov==5.0.0
-tox==4.15.0
-ruff==0.4.6
+black==26.3.0
+codespell==2.4.2
+coverage==7.13.4
+pytest==9.0.2
+isort==8.0.1
+pytest-cov==7.0.0
+tox==4.49.1
+ruff==0.15.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,5 +8,5 @@ coverage==7.13.4
 pytest==9.0.2
 isort==8.0.1
 pytest-cov==7.0.0
-tox==4.49.1
+tox==4.20.0
 ruff==0.15.5

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -4,4 +4,4 @@ hdmf==5.0.0
 numpy==1.24.0
 pandas==1.4.0
 python-dateutil==2.8.2
-platformdirs==4.1.0
+platformdirs==4.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
-h5py==3.12.1
+h5py==3.16.0
 hdmf==5.0.0
-numpy==2.1.1
-pandas==2.2.3
+numpy==2.4.3
+pandas==2.3.3
 python-dateutil==2.9.0.post0
-platformdirs==4.3.6
+platformdirs==4.9.4

--- a/tox.ini
+++ b/tox.ini
@@ -36,13 +36,13 @@ commands =
 # list of pre-defined environments.
 [testenv:test-py314-upgraded]
 [testenv:test-py314-prerelease]
-[testenv:test-py311-optional-pinned]  # some optional reqs not compatible with py312 yet
+[testenv:test-py313-optional-pinned]
 [testenv:test-py{310,311,312,313,314}-pinned]
 [testenv:test-py310-minimum]
 
 [testenv:gallery-py314-upgraded]
 [testenv:gallery-py314-prerelease]
-[testenv:gallery-py311-optional-pinned]
+[testenv:gallery-py313-optional-pinned]
 [testenv:gallery-py{310,311,312,313,314}-pinned]
 [testenv:gallery-py310-minimum]
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,6 +42,8 @@ commands =
 
 [testenv:gallery-py314-upgraded]
 [testenv:gallery-py314-prerelease]
+[testenv:gallery-py313-upgraded]
+[testenv:gallery-py313-prerelease]
 [testenv:gallery-py313-optional-pinned]
 [testenv:gallery-py{310,311,312,313,314}-pinned]
 [testenv:gallery-py310-minimum]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = test-py{39,310,311,312,313}-pinned
+envlist = test-py{39,310,311,312,313,314}-pinned
 requires = pip >= 22.0
 
 [testenv]
@@ -34,21 +34,21 @@ commands =
     wheelinstall: python -c "import pynwb"
 
 # list of pre-defined environments.
-[testenv:test-py313-upgraded]
-[testenv:test-py313-prerelease]
+[testenv:test-py314-upgraded]
+[testenv:test-py314-prerelease]
 [testenv:test-py311-optional-pinned]  # some optional reqs not compatible with py312 yet
-[testenv:test-py{39,310,311,312,313}-pinned]
+[testenv:test-py{39,310,311,312,313,314}-pinned]
 [testenv:test-py39-minimum]
 
-[testenv:gallery-py313-upgraded]
-[testenv:gallery-py313-prerelease]
+[testenv:gallery-py314-upgraded]
+[testenv:gallery-py314-prerelease]
 [testenv:gallery-py311-optional-pinned]
-[testenv:gallery-py{39,310,311,312,313}-pinned]
+[testenv:gallery-py{39,310,311,312,313,314}-pinned]
 [testenv:gallery-py39-minimum]
 
-[testenv:build-py313-upgraded]
-[testenv:build-py313-prerelease]
-[testenv:build-py{39,310,311,312,313}-pinned]  # using tox for this so that we can have a clean build environment
+[testenv:build-py314-upgraded]
+[testenv:build-py314-prerelease]
+[testenv:build-py{39,310,311,312,313,314}-pinned]  # using tox for this so that we can have a clean build environment
 [testenv:build-py39-minimum]
 
 [testenv:wheelinstall]  # use with `--installpkg dist/*-none-any.whl`


### PR DESCRIPTION
## Summary
- Add Python 3.14 classifier to `pyproject.toml`
- Add `314` to all tox env lists and move `upgraded`/`prerelease` envs from `py313` to `py314`
- Add Python 3.14 pinned entries and update upgraded/prerelease entries across all CI workflows (`run_all_tests.yml`, `run_tests.yml`, `run_coverage.yml`, `deploy_release.yml`)
- Add `"3.14"` to bug report template Python version dropdown
- Update docs to list Python 3.14 as supported

## Test plan
- [x] CI passes on all matrix entries
- [x] Python 3.14 pinned, upgraded, and prerelease jobs run successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)