### PR TITLE
Update ReadTheDocs build image to Ubuntu 24.04

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,9 +6,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: '3.11'
+    python: '3.13'
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Summary
- Update ReadTheDocs build OS from `ubuntu-20.04` to `ubuntu-24.04`
- Bump Python version from 3.11 to 3.13

Fixes #2177

## Background

ReadTheDocs is deprecating the Ubuntu 20.04 LTS build image. After June 1, 2026, projects still using `ubuntu-20.04` will fail to build. Ubuntu 20.04 is no longer receiving security updates.

See: https://docs.readthedocs.io/en/stable/config-file/v2.html#build-os

## Test plan
- [x] Verify ReadTheDocs build succeeds with the new configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)