### PR TITLE
Update nwb-schema submodule to NWB 2.10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ manifest.json
 
 # Auto-generated tutorials
 docs/source/tutorials/
+docs/source/sg_execution_times.rst
 
 ### Python ###
 # Byte-compiled / optimized / DLL files

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,7 +46,7 @@ help:
 	@echo "  apidoc     to build RST from source code"
 
 clean:
-	-rm -rf $(BUILDDIR)/* $(RSTDIR)/$(PKGNAME)*.rst $(RSTDIR)/tutorials $(GALLERYDIR)/advanced_io/*.npy $(GALLERYDIR)/advanced_io/*.nwb
+	-rm -rf $(BUILDDIR)/* $(RSTDIR)/$(PKGNAME)*.rst $(RSTDIR)/tutorials $(RSTDIR)/sg_execution_times.rst $(GALLERYDIR)/advanced_io/*.npy $(GALLERYDIR)/advanced_io/*.nwb
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/docs/gallery/general/add_remove_containers.py
+++ b/docs/gallery/general/add_remove_containers.py
@@ -224,7 +224,7 @@ with h5py.File(filename, "r+") as f:
 # model. The example builds a valid name by replacing ``/`` and ``:`` with ``_``.
 #
 # The legacy file stores ``model`` as a string attribute, so it cannot be modified in place
-# (``mode="r+"``) or written to a new path with :py:meth:`~pynwb.NWBHDF5IO.write`. Use
+# (``mode="r+"``) or written to a new path with :py:meth:`~hdmf.backends.hdf5.h5tools.HDF5IO.write`. Use
 # :py:meth:`~pynwb.NWBHDF5IO.export` instead, and call
 # :py:meth:`~hdmf.container.AbstractContainer.set_modified` on the :py:class:`~pynwb.device.Device` so
 # that export rewrites it, dropping the legacy string attribute and writing a link to the new

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,7 +168,11 @@ extlinks = {
 
 nitpicky = True
 nitpick_ignore = [('py:class', 'Intracomm'),
-                  ('py:class', 'BaseStorageSpec')]
+                  ('py:class', 'BaseStorageSpec'),
+                  # pandas publishes ``pandas.DataFrame`` but autodoc renders the return
+                  # annotation as its qualname ``pandas.core.frame.DataFrame``, which has no
+                  # intersphinx target.
+                  ('py:class', 'pandas.core.frame.DataFrame')]
 
 linkcheck_ignore = [
     r'https://training.incf.org/*',  # temporary ignore until SSL certificate issue is resolved


### PR DESCRIPTION
## Motivation

Updates the `nwb-schema` submodule to the tip of the [`prepare_2.10.0`](https://github.com/NeurodataWithoutBorders/nwb-schema/tree/prepare_2.10.0) branch (NWB 2.10.0), which depends on nwb-schema PR NeurodataWithoutBorders/nwb-schema#681. This advances the nested `hdmf-common-schema` to 1.9.0 (adds `MeaningsTable`, promotes `HERD` to stable in hdmf-common).

Draft while NWB 2.10.0 is finalized.

Also fixes some Sphinx warnings.

## How to test the behavior?

The full pynwb test suite passes against the updated schema (`829 passed, 7 skipped, 6701 subtests passed`), after clearing the cached core typemap (`pynwb.clear_cache_dir()`).

## Checklist

- [ ] Did you update CHANGELOG.md with your changes?
  - Already added from a previous PR.
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff` from the source directory.
- [x] Have you checked to ensure that there aren't other open or previously closed [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)