### PR TITLE
Skip linkcheck on app.readthedocs.org/projects/pynwb URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## PyNWB 4.0.0 (Upcoming)
 
 ### Documentation and tutorial enhancements
+- Added `app.readthedocs.org/projects/pynwb/*` to `linkcheck_ignore` to stop the Sphinx linkcheck CI job from intermittently failing when GitHub Actions runners get throttled by readthedocs. @h-mayorquin [#2191](https://github.com/NeurodataWithoutBorders/pynwb/pull/2191)
 - Added documentation for `ExternalImage` to the images tutorial. @h-mayorquin [#2159](https://github.com/NeurodataWithoutBorders/pynwb/pull/2159)
 - Fixed broken and redirecting links in documentation. @bendichter [#2165](https://github.com/NeurodataWithoutBorders/pynwb/pull/2165)
 - Added `EventsTable` examples to the NWB file basics and behavior tutorials. @rly [#2156](https://github.com/NeurodataWithoutBorders/pynwb/pull/2156)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -173,6 +173,7 @@ nitpick_ignore = [('py:class', 'Intracomm'),
 linkcheck_ignore = [
     r'https://training.incf.org/*',  # temporary ignore until SSL certificate issue is resolved
     r'https://scicrunch.org/*',  # scicrunch.org blocks automated requests with 403
+    r'https://app\.readthedocs\.org/projects/pynwb/.*',  # readthedocs blocks CI runner IPs (intermittent 403)
 ]
 
 suppress_warnings = ["config.cache"]


### PR DESCRIPTION
The Sphinx linkcheck CI job has been intermittently failing on the two `app.readthedocs.org/projects/pynwb/...` URLs introduced in #2166 (`docs/source/make_a_release.rst` and `docs/source/software_process.rst`). The URLs themselves are valid and return 200 OK from a normal browser or local `curl`, but GitHub Actions runners frequently get throttled or blocked at readthedocs' CDN layer and receive 403s instead. Same failure mode as the existing scicrunch.org entry, so I added an analogous `linkcheck_ignore` pattern scoped to `app\.readthedocs\.org/projects/pynwb/.*`. I scoped it to the pynwb project specifically (rather than a broad `app.readthedocs.org/*` like the scicrunch entry uses) so that any future readthedocs URL elsewhere in the docs still gets caught by linkcheck if it ever points at a typo or a removed project.


## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
