### PR TITLE
Add num_samples to ImageSeries

### DIFF
--- a/docs/gallery/domain/images.py
+++ b/docs/gallery/domain/images.py
@@ -174,9 +174,11 @@ nwbfile.add_acquisition(behavior_images)
 # Either ``external_file`` or ``data`` must be specified, but not both.
 #
 # If the sampling rate is constant, use :py:attr:`~pynwb.base.TimeSeries.rate` and
-# :py:attr:`~pynwb.base.TimeSeries.starting_time` to specify time.
+# :py:attr:`~pynwb.base.TimeSeries.starting_time` to specify time. When using ``rate``, you must also set
+# :py:attr:`~pynwb.image.ImageSeries.num_samples` to the total number of frames across all external files,
+# because the data array is empty and its length cannot be used to determine the frame count.
 # For irregularly sampled recordings, use :py:attr:`~pynwb.base.TimeSeries.timestamps` to specify time for each sample
-# image.
+# image. When using ``timestamps``, ``num_samples`` is not required because ``len(timestamps)`` serves this purpose.
 #
 # Each external image may contain one or more consecutive frames of the full :py:class:`~pynwb.image.ImageSeries`.
 # The :py:attr:`~pynwb.image.ImageSeries.starting_frame` attribute serves as an index to indicate which frame

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python==3.14
   - h5py==3.15.1
-  - hdmf==6.0.1
+  - hdmf==6.0.2
   - matplotlib==3.10.8
   - numpy==2.4.2
   - pandas==2.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "h5py>=3.6.0",
-    "hdmf>=6.0.1,<7",
+    "hdmf>=6.0.2,<7",
     "numpy>=1.24.0",
     "pandas>=1.4.0,<3",
     "python-dateutil>=2.8.2",

--- a/requirements-min.txt
+++ b/requirements-min.txt
@@ -1,6 +1,6 @@
 # minimum versions of package dependencies for installing PyNWB
 h5py==3.6.0
-hdmf==6.0.1
+hdmf==6.0.2
 numpy==1.24.0
 pandas==1.4.0
 python-dateutil==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # pinned dependencies to reproduce an entire development environment to use PyNWB
 h5py==3.16.0
-hdmf==6.0.1
+hdmf==6.0.2
 numpy==2.4.3
 pandas==2.3.3
 python-dateutil==2.9.0.post0

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -62,6 +62,7 @@ class ImageSeries(TimeSeries):
                      'external_file',
                      'starting_frame',
                      'format',
+                     'num_samples',
                      'device')
 
     # value used when an ImageSeries is read and missing data
@@ -88,6 +89,12 @@ class ImageSeries(TimeSeries):
             {'name': 'starting_frame', 'type': Iterable,
              'doc': 'Each entry is a frame number that corresponds to the first frame of each file '
                     'listed in external_file within the full ImageSeries.', 'default': None},
+            {'name': 'num_samples', 'type': (int, np.unsignedinteger),
+             'doc': ('Total number of frames across all external files. Required when format="external" and '
+                     'timing is described using starting_time and rate, because data is empty and its first '
+                     'dimension cannot be used to determine the number of frames. When timestamps is provided, '
+                     'len(timestamps) already serves this purpose.'),
+             'default': None},
             {'name': 'bits_per_pixel', 'type': int, 'doc': 'DEPRECATED: Number of bits per image pixel',
              'default': None},
             {'name': 'dimension', 'type': Iterable,
@@ -98,6 +105,7 @@ class ImageSeries(TimeSeries):
              'doc': 'Device used to capture the images/video.', 'default': None},
              allow_positional=AllowPositional.WARNING,)
     def __init__(self, **kwargs):
+        num_samples = kwargs.pop('num_samples')
         keys_to_set = ('bits_per_pixel', 'dimension', 'external_file', 'starting_frame', 'format', 'device')
         args_to_set = popargs_to_dict(keys_to_set, kwargs)
         name, data, unit = getargs('name', 'data', 'unit', kwargs)
@@ -123,11 +131,13 @@ class ImageSeries(TimeSeries):
                 [0] if len(args_to_set["external_file"]) == 1 else None
             )
 
+        self._num_samples = None  # must exist before super().__init__ accesses num_samples
         super().__init__(**kwargs)
 
         for key, val in args_to_set.items():
             setattr(self, key, val)
 
+        self._num_samples = num_samples
         self._change_external_file_format()
 
         error_msg = self._check_image_series_dimension()
@@ -145,6 +155,26 @@ class ImageSeries(TimeSeries):
         error_msg = self._check_external_file_data()
         if error_msg:
             self._error_on_new_warn_on_construct(error_msg=error_msg)
+
+        error_msg = self._check_num_samples()
+        if error_msg:
+            self._error_on_new_pass_on_construct(error_msg=error_msg)
+
+    def _check_num_samples(self):
+        """Check that num_samples is set when format='external' and rate is used for timing.
+
+        In this configuration data is an empty array so its shape cannot indicate frame count.
+        """
+        if (
+            self.external_file is not None
+            and self.rate is not None
+            and self.num_samples is None
+        ):
+            return (
+                "%s '%s': num_samples should be set when format='external' and rate is used for timing, "
+                "because data is empty and its length cannot be used to determine the number of frames."
+                % (self.__class__.__name__, self.name)
+            )
 
     def _change_external_file_format(self):
         """
@@ -216,6 +246,16 @@ class ImageSeries(TimeSeries):
             "%s '%s': Either external_file or data must be specified (not None), but not both."
             % (self.__class__.__name__, self.name)
         )
+
+    @property
+    def num_samples(self):
+        # Overrides TimeSeries.num_samples to return the stored attribute when set, because
+        # external-file series have empty data and len(data) would give 0 instead of the true count.
+        if self._num_samples is not None:
+            return self._num_samples
+        if self.external_file is not None:
+            return None
+        return super().num_samples
 
     @property
     def bits_per_pixel(self):

--- a/tests/integration/hdf5/test_image.py
+++ b/tests/integration/hdf5/test_image.py
@@ -28,6 +28,28 @@ class TestImageSeriesIO(AcquisitionH5IOMixin, TestCase):
         super().addContainer(nwbfile)
 
 
+class TestImageSeriesWithNumSamplesIO(AcquisitionH5IOMixin, TestCase):
+    """Roundtrip test for ImageSeries with num_samples (external file + rate timing)."""
+
+    def setUpContainer(self):
+        self.dev1 = Device(name='dev1')
+        iS = ImageSeries(
+            name='test_iS_num_samples',
+            unit='Frames',
+            external_file=['external_file'],
+            starting_frame=[0],
+            format='external',
+            rate=30.0,
+            num_samples=900,
+            device=self.dev1,
+        )
+        return iS
+
+    def addContainer(self, nwbfile):
+        nwbfile.add_device(self.dev1)
+        super().addContainer(nwbfile)
+
+
 class TestIndexSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -121,7 +121,7 @@ class ImageSeriesConstructor(TestCase):
         obj._in_construct_mode = False
 
     def test_dimension_warning_external_file_with_rate(self):
-        """Test that a warning is not raised when external file is used with rate."""
+        """Test that no warnings are raised when external file is used with rate and num_samples."""
         with warnings.catch_warnings(record=True) as w:
             ImageSeries(
                 name='test_iS',
@@ -130,6 +130,7 @@ class ImageSeriesConstructor(TestCase):
                 unit='Frames',
                 starting_frame=[0],
                 rate=0.2,
+                num_samples=10,
             )
             self.assertEqual(w, [])
 
@@ -195,18 +196,20 @@ class ImageSeriesConstructor(TestCase):
                 unit="n.a.",
                 starting_frame=[0, 15, 30],
                 rate=0.2,
+                num_samples=30,
             )
             self.assertEqual(w, [])
 
     def test_external_file_with_default_starting_frame(self):
         """Test that starting_frame is set to [0] if not provided, when external_file is has length 1."""
         iS = ImageSeries(
-                name="test_iS",
-                external_file=["external_file"],
-                format="external",
-                unit="n.a.",
-                starting_frame=None,
-                rate=0.2,
+            name="test_iS",
+            external_file=["external_file"],
+            format="external",
+            unit="n.a.",
+            starting_frame=None,
+            rate=0.2,
+            num_samples=10,
         )
         self.assertEqual(iS.starting_frame, [0])
 
@@ -250,12 +253,15 @@ class ImageSeriesConstructor(TestCase):
     def test_external_file_default_format(self):
         """Test that format is set to 'external' if not provided, when external_file is provided."""
 
-        kwargs = dict(name="test_iS",
-                external_file=["external_file", "external_file2"],
-                unit="n.a.",
-                starting_frame=[0, 10],
-                rate=0.2,)
-        
+        kwargs = dict(
+            name="test_iS",
+            external_file=["external_file", "external_file2"],
+            unit="n.a.",
+            starting_frame=[0, 10],
+            rate=0.2,
+            num_samples=20,
+        )
+
         iS = ImageSeries(**kwargs)
         self.assertEqual(iS.format, "external")
 
@@ -270,6 +276,7 @@ class ImageSeriesConstructor(TestCase):
                 unit="n.a.",
                 starting_frame=[0],
                 rate=0.2,
+                num_samples=10,
             )
             self.assertEqual(w, [])
 
@@ -312,6 +319,74 @@ class ImageSeriesConstructor(TestCase):
                 rate=0.2,
             )
 
+    def test_num_samples(self):
+        """Test that num_samples can be set on an external-file ImageSeries."""
+        iS = ImageSeries(
+            name='test_iS',
+            external_file=['external_file'],
+            format='external',
+            unit='Frames',
+            starting_frame=[0],
+            rate=30.0,
+            num_samples=900,
+        )
+        self.assertEqual(iS.num_samples, 900)
+
+    def test_num_samples_error_missing_with_rate(self):
+        """Test that a ValueError is raised when external_file + rate is used without num_samples."""
+        msg = (
+            "ImageSeries 'test_iS': num_samples should be set when format='external' and rate is used "
+            "for timing, because data is empty and its length cannot be used to determine the number of frames."
+        )
+        with self.assertRaisesWith(ValueError, msg):
+            ImageSeries(
+                name='test_iS',
+                external_file=['external_file'],
+                format='external',
+                unit='Frames',
+                starting_frame=[0],
+                rate=30.0,
+            )
+
+    def test_num_samples_not_required_with_timestamps(self):
+        """Test that num_samples is not required when timestamps are provided."""
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            ImageSeries(
+                name='test_iS',
+                external_file=['external_file'],
+                format='external',
+                unit='Frames',
+                starting_frame=[0],
+                timestamps=[1.0, 2.0, 3.0],
+            )
+        num_samples_warnings = [x for x in w if 'num_samples' in str(x.message)]
+        self.assertEqual(num_samples_warnings, [])
+
+    def test_num_samples_missing_with_rate_construct_mode(self):
+        """Test that no error or warning is raised in construct mode when num_samples is absent.
+
+        Old files written without num_samples should be readable without any complaints.
+        """
+        obj = ImageSeries.__new__(
+            ImageSeries,
+            container_source=None,
+            parent=None,
+            object_id="test",
+            in_construct_mode=True,
+        )
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            obj.__init__(
+                name='test_iS',
+                external_file=['external_file'],
+                format='external',
+                unit='Frames',
+                starting_frame=[0],
+                rate=30.0,
+            )
+        num_samples_warnings = [x for x in w if 'num_samples' in str(x.message)]
+        self.assertEqual(num_samples_warnings, [])
 
     def test_bits_per_pixel_deprecation(self):
         """Test that bits_per_pixel can be set and that a deprecated warning is raised."""


### PR DESCRIPTION
## Summary

- Points the nwb-schema submodule to the latest dev tip (`489cc31f`), which adds the optional
  `num_samples` dataset to `ImageSeries`. Corresponds to https://github.com/NeurodataWithoutBorders/nwb-schema/pull/678
- Implements `num_samples` in `ImageSeries`: when `format='external'` and `rate`-based timing is
  used, the data array is empty (shape `(0, 0, 0)`) and its length cannot be used to determine the
  frame count. `num_samples` fills that gap.
- Raises `ValueError` on construction when `external_file` + `rate` are set but `num_samples` is
  absent. Files missing the field are read silently (no warning) to avoid noise from existing data.
- Overrides `TimeSeries.num_samples` (a computed read-only property) with a stored attribute backed
  by `self._num_samples`, falling back to the parent implementation for data-bearing series.
- Updates gallery docs to document the `rate` + `num_samples` requirement for external-file series.
- Pins HDMF to `>=6.0.2`, which fixed a `TypeError` when writing `np.uint64` values.

## Checklist

- [x] `num_samples` is written to and read back from HDF5 (roundtrip test added)
- [x] `ValueError` raised when `external_file` + `rate` + no `num_samples` on construction
- [x] No error or warning when reading old files without `num_samples`
- [x] `num_samples` not required when `timestamps` is provided
- [x] Gallery docs updated