### PR TITLE
Add example of setting Units.resolution in the ecephys tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Documentation and tutorial enhancements
 - Added documentation for `ExternalImage` to the images tutorial. @h-mayorquin [#2159](https://github.com/NeurodataWithoutBorders/pynwb/pull/2159)
 - Fixed broken and redirecting links in documentation. @bendichter [#2165](https://github.com/NeurodataWithoutBorders/pynwb/pull/2165)
+- Added example of setting `Units.resolution` in the ecephys tutorial. @h-mayorquin [#2174](https://github.com/NeurodataWithoutBorders/pynwb/pull/2174)
 
 ### Added
 - Added support for HERD (HDMF External Resources Data Structure) as the `external_resources` field on `NWBFile`, enabling users to associate external resource annotations (e.g., ontology term mappings) with their NWB files. `link_resources` and `get_external_resources` are inherited from `HERDManager` in hdmf. @mavaylon1, @rly [#2111](https://github.com/NeurodataWithoutBorders/pynwb/pull/2111)

--- a/docs/gallery/domain/ecephys.py
+++ b/docs/gallery/domain/ecephys.py
@@ -348,6 +348,14 @@ for n_units_per_shank in range(n_units):
 # data, typically ``1 / sampling_rate`` of the acquisition system (i.e., the smallest measurable difference
 # between two spike times, in seconds). Setting it helps downstream users judge whether fine-timescale
 # analyses are appropriate for the dataset.
+#
+# When creating the :py:class:`~pynwb.misc.Units` table directly, you can pass it to the constructor:
+#
+# .. code-block:: python
+#
+#     units = Units(name="units", resolution=1 / 30000)  # 30 kHz recording system
+#
+# Since the tutorial uses :py:meth:`.NWBFile.add_unit`, we set it after the fact:
 
 nwbfile.units.resolution = 1 / res  # resolution in seconds (1 / sampling rate)
 

--- a/docs/gallery/domain/ecephys.py
+++ b/docs/gallery/domain/ecephys.py
@@ -343,6 +343,14 @@ for n_units_per_shank in range(n_units):
     spike_times = np.where(np.random.rand((res * duration)) < (firing_rate / res))[0] / res
     nwbfile.add_unit(spike_times=spike_times, quality="good")
 
+####################
+# The ``resolution`` field on the :py:class:`~pynwb.misc.Units` table documents the precision of spike timing
+# data, typically ``1 / sampling_rate`` of the acquisition system (i.e., the smallest measurable difference
+# between two spike times, in seconds). Setting it helps downstream users judge whether fine-timescale
+# analyses are appropriate for the dataset.
+
+nwbfile.units.resolution = 1 / res  # resolution in seconds (1 / sampling rate)
+
 #######################
 # The :py:class:`~pynwb.misc.Units` table can also be converted to a pandas :py:class:`~pandas.DataFrame`.
 #

--- a/docs/gallery/domain/ecephys.py
+++ b/docs/gallery/domain/ecephys.py
@@ -348,14 +348,6 @@ for n_units_per_shank in range(n_units):
 # data, typically ``1 / sampling_rate`` of the acquisition system (i.e., the smallest measurable difference
 # between two spike times, in seconds). Setting it helps downstream users judge whether fine-timescale
 # analyses are appropriate for the dataset.
-#
-# When creating the :py:class:`~pynwb.misc.Units` table directly, you can pass it to the constructor:
-#
-# .. code-block:: python
-#
-#     units = Units(name="units", resolution=1 / 30000)  # 30 kHz recording system
-#
-# Since the tutorial uses :py:meth:`.NWBFile.add_unit`, we set it after the fact:
 
 nwbfile.units.resolution = 1 / res  # resolution in seconds (1 / sampling rate)
 


### PR DESCRIPTION
## Motivation

At the inspector we are working on `check_units_resolution_is_set` check (NeurodataWithoutBorders/nwbinspector#685), which flags `Units` tables that contain `spike_times` but have no `resolution` set. Users running the inspector on files created by following our tutorials would get this warning with no guidance on how to fix it.

I have added a short section to the ecephys tutorial that sets `nwbfile.units.resolution` right after the existing `add_unit` loop, with a brief explanation of what the field means and why it matters. I kept the change minimal to avoid restructuring the existing tutorial flow.

What was the reasoning behind this change? Please explain the changes briefly.



## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
