### PR TITLE
Address GitHub Actions deprecation warnings

### DIFF
--- a/.github/workflows/check_sphinx_links.yml
+++ b/.github/workflows/check_sphinx_links.yml
@@ -5,23 +5,21 @@ on:
     - cron: '0 5 * * *'  # once per day at midnight ET
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-sphinx-links:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -10,13 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/generate_test_files.yml
+++ b/.github/workflows/generate_test_files.yml
@@ -17,13 +17,13 @@ jobs:
           - { name: pynwb-1.5.1, pynwb-version: "1.5.1", python-version: "3.8"}
           - { name: pynwb-2.1.0, pynwb-version: "2.1.0", python-version: "3.9"}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -37,7 +37,7 @@ jobs:
           python src/pynwb/testing/make_test_files.py
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v7
         with:
           name: test-files-${{ matrix.name }}
           path: |

--- a/.github/workflows/project_action.yml
+++ b/.github/workflows/project_action.yml
@@ -12,15 +12,15 @@ jobs:
     steps:
       - name: GitHub App token
         id: generate_token
-        uses: tibdex/github-app-token@v1.7.0
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PEM }}
-          
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PEM }}
+
       - name: Add to Developer Board
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}
-        uses: actions/add-to-project@v0.4.0
+        uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/NeurodataWithoutBorders/projects/7
           github-token: ${{ env.TOKEN }}
@@ -28,7 +28,7 @@ jobs:
       - name: Add to Community Board
         env:
           TOKEN: ${{ steps.generate_token.outputs.token }}
-        uses: actions/add-to-project@v0.4.0
+        uses: actions/add-to-project@v2.0.0
         with:
           project-url: https://github.com/orgs/NeurodataWithoutBorders/projects/8
           github-token: ${{ env.TOKEN }}

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -6,6 +6,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Run ruff
-        uses: chartboost/ruff-action@v1
+        uses: astral-sh/ruff-action@v3

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -7,6 +7,10 @@ on:
       - '/^[0-9]+(\.[0-9]+)?(\.[0-9]+)?$/'
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-all-tests:
     # the only differences between this job and "run_tests.yml" is the "strategy.matrix.include" and the upload
@@ -47,19 +51,13 @@ jobs:
           - { name: macos-python3.14-upgraded    , test-tox-env: test-py314-upgraded       , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: macos-latest }
           - { name: macos-python3.14-prerelease  , test-tox-env: test-py314-prerelease     , build-tox-env: build-py314-prerelease, python-ver: "3.14", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-ver }}
 
@@ -103,19 +101,13 @@ jobs:
           - { name: macos-gallery-python3.13-upgraded    , test-tox-env: gallery-py313-upgraded  , python-ver: "3.13", os: macos-latest }
           - { name: macos-gallery-python3.13-prerelease  , test-tox-env: gallery-py313-prerelease, python-ver: "3.13", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-ver }}
 
@@ -147,19 +139,13 @@ jobs:
           - { name: conda-linux-python3.14-upgraded  , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: ubuntu-latest }
           - { name: conda-linux-python3.14-prerelease, test-tox-env: test-py314-prerelease, build-tox-env: build-py314-prerelease, python-ver: "3.14", os: ubuntu-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-ver }}
@@ -204,26 +190,21 @@ jobs:
           - { name: conda-windows-python3.14-ros3, python-ver: "3.14", os: windows-latest }
           - { name: conda-macos-python3.14-ros3  , python-ver: "3.14", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           activate-environment: ros3
           environment-file: environment-ros3.yml
           python-version: ${{ matrix.python-ver }}
           channels: conda-forge
-          auto-activate-base: false
+          conda-remove-defaults: "true"
+          auto-activate: false
 
       - name: Install run dependencies
         run: |
@@ -251,26 +232,21 @@ jobs:
           - { name: conda-windows-gallery-python3.14-ros3, python-ver: "3.14", os: windows-latest }
           - { name: conda-macos-gallery-python3.14-ros3  , python-ver: "3.14", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           activate-environment: ros3
           environment-file: environment-ros3.yml
           python-version: ${{ matrix.python-ver }}
           channels: conda-forge
-          auto-activate-base: false
+          conda-remove-defaults: "true"
+          auto-activate: false
 
       - name: Install run dependencies
         run: |

--- a/.github/workflows/run_coverage.yml
+++ b/.github/workflows/run_coverage.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-coverage:
     name: ${{ matrix.os }}, opt reqs ${{ matrix.opt_req }}
@@ -30,19 +34,13 @@ jobs:
       OS: ${{ matrix.os }}
       PYTHON: '3.14'
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON }}
 
@@ -67,7 +65,7 @@ jobs:
           python -m coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           flags: unit
           file: coverage.xml
@@ -84,7 +82,7 @@ jobs:
           python -m coverage report
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           flags: integration
           file: coverage.xml

--- a/.github/workflows/run_dandi_read_tests.yml
+++ b/.github/workflows/run_dandi_read_tests.yml
@@ -7,23 +7,21 @@ on:
   #   - cron: '0 6 * * *'  # once per day at 1am ET
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 

--- a/.github/workflows/run_inspector_tests.yml
+++ b/.github/workflows/run_inspector_tests.yml
@@ -5,23 +5,21 @@ on:
     - cron: '0 5 * * *'  # once per day at midnight ET
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -8,6 +8,10 @@ on:
       - 'latest-tmp'
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   run-tests:
     name: ${{ matrix.name }}
@@ -27,19 +31,13 @@ jobs:
           - { name: macos-python3.10-minimum     , test-tox-env: test-py310-minimum   , build-tox-env: build-py310-minimum  , python-ver: "3.10", os: macos-15-intel }
           - { name: macos-python3.14-upgraded    , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded , python-ver: "3.14", os: macos-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-ver }}
 
@@ -64,7 +62,7 @@ jobs:
 
       - name: Upload distribution as a workspace artifact
         if: ${{ matrix.upload-wheels }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: distributions
           path: dist
@@ -84,19 +82,13 @@ jobs:
           - { name: windows-gallery-python3.10-minimum , test-tox-env: gallery-py310-minimum , python-ver: "3.10", os: windows-latest }
           - { name: windows-gallery-python3.14-upgraded, test-tox-env: gallery-py314-upgraded, python-ver: "3.14", os: windows-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-ver }}
 
@@ -123,19 +115,13 @@ jobs:
           - { name: conda-linux-python3.10-minimum   , test-tox-env: test-py310-minimum   , build-tox-env: build-py310-minimum   , python-ver: "3.10", os: ubuntu-latest }
           - { name: conda-linux-python3.14-upgraded  , test-tox-env: test-py314-upgraded  , build-tox-env: build-py314-upgraded  , python-ver: "3.14", os: ubuntu-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           python-version: ${{ matrix.python-ver }}
@@ -177,26 +163,21 @@ jobs:
         include:
           - { name: conda-linux-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           activate-environment: ros3
           environment-file: environment-ros3.yml
           python-version: ${{ matrix.python-ver }}
           channels: conda-forge
-          auto-activate-base: false
+          conda-remove-defaults: "true"
+          auto-activate: false
 
       - name: Install run dependencies
         run: |
@@ -222,26 +203,21 @@ jobs:
         include:
           - { name: conda-linux-gallery-python3.14-ros3  , python-ver: "3.14", os: ubuntu-latest }
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Conda
-        uses: conda-incubator/setup-miniconda@v3
+        uses: conda-incubator/setup-miniconda@v4
         with:
           auto-update-conda: true
           activate-environment: ros3
           environment-file: environment-ros3.yml
           python-version: ${{ matrix.python-ver }}
           channels: conda-forge
-          auto-activate-base: false
+          conda-remove-defaults: "true"
+          auto-activate: false
 
       - name: Install run dependencies
         run: |
@@ -265,25 +241,19 @@ jobs:
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Cancel non-latest runs
-        uses: styfle/cancel-workflow-action@0.11.0
-        with:
-          all_but_latest: true
-          access_token: ${{ github.token }}
-
       - name: Checkout repo with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.14'
 
       - name: Download wheel and source distributions from artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: distributions
           path: dist


### PR DESCRIPTION
## Motivation

Fixes #2202.

The GitHub Actions workflows emit deprecation warnings (seen in [run 28013775824](https://github.com/NeurodataWithoutBorders/pynwb/actions/runs/28013775824)): Node.js 20 deprecation for several actions, the unmaintained `styfle/cancel-workflow-action`, and `setup-miniconda` warnings (`auto-activate-base` deprecated; implicit `defaults` channel).

## Changes

- **Bumped all actions to their latest versions** (aligning with the hdmf repo):
  `actions/checkout@v7`, `actions/setup-python@v6`, `conda-incubator/setup-miniconda@v4`,
  `codecov/codecov-action@v7`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`,
  `actions/add-to-project@v2.0.0`, `actions/create-github-app-token@v3` (replacing `tibdex/github-app-token`),
  and `astral-sh/ruff-action@v3` (replacing the deprecated `chartboost/ruff-action`).
- **Removed `styfle/cancel-workflow-action`** from every workflow and replaced it with a native top-level
  `concurrency` group (`group: ${{ github.workflow }}-${{ github.ref }}`, `cancel-in-progress: true`),
  which reproduces the old `all_but_latest` behavior.
- **Fixed the `setup-miniconda` config**: `auto-activate-base: false` → `auto-activate: false`, and added
  `conda-remove-defaults: "true"` to silence the implicit `defaults` channel warning.

## Notes

- Used a **workflow-level** `concurrency` group (equivalent to the old workflow-wide `all_but_latest`) rather
  than hdmf's per-job/per-matrix groups. Happy to switch to per-job if preferred.
- All 11 workflow files validate as YAML. The action versions match those currently used in hdmf.

## Checklist

- [ ] Did you update CHANGELOG.md with your changes? <sub>CI-only maintenance; not user-facing, so no changelog entry. Let me know if you want one.</sub>
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style?
- [x] Have you checked to ensure that there aren't other open Pull Requests for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
