### PR TITLE
Map Units waveform metadata to waveforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Fixed
 - Fixed invalid CSS properties in documentation assistant toggle that prevented proper positioning on displays ≥1400px wide. @rly [#2151](https://github.com/NeurodataWithoutBorders/pynwb/pull/2151)
 - Fixed `TimeSeries.get_timestamps()` to handle numpy array timestamps when they are set. @pauladkisson [#2181](https://github.com/NeurodataWithoutBorders/pynwb/pull/2181)
+- Fixed `Units.waveform_rate` and `Units.waveform_unit` to also map to the `sampling_rate` and `unit` attributes of the `waveforms` column on write and read, so waveform sampling metadata round-trips for `Units` tables that contain only `waveforms` (without `waveform_mean` or `waveform_sd`). @ehennestad [#2183](https://github.com/NeurodataWithoutBorders/pynwb/pull/2183)
 
 ### Changed
 - Added Python 3.14 support. @bendichter, @rly [#2168](https://github.com/NeurodataWithoutBorders/pynwb/pull/2168)

--- a/src/pynwb/io/core.py
+++ b/src/pynwb/io/core.py
@@ -42,9 +42,9 @@ class VectorDataMap(ObjectMapper):
         ''' Get the value of the attribute corresponding to this spec from the given container '''
         spec, container, manager = getargs('spec', 'container', 'manager', kwargs)
 
-        # handle custom mapping of container Units.waveform_rate -> spec Units.waveform_mean.sampling_rate
+        # handle custom mapping of Units waveform metadata onto waveform-bearing columns
         if isinstance(container.parent, Units):
-            if container.name == 'waveform_mean' or container.name == 'waveform_sd':
+            if container.name in ('waveform_mean', 'waveform_sd', 'waveforms'):
                 if spec.name == 'sampling_rate':
                     return container.parent.waveform_rate
                 if spec.name == 'unit':

--- a/src/pynwb/io/misc.py
+++ b/src/pynwb/io/misc.py
@@ -22,19 +22,17 @@ class UnitsMap(DynamicTableMap):
         return self._get_waveform_stat(builder, 'unit')
 
     def _get_waveform_stat(self, builder, attribute):
-        if 'waveform_mean' not in builder and 'waveform_sd' not in builder:
+        waveform_columns = ('waveform_mean', 'waveform_sd', 'waveforms')
+        stats = [builder[column].attributes.get(attribute) for column in waveform_columns if column in builder]
+        if not stats:
             return None
-        mean_stat = None
-        sd_stat = None
-        if 'waveform_mean' in builder:
-            mean_stat = builder['waveform_mean'].attributes.get(attribute)
-        if 'waveform_sd' in builder:
-            sd_stat = builder['waveform_sd'].attributes.get(attribute)
-        if mean_stat is not None and sd_stat is not None:
-            if mean_stat != sd_stat:
-                # throw warning
-                pass
-        return mean_stat
+        populated_stats = [stat for stat in stats if stat is not None]
+        if len(set(populated_stats)) > 1:
+            # throw warning
+            pass
+        if populated_stats:
+            return populated_stats[0]
+        return None
 
     @DynamicTableMap.object_attr("electrodes")
     def electrodes_column(self, container, manager):

--- a/tests/integration/hdf5/test_misc.py
+++ b/tests/integration/hdf5/test_misc.py
@@ -1,3 +1,4 @@
+import h5py
 import numpy as np
 
 from hdmf.common import VectorData, DynamicTableRegion
@@ -68,6 +69,58 @@ class TestUnitsIO(AcquisitionH5IOMixin, TestCase):
         received = ut.get_unit_obs_intervals(1)
         np.testing.assert_array_equal(received, [[2., 5.], [6., 7.]])
         np.testing.assert_array_equal(ut['obs_intervals'][:], [[[0., 1.], [2., 3.]], [[2., 5.], [6., 7.]]])
+
+
+class TestUnitsWaveformsOnlyIO(AcquisitionH5IOMixin, TestCase):
+    """Test roundtripping waveform metadata when only waveforms are present."""
+
+    def setUpContainer(self):
+        ut = Units(name='UnitsWaveformsOnlyTest', description='a simple table for testing Units waveforms')
+        ut.add_unit(
+            spike_times=[0., 1., 2.],
+            waveforms=[
+                [
+                    [1, 2, 3],
+                    [1, 2, 3],
+                    [1, 2, 3]
+                ], [
+                    [1, 2, 3],
+                    [1, 2, 3],
+                    [1, 2, 3]
+                ]
+            ]
+        )
+        ut.add_unit(
+            spike_times=[3., 4., 5.],
+            waveforms=np.array([
+                [
+                    [1, 2, 3],
+                    [1, 2, 3],
+                    [1, 2, 3]
+                ], [
+                    [1, 2, 3],
+                    [1, 2, 3],
+                    [1, 2, 3]
+                ]
+            ])
+        )
+        ut.waveform_rate = 40000.
+        return ut
+
+    def test_waveform_metadata_roundtrip(self):
+        ut = self.roundtripContainer()
+        self.assertEqual(ut.waveform_rate, 40000.)
+        self.assertEqual(ut.waveform_unit, 'volts')
+
+    def test_waveforms_attributes_written(self):
+        self.roundtripContainer()
+        with h5py.File(self.filename, 'r') as infile:
+            waveforms = infile['acquisition'][self.container.name]['waveforms']
+            self.assertEqual(waveforms.attrs['sampling_rate'], 40000.)
+            unit = waveforms.attrs['unit']
+            if isinstance(unit, bytes):
+                unit = unit.decode('utf-8')
+            self.assertEqual(unit, 'volts')
 
 
 class TestUnitsFileIO(NWBH5IOMixin, TestCase):


### PR DESCRIPTION
## Motivation

This change fixes a mismatch between the NWB schema and the PyNWB `Units` mapper for waveform metadata.

The schema defines `sampling_rate` and `unit` attributes on `waveform_mean`, `waveform_sd`, and `waveforms`, but PyNWB only propagated `Units.waveform_rate` and `Units.waveform_unit` to `waveform_mean` and `waveform_sd`. As a result, a `Units` table containing only `waveforms` would lose waveform sampling metadata on write, and `waveform_rate` would not round-trip on read.

Fix #2182.

## What changed

- Extend the write-side `VectorData` mapper so `Units.waveform_rate` and `Units.waveform_unit` are also written to the `waveforms` column attributes.
- Extend the read-side `UnitsMap` logic so it also considers `waveforms` when reconstructing waveform metadata.
- Add an integration test that round-trips a `Units` table with only `waveforms` and verifies both the in-memory metadata and the on-disk attributes.

## How to test the behavior?

```bash
PYTHONPATH=src python -m unittest tests.integration.hdf5.test_misc.TestUnitsWaveformsOnlyIO tests.integration.hdf5.test_misc.TestUnitsIO
```

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [ ] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [ ] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.

Prepared with Codex.
