### PR TITLE
Remove deprecated functionality marked for removal in PyNWB 4.0

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -4,8 +4,7 @@ Prepare for release of PyNWB [version]
 - [ ] Make sure all PRs to be included in this release have been merged to `dev`.
 - [ ] Major and minor releases: Update the dependency version bounds in `pyproject.toml` and the pinned
   versions in `environment-ros3.yml` to the latest as needed.
-- [ ] Major releases: Remove the deprecated functionality marked for removal in this version
-  (search the codebase for "removed in PyNWB <version>").
+- [ ] Major releases: Remove the deprecated functionality slated for removal in this version.
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
 - [ ] Update `pyproject.toml` as needed

--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -4,6 +4,8 @@ Prepare for release of PyNWB [version]
 - [ ] Make sure all PRs to be included in this release have been merged to `dev`.
 - [ ] Major and minor releases: Update the dependency version bounds in `pyproject.toml` and the pinned
   versions in `environment-ros3.yml` to the latest as needed.
+- [ ] Major releases: Remove the deprecated functionality marked for removal in this version
+  (search the codebase for "removed in PyNWB <version>").
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed
 - [ ] Update `pyproject.toml` as needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## PyNWB 4.0.0 (Upcoming)
 
+### Removed
+- Removed functionality that was deprecated with a "will be removed in PyNWB 4.0" notice. @rly [#2210](https://github.com/NeurodataWithoutBorders/pynwb/issues/2210)
+  - `ProcessingModule.add_container`, `get_container`, `add_data_interface`, and `get_data_interface`. Use `add` and `get` instead.
+  - The `extensions` argument of `get_type_map`, `get_manager`, and `NWBHDF5IO`. Load cached namespaces from the file or pass a prebuilt `manager` instead.
+  - The `notes` argument and `notes` property of `ScratchData`. Use `description` instead.
+  - The `notes` and `table_description` arguments of `NWBFile.add_scratch`. Use `description` instead.
+  - The `ic_electrodes` argument of `NWBFile`. Use `icephys_electrodes` instead.
+  - The `paths` argument of `pynwb.validate`. Use `path` and call `validate` once per file instead.
+- Made `NWBFile.icephys_filtering` read-only. Use `IntracellularElectrode.filtering` instead. The legacy `/general/intracellular_ephys/filtering` value is still read from older files. @rly [#2210](https://github.com/NeurodataWithoutBorders/pynwb/issues/2210)
+
 ### Documentation and tutorial enhancements
 - Added a tutorial on using HERD to annotate an NWB file with external resources and store it at `/general/external_resources`, plus a companion example showing how to annotate multiple NWB files streamed from a DANDI dandiset with a single HERD. @rly, @mavaylon1 [#2200](https://github.com/NeurodataWithoutBorders/pynwb/pull/2200)
 - Added `pandas.ExtensionArray` to `nitpick_ignore` so the Sphinx build does not fail on the unresolved cross-reference that HDMF's `array_data` docval macro renders for every type that accepts array data. @rly [#2209](https://github.com/NeurodataWithoutBorders/pynwb/pull/2209)

--- a/docs/gallery/general/extensions.py
+++ b/docs/gallery/general/extensions.py
@@ -347,7 +347,7 @@ nwbfile = NWBFile(
 )
 
 pmod = nwbfile.create_processing_module("module_name", "desc")
-pmod.add_container(potato_sack)
+pmod.add(potato_sack)
 
 
 with NWBHDF5IO("test_multicontainerinterface.nwb", "w") as io:
@@ -480,7 +480,7 @@ nwbfile = NWBFile("my first synthetic recording", "EXAMPLE_ID", datetime.now())
 cortex_module = nwbfile.create_processing_module(
     name="cortex", description="description"
 )
-cortex_module.add_container(cortical_surface)
+cortex_module.add(cortical_surface)
 
 
 with NWBHDF5IO("test_cortical_surface.nwb", "w") as io:

--- a/docs/gallery/general/scratch.py
+++ b/docs/gallery/general/scratch.py
@@ -91,7 +91,7 @@ ts1 = nwb_in.acquisition["raw_timeseries"]
 filt_data = np.convolve(ts1.data, np.ones(128), mode="same") / 128
 ts2 = TimeSeries(name="filtered_timeseries", data=filt_data, unit="m", timestamps=ts1)
 
-mod.add_container(ts2)
+mod.add(ts2)
 
 
 ####################

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -98,47 +98,23 @@ __TYPE_MAP.merge(hdmf_typemap, ns_catalog=True)
 __resources = __get_resources()
 
 
-@docval({'name': 'extensions', 'type': (str, TypeMap, list),
-         'doc': 'a path to a namespace, a TypeMap, or a list consisting of paths to namespaces and TypeMaps',
-         'default': None},
-        {
+@docval({
             'name': 'copy', 'type': bool,
             'doc': 'Whether to return a deepcopy of the TypeMap. '
             'If False, a direct reference may be returned (use with caution).',
             'default': True
         },
-        returns="TypeMap loaded for the given extension or NWB core namespace", rtype=TypeMap,
+        returns="TypeMap loaded for the NWB core namespace", rtype=TypeMap,
         is_method=False)
 def get_type_map(**kwargs):
     '''
-    Get the TypeMap for the given extensions. If no extensions are provided,
-    return the TypeMap for the core namespace
+    Get the TypeMap for the NWB core namespace.
     '''
-    extensions, copy_map = getargs('extensions', 'copy', kwargs)
-    type_map = None
-    if extensions is None:
-        if copy_map:
-            type_map = deepcopy(__TYPE_MAP)
-        else:
-            type_map = __TYPE_MAP
+    copy_map = getargs('copy', kwargs)
+    if copy_map:
+        type_map = deepcopy(__TYPE_MAP)
     else:
-        warn("The 'extensions' argument is deprecated and will be removed in PyNWB 4.0", DeprecationWarning)
-        if isinstance(extensions, TypeMap):
-            type_map = extensions
-        else:
-            type_map = deepcopy(__TYPE_MAP)
-        if isinstance(extensions, list):
-            for ext in extensions:
-                if isinstance(ext, str):
-                    type_map.load_namespaces(ext)
-                elif isinstance(ext, TypeMap):
-                    type_map.merge(ext)
-                else:
-                    raise ValueError('extensions must be a list of paths to namespace specs or a TypeMaps')
-        elif isinstance(extensions, str):
-            type_map.load_namespaces(extensions)
-        elif isinstance(extensions, TypeMap):
-            type_map.merge(extensions)
+        type_map = __TYPE_MAP
     return type_map
 
 
@@ -147,8 +123,7 @@ def get_type_map(**kwargs):
         is_method=False)
 def get_manager(**kwargs):
     '''
-    Get a BuildManager to use for I/O using the given extensions. If no extensions are provided,
-    return a BuildManager that uses the core namespace
+    Get a BuildManager to use for I/O that uses the NWB core namespace.
     '''
     type_map = get_type_map(**kwargs)
     return BuildManager(type_map)
@@ -412,20 +387,17 @@ class NWBHDF5IO(_HDF5IO):
              'default': 'r'},
             {'name': 'load_namespaces', 'type': bool,
              'doc': ('whether or not to load cached namespaces from given path - not applicable in write mode '
-                     'or when `manager` is not None or when `extensions` is not None'),
+                     'or when `manager` is not None'),
              'default': True},
             {'name': 'manager', 'type': BuildManager, 'doc': 'the BuildManager to use for I/O', 'default': None},
-            {'name': 'extensions', 'type': (str, TypeMap, list),
-             'doc': 'a path to a namespace, a TypeMap, or a list consisting paths to namespaces and TypeMaps',
-             'default': None},
             *get_docval(_HDF5IO.__init__, "file", "comm", "driver", "aws_region", "herd_path"),)
     def __init__(self, **kwargs):
-        path, mode, manager, extensions, load_namespaces, file_obj, comm, driver, aws_region, herd_path =\
-            popargs('path', 'mode', 'manager', 'extensions', 'load_namespaces',
+        path, mode, manager, load_namespaces, file_obj, comm, driver, aws_region, herd_path =\
+            popargs('path', 'mode', 'manager', 'load_namespaces',
                     'file', 'comm', 'driver', 'aws_region', 'herd_path', kwargs)
         # Define the BuildManager to use
         io_modes_that_create_file = ['w', 'w-', 'x']
-        if mode in io_modes_that_create_file or manager is not None or extensions is not None:
+        if mode in io_modes_that_create_file or manager is not None:
             load_namespaces = False
 
         if mode in io_modes_that_create_file and path is not None and not str(path).endswith('.nwb'):
@@ -443,13 +415,8 @@ class NWBHDF5IO(_HDF5IO):
             # super().load_namespaces(ns_catalog, path)
             # tm = TypeMap(ns_catalog)
             # tm.copy_mappers(get_type_map())
-        else:
-            if manager is not None and extensions is not None:
-                raise ValueError("'manager' and 'extensions' cannot be specified together")
-            elif extensions is not None:
-                manager = get_manager(extensions=extensions)
-            elif manager is None:
-                manager = get_manager()
+        elif manager is None:
+            manager = get_manager()
         # Open the file
         super().__init__(path, manager=manager, mode=mode, file=file_obj, comm=comm,
                          driver=driver, aws_region=aws_region, herd_path=herd_path)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -59,34 +59,6 @@ class ProcessingModule(MultiContainerInterface):
     def containers(self):
         return self.data_interfaces
 
-    @docval({'name': 'container', 'type': (NWBDataInterface, DynamicTable),
-             'doc': 'the NWBDataInterface to add to this Module'})
-    def add_container(self, **kwargs):
-        '''
-        Add an NWBContainer to this ProcessingModule
-        '''
-        warn("add_container is deprecated and will be removed in PyNWB 4.0. Use add instead.", DeprecationWarning)
-        self.add(kwargs['container'])
-
-    @docval({'name': 'container_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})
-    def get_container(self, **kwargs):
-        '''
-        Retrieve an NWBContainer from this ProcessingModule
-        '''
-        warn('get_container is deprecated and will be removed in PyNWB 4.0. Use get instead.', DeprecationWarning)
-        return self.get(kwargs['container_name'])
-
-    @docval({'name': 'NWBDataInterface', 'type': (NWBDataInterface, DynamicTable),
-             'doc': 'the NWBDataInterface to add to this Module'})
-    def add_data_interface(self, **kwargs):
-        warn('add_data_interface is deprecated and will be removed in PyNWB 4.0. Use add instead.', DeprecationWarning)
-        self.add(kwargs['NWBDataInterface'])
-
-    @docval({'name': 'data_interface_name', 'type': str, 'doc': 'the name of the NWBContainer to retrieve'})
-    def get_data_interface(self, **kwargs):
-        warn('get_data_interface is deprecated and will be removed in PyNWB 4.0. Use get instead.', DeprecationWarning)
-        return self.get(kwargs['data_interface_name'])
-
     def __len__(self):
         """Get the number of data interfaces in this ProcessingModule.
 

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -155,44 +155,14 @@ class ScratchData(NWBData):
 
     @docval({'name': 'name', 'type': str, 'doc': 'the name of this container'},
             {'name': 'data', 'type': ('scalar_data', 'array_data', 'data', Data), 'doc': 'the source of the data'},
-            {'name': 'notes', 'type': str,
-             'doc': 'notes about the data. This argument will be deprecated. Use description instead', 'default': None},
             {'name': 'description', 'type': str, 'doc': 'notes about the data', 'default': None},
             allow_positional=AllowPositional.WARNING,)
     def __init__(self, **kwargs):
-        notes, description = popargs('notes', 'description', kwargs)
+        description = popargs('description', kwargs)
         super().__init__(**kwargs)
-        if notes is not None:
-            self._error_on_new_pass_on_construct(
-                    error_msg=("The `notes` argument of ScratchData.__init__ has been deprecated and "
-                               "will be removed in PyNWB 4.0. Use description instead.")
-                    )
-            if notes is not None and description is not None:
-                raise ValueError('Cannot provide both notes and description to ScratchData.__init__. The description '
-                                 'argument is recommended.')
-            description = notes
         if not description:
             self._error_on_new_pass_on_construct(error_msg='ScratchData.description is required.')
         self.description = description
-
-    @property
-    def notes(self):
-        """
-        Get the notes attribute. Use of ScratchData.notes has been deprecated and will be removed in PyNWB 4.0.
-        """
-        warn(("Use of ScratchData.notes has been deprecated and will be removed in PyNWB 4.0. "
-              "Use ScratchData.description instead."), DeprecationWarning)
-        return self.description
-
-    @notes.setter
-    def notes(self, value):
-        """
-        Set the notes attribute. Use of ScratchData.notes has been deprecated and will be removed in PyNWB 4.0.
-        """
-        self._error_on_new_pass_on_construct(
-                    error_msg=("Use of ScratchData.notes has been deprecated and will be removed in PyNWB 4.0. "
-                               "Use ScratchData.description instead."))
-        self.description = value
 
 
 class NWBTable(Table):

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -301,7 +301,8 @@ class NWBFile(MultiContainerInterface, HERDManager):
                      {'name': 'external_resources', 'child': True, 'required_name': 'external_resources'},
                      {'name': 'sweep_table', 'child': True, 'required_name': 'sweep_table'},
                      {'name': 'invalid_times', 'child': True, 'required_name': 'invalid_times'},
-                     # icephys_filtering is temporary. /intracellular_ephys/filtering dataset will be deprecated
+                     # icephys_filtering is read-only; the legacy /intracellular_ephys/filtering dataset is
+                     # mapped to this field when reading older files
                      {'name': 'icephys_filtering', 'settable': False},
                      {'name': 'intracellular_recordings', 'child': True,
                       'required_name': 'intracellular_recordings',
@@ -411,10 +412,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
              'doc': 'the ElectrodesTable that belongs to this NWBFile', 'default': None},
             {'name': 'electrode_groups', 'type': Iterable,
              'doc': 'the ElectrodeGroups that belong to this NWBFile', 'default': None},
-            {'name': 'ic_electrodes', 'type': (list, tuple),
-             'doc': 'DEPRECATED use icephys_electrodes parameter instead. '
-                    'IntracellularElectrodes that belong to this NWBFile', 'default': None},
-                    # TODO remove this arg in PyNWB 4.0
             {'name': 'sweep_table', 'type': SweepTable,
              'doc': '[DEPRECATED] Use IntracellularRecordingsTable instead. '
                     'The SweepTable that belong to this NWBFile', 'default': None},
@@ -433,7 +430,8 @@ class NWBFile(MultiContainerInterface, HERDManager):
             {'name': 'icephys_electrodes', 'type': (list, tuple),
              'doc': 'IntracellularElectrodes that belong to this NWBFile.', 'default': None},
             {'name': 'icephys_filtering', 'type': str, 'default': None,
-             'doc': '[DEPRECATED] Use IntracellularElectrode.filtering instead. Description of filtering used.'},
+             'doc': ('Read-only. The legacy /general/intracellular_ephys/filtering value read from older files. '
+                     'Use IntracellularElectrode.filtering for new files.')},
             {'name': 'intracellular_recordings', 'type': IntracellularRecordingsTable, 'default': None,
              'doc': 'the IntracellularRecordingsTable table that belongs to this NWBFile'},
             {'name': 'icephys_simultaneous_recordings', 'type': SimultaneousRecordingsTable, 'default': None,
@@ -451,7 +449,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
             'session_start_time',
             'experimenter',
             'file_create_date',
-            'ic_electrodes',
             'icephys_electrodes',
             'related_publications',
             'timestamps_reference_time',
@@ -492,7 +489,7 @@ class NWBFile(MultiContainerInterface, HERDManager):
             'surgery',
             'virus',
             'stimulus_notes',
-            'icephys_filtering',  # DEPRECATION warning will be raised in the setter when calling setattr in the loop
+            'icephys_filtering',  # read-only; handled explicitly below so it is not set via the loop
             'intracellular_recordings',
             'icephys_simultaneous_recordings',
             'icephys_sequential_recordings',
@@ -525,20 +522,19 @@ class NWBFile(MultiContainerInterface, HERDManager):
             file_create_date = [file_create_date]
         args_to_set['file_create_date'] = list(map(_add_missing_timezone, file_create_date))
 
-        # backwards-compatibility code for ic_electrodes / icephys_electrodes
-        ic_electrodes = args_to_set['ic_electrodes']
-        if ic_electrodes is not None:
-            self._error_on_new_pass_on_construct(error_msg=("Use of the ic_electrodes parameter is deprecated "
-                                                            "and will be removed in PyNWB 4.0. "
-                                                            "Use the icephys_electrodes parameter instead"))
-            args_to_set['icephys_electrodes'] = ic_electrodes
-        args_to_set.pop('ic_electrodes')  # do not set this arg
-
         # backwards-compatibility for sweep table
         if args_to_set['sweep_table'] is not None:
             self._error_on_new_pass_on_construct(error_msg=("SweepTable is deprecated. Use the "
                                                             "IntracellularRecordingsTable instead. See also the "
                                                             "NWBFile.add_intracellular_recordings function."))
+
+        # icephys_filtering is read-only. The legacy /general/intracellular_ephys/filtering dataset is mapped
+        # to this field when reading older files. Setting it on a new file raises an error.
+        icephys_filtering = args_to_set.pop('icephys_filtering')
+        if icephys_filtering is not None:
+            self._error_on_new_warn_on_construct("Use of icephys_filtering has been removed in PyNWB 4.0. "
+                                                 "Use the IntracellularElectrode.filtering field instead.")
+            self.fields['icephys_filtering'] = icephys_filtering
 
         # convert single experimenter to tuple
         experimenter = args_to_set['experimenter']
@@ -601,14 +597,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
     @property
     def icephys_filtering(self):
         return self.fields.get('icephys_filtering')
-
-    @icephys_filtering.setter
-    def icephys_filtering(self, val):
-        if val is not None:
-            self._error_on_new_warn_on_construct("Use of icephys_filtering is deprecated "
-                                                 "and will be removed in PyNWB 4.0. "
-                                                 "Use the IntracellularElectrode.filtering field instead")
-            self.fields['icephys_filtering'] = val
 
     def __check_epochs(self):
         if self.epochs is None:
@@ -1038,16 +1026,6 @@ class NWBFile(MultiContainerInterface, HERDManager):
              'doc': ('The name of the data. Required only when passing in a scalar, numpy.ndarray, list, tuple, '
                      'pandas.Series, or pandas extension array'),
              'default': None},
-            {'name': 'notes', 'type': str,
-             'doc': ('[DEPRECATED] Notes to add to the data. '
-                     'Only used when passing in numpy.ndarray, list, or tuple. This argument is not recommended. '
-                     'Use the `description` argument instead.'),  # TODO remove this arg in PyNWB 4.0
-             'default': None},
-            {'name': 'table_description', 'type': str,
-             'doc': ('[DEPRECATED] Description for the internal DynamicTable used to store a pandas.DataFrame. This '
-                     'argument is not recommended. Use the `description` argument instead.'),
-                     # TODO remove this arg in PyNWB 4.0
-             'default': ''},
             {'name': 'description', 'type': str,
              'doc': ('Description of the data. Required only when passing in a scalar, numpy.ndarray, '
                      'list, tuple, pandas.Series, pandas extension array, or pandas.DataFrame. Ignored '
@@ -1055,13 +1033,7 @@ class NWBFile(MultiContainerInterface, HERDManager):
              'default': None})
     def add_scratch(self, **kwargs):
         '''Add data to the scratch space'''
-        data, name, notes, table_description, description = getargs('data', 'name', 'notes', 'table_description',
-                                                                    'description', kwargs)
-        if notes is not None or table_description != '':
-            warn(('Use of the `notes` or `table_description` argument is deprecated and will be removed in PyNWB 4.0. '
-                  'Use the `description` argument instead.'), DeprecationWarning)
-            if description is not None:
-                raise ValueError('Cannot call add_scratch with (notes or table_description) and description')
+        data, name, description = getargs('data', 'name', 'description', kwargs)
 
         if isinstance(data, (str, int, float, bytes, np.ndarray, list, tuple, pd.Series, _PdExtensionArray,
                              pd.DataFrame)):
@@ -1069,21 +1041,13 @@ class NWBFile(MultiContainerInterface, HERDManager):
                 msg = ('A name is required for NWBFile.add_scratch when adding a scalar, numpy.ndarray, '
                        'list, tuple, pandas.Series, pandas extension array, or pandas.DataFrame as scratch data.')
                 raise ValueError(msg)
+            if description is None:
+                msg = ('A description is required for NWBFile.add_scratch when adding a scalar, numpy.ndarray, '
+                       'list, tuple, pandas.Series, pandas extension array, or pandas.DataFrame as scratch data.')
+                raise ValueError(msg)
             if isinstance(data, pd.DataFrame):
-                if table_description != '':
-                    description = table_description  # remove after deprecation
-                if description is None:
-                    msg = ('A description is required for NWBFile.add_scratch when adding a scalar, numpy.ndarray, '
-                           'list, tuple, pandas.Series, pandas extension array, or pandas.DataFrame as scratch data.')
-                    raise ValueError(msg)
                 data = DynamicTable.from_dataframe(df=data, name=name, table_description=description)
             else:
-                if notes is not None:
-                    description = notes  # remove after deprecation
-                if description is None:
-                    msg = ('A description is required for NWBFile.add_scratch when adding a scalar, numpy.ndarray, '
-                           'list, tuple, pandas.Series, pandas extension array, or pandas.DataFrame as scratch data.')
-                    raise ValueError(msg)
                 data = ScratchData(name=name, data=data, description=description)
         else:
             if name is not None:

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -489,7 +489,7 @@ class NWBFile(MultiContainerInterface, HERDManager):
             'surgery',
             'virus',
             'stimulus_notes',
-            'icephys_filtering',  # read-only; handled explicitly below so it is not set via the loop
+            'icephys_filtering',  # read-only; set explicitly below
             'intracellular_recordings',
             'icephys_simultaneous_recordings',
             'icephys_sequential_recordings',

--- a/src/pynwb/legacy/io/file.py
+++ b/src/pynwb/legacy/io/file.py
@@ -23,7 +23,8 @@ class NWBFileMap(ObjectMapper):
 
         general_spec = self.spec.get_group('general')
         self.map_spec(
-            'ic_electrodes', general_spec.get_group('intracellular_ephys').get_neurodata_type('IntracellularElectrode'))
+            'icephys_electrodes',
+            general_spec.get_group('intracellular_ephys').get_neurodata_type('IntracellularElectrode'))
         self.map_spec(
             'ec_electrodes', general_spec.get_group('extracellular_ephys').get_neurodata_type('ElectrodeGroup'))
         self.map_spec(

--- a/src/pynwb/validation.py
+++ b/src/pynwb/validation.py
@@ -103,13 +103,6 @@ def get_cached_namespaces_to_validate(path: Optional[str] = None,
         "default": None,
     },  # Argument order is for back-compatability
     {
-         "name": "paths",
-         "type": list,
-         "doc": ("List of NWB file paths. This argument will be deprecated in PyNWB 4.0. "
-                 "Use 'path' instead."),
-         "default": None,
-    },
-    {
         "name": "path",
         "type": (str, Path),
         "doc": "NWB file path.",
@@ -146,25 +139,8 @@ def validate(**kwargs):
     compliance with the schema and compliance of data with NWB best practices.
     """
 
-    paths, path = popargs("paths", "path", kwargs)
-
-    if paths is not None:
-        warn("The 'paths' argument will be deprecated in PyNWB 4.0 "
-            "Use 'path' instead. To migrate, call this function separately for "
-            "each path instead of passing a list.",
-            DeprecationWarning)
-
-        if path is not None:
-            raise ValueError("Both 'paths' and 'path' were specified. "
-                             "Please choose only one.")
-
-        validation_errors = []
-        for p in paths:
-            validation_errors +=  _validate_single_file(path=p, **kwargs)
-    else:
-        validation_errors = _validate_single_file(path=path, **kwargs)
-
-    return validation_errors
+    path = popargs("path", kwargs)
+    return _validate_single_file(path=path, **kwargs)
 
 
 def _validate_single_file(**kwargs):

--- a/src/pynwb/validation.py
+++ b/src/pynwb/validation.py
@@ -5,7 +5,7 @@ from warnings import warn
 
 from hdmf.spec import NamespaceCatalog
 from hdmf.build import BuildManager, TypeMap
-from hdmf.utils import docval, getargs, popargs, AllowPositional
+from hdmf.utils import docval, getargs, AllowPositional
 from hdmf.backends.io import HDMFIO
 from hdmf.validate import ValidatorMap
 
@@ -132,18 +132,12 @@ def get_cached_namespaces_to_validate(path: Optional[str] = None,
     allow_positional=AllowPositional.WARNING,
 )
 def validate(**kwargs):
-    """Validate NWB file(s) against a namespace or its cached namespaces.
+    """Validate an NWB file against a namespace or its cached namespaces.
 
-    Note: this function checks for compliance with the NWB schema. 
+    Note: this function checks for compliance with the NWB schema.
     It is recommended to use the NWBInspector for more comprehensive validation of both
     compliance with the schema and compliance of data with NWB best practices.
     """
-
-    path = popargs("path", kwargs)
-    return _validate_single_file(path=path, **kwargs)
-
-
-def _validate_single_file(**kwargs):
 
     io, path, use_cached_namespaces, namespace, verbose, driver = getargs(
         "io", "path", "use_cached_namespaces", "namespace", "verbose", "driver", kwargs

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -43,26 +43,6 @@ class TestProcessingModule(TestCase):
         self.assertIn(ts.name, self.pm.containers)
         self.assertIs(ts, self.pm.containers[ts.name])
 
-    def test_deprecated_add_data_interface(self):
-        ts = self._create_time_series()
-        msg = 'add_data_interface is deprecated and will be removed in PyNWB 4.0. Use add instead.'
-        with self.assertWarnsWith(warn_type=DeprecationWarning,
-                                  exc_msg=msg
-        ):
-            self.pm.add_data_interface(ts)
-            self.assertIn(ts.name, self.pm.containers)
-            self.assertIs(ts, self.pm.containers[ts.name])
-
-    def test_deprecated_add_container(self):
-        ts = self._create_time_series()
-        msg = 'add_container is deprecated and will be removed in PyNWB 4.0. Use add instead.'
-        with self.assertWarnsWith(warn_type=DeprecationWarning, 
-                                  exc_msg=msg
-        ):
-            self.pm.add_container(ts)
-            self.assertIn(ts.name, self.pm.containers)
-            self.assertIs(ts, self.pm.containers[ts.name])
-
     def test_get_data_interface(self):
         """Test adding a data interface to a ProcessingModule and retrieving it using get(...)."""
         ts = self._create_time_series()
@@ -70,26 +50,6 @@ class TestProcessingModule(TestCase):
         tmp = self.pm.get("test_ts")
         self.assertIs(tmp, ts)
         self.assertIs(self.pm["test_ts"], self.pm.get("test_ts"))
-
-    def test_deprecated_get_data_interface(self):
-        ts = self._create_time_series()
-        self.pm.add(ts)
-        msg = 'get_data_interface is deprecated and will be removed in PyNWB 4.0. Use get instead.'
-        with self.assertWarnsWith(warn_type=DeprecationWarning, 
-                                  exc_msg=msg
-        ):
-            tmp = self.pm.get_data_interface("test_ts")
-            self.assertIs(tmp, ts)
-
-    def test_deprecated_get_container(self):
-        ts = self._create_time_series()
-        self.pm.add(ts)
-        msg = 'get_container is deprecated and will be removed in PyNWB 4.0. Use get instead.'
-        with self.assertWarnsWith(warn_type=DeprecationWarning, 
-                                  exc_msg=msg
-        ):
-            tmp = self.pm.get_container("test_ts")
-            self.assertIs(tmp, ts)
 
     def test_getitem(self):
         """Test adding a data interface to a ProcessingModule and retrieving it using __getitem__(...)."""

--- a/tests/unit/test_icephys.py
+++ b/tests/unit/test_icephys.py
@@ -73,14 +73,22 @@ class NWBFileICEphys(TestCase):
                 icephys_electrodes=[self.icephys_electrode, ])
         self.assertEqual(nwbfile.get_icephys_electrode('test_iS'), self.icephys_electrode)
 
-    def test_ic_electrodes_attribute_deprecation(self):
+    def test_ic_electrodes_argument_removed(self):
+        msg = ("NWBFile.__init__: unrecognized argument: 'ic_electrodes'")
+        with self.assertRaisesWith(TypeError, msg):
+            NWBFile(
+                session_description='NWBFile icephys test',
+                identifier='NWB123',  # required
+                session_start_time=datetime(2017, 4, 3, 11, tzinfo=tzlocal()),
+                ic_electrodes=[self.icephys_electrode, ])
+
+    def test_get_ic_electrode_removed(self):
         nwbfile = NWBFile(
             session_description='NWBFile icephys test',
             identifier='NWB123',  # required
             session_start_time=datetime(2017, 4, 3, 11, tzinfo=tzlocal()),
             icephys_electrodes=[self.icephys_electrode, ])
 
-        # make sure NWBFile.get_ic_electrode warns
         msg = "'NWBFile' object has no attribute 'get_ic_electrode'"
         with self.assertRaisesWith(AttributeError, msg):
             nwbfile.get_ic_electrode(self.icephys_electrode.name)

--- a/tests/unit/test_icephys_metadata_tables.py
+++ b/tests/unit/test_icephys_metadata_tables.py
@@ -1281,47 +1281,56 @@ class NWBFileTests(TestCase):
         stimulus = self.__get_stimulus(electrode=electrode)
         nwbfile.add_stimulus(stimulus, use_sweep_table=True)
 
-    def test_deprecation_icephys_filtering_on_init(self):
+    def test_icephys_filtering_on_init(self):
         kwargs = dict(session_description='my first synthetic recording',
                 identifier='EXAMPLE_ID',
                 session_start_time=datetime.now(tzlocal()),
                 icephys_filtering='test filtering')
-        msg = ("Use of icephys_filtering is deprecated and will be removed in PyNWB 4.0. "
-               "Use the IntracellularElectrode.filtering field instead")        
-        
-        with self.assertRaisesWith(ValueError, msg):
-            nwbfile = NWBFile(**kwargs)
+        msg = ("Use of icephys_filtering has been removed in PyNWB 4.0. "
+               "Use the IntracellularElectrode.filtering field instead.")
 
-        # create object in construct mode, modeling the behavior of the ObjectMapper on read
+        # passing icephys_filtering when creating a new file raises an error
+        with self.assertRaisesWith(ValueError, msg):
+            NWBFile(**kwargs)
+
+        # create object in construct mode, modeling the behavior of the ObjectMapper on read;
+        # the legacy value is read into the read-only icephys_filtering field with a warning
         nwbfile = NWBFile.__new__(NWBFile, in_construct_mode=True)
         with self.assertWarnsWith(warn_type=UserWarning, exc_msg=msg):
             nwbfile.__init__(**kwargs)
 
         self.assertEqual(nwbfile.icephys_filtering, 'test filtering')
 
-    def test_icephys_filtering_roundtrip(self):
-        # create the base file
+    def test_icephys_filtering_read_only(self):
+        # icephys_filtering is read-only and cannot be set on an existing file
         nwbfile = NWBFile(
             session_description='my first synthetic recording',
             identifier='EXAMPLE_ID',
             session_start_time=datetime.now(tzlocal())
         )
-        # set the icephys_filtering attribute and make sure we get a deprecation warning
-        msg = ("Use of icephys_filtering is deprecated and will be removed in PyNWB 4.0. "
-               "Use the IntracellularElectrode.filtering field instead")
-        with self.assertRaisesWith(ValueError, msg):
+        with self.assertRaises(AttributeError):
             nwbfile.icephys_filtering = 'test filtering'
 
-        # create object in construct mode, modeling the behavior of the ObjectMapper on read
-        nwbfile._in_construct_mode = True
+    def test_icephys_filtering_roundtrip(self):
+        msg = ("Use of icephys_filtering has been removed in PyNWB 4.0. "
+               "Use the IntracellularElectrode.filtering field instead.")
+
+        # model the behavior of the ObjectMapper on read: the legacy
+        # /general/intracellular_ephys/filtering value populates the read-only field in construct mode
+        nwbfile = NWBFile.__new__(NWBFile, in_construct_mode=True)
         with self.assertWarnsWith(warn_type=UserWarning, exc_msg=msg):
-            nwbfile.icephys_filtering = 'test filtering'
+            nwbfile.__init__(
+                session_description='my first synthetic recording',
+                identifier='EXAMPLE_ID',
+                session_start_time=datetime.now(tzlocal()),
+                icephys_filtering='test filtering'
+            )
         nwbfile._in_construct_mode = False
 
         # write the test file
         with NWBHDF5IO(self.path, 'w') as io:
             io.write(nwbfile)
-        # read the test file and confirm icephys_filtering has been written
+        # read the test file and confirm icephys_filtering is read back from the legacy location
         with NWBHDF5IO(self.path, 'r') as io:
             with self.assertWarnsWith(UserWarning, msg):
                 infile = io.read()

--- a/tests/unit/test_scratch.py
+++ b/tests/unit/test_scratch.py
@@ -32,41 +32,9 @@ class TestScratchData(TestCase):
         self.assertListEqual(sd.data, [1, 2, 3, 4])
         self.assertEqual(sd.description, 'test scratch')
 
-    def test_scratch_notes_deprecation(self):
-        msg = ("The `notes` argument of ScratchData.__init__ has been deprecated and will "
-               "be removed in PyNWB 4.0. Use description instead.")
-        with self.assertRaisesWith(ValueError, msg):
-            ScratchData(name='test', data=[1, 2, 3, 4, 5], notes='test notes')
-
-        # create object in construct mode, modeling the behavior of the ObjectMapper on read 
-        # should not raise error or warning
-        data = ScratchData.__new__(ScratchData, in_construct_mode=True)
-        data.__init__(name='test', data=[1, 2, 3, 4, 5], notes='test notes')
-        self.assertEqual(data.description, 'test notes')
-
-        # test notes property
-        msg = ("Use of ScratchData.notes has been deprecated and will be removed in PyNWB 4.0. "
-               "Use ScratchData.description instead.")
-        
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            data.notes
-
-        # test notes setter
-        data = ScratchData(name='test', data=[1, 2, 3, 4, 5], description='test description')
-        with self.assertRaisesWith(ValueError, msg):
-            data.notes = 'test notes'
-
     def test_scratch_no_description(self):
         with self.assertRaisesWith(ValueError, 'ScratchData.description is required.'):
             ScratchData(name='test', data=[1, 2, 3, 4, 5])
-
-    def test_scratch_notes_and_description(self):
-        msg = ('Cannot provide both notes and description to ScratchData.__init__. The description '
-               'argument is recommended.')
-        data = ScratchData.__new__(ScratchData, in_construct_mode=True)
-        with self.assertRaisesWith(ValueError, msg):
-            data.__init__(name='test', data=[1, 2, 3, 4, 5], notes='test notes',
-                          description='test description')
 
     def test_add_scratch_int(self):
         ret = self.nwbfile.add_scratch(2, name='test', description='test data')
@@ -147,14 +115,6 @@ class TestScratchData(TestCase):
         with self.assertRaisesWith(ValueError, msg):
             self.nwbfile.add_scratch(pd.Series([1, 2, 3, 4]))
 
-    def test_add_scratch_notes_and_description(self):
-        error_msg = 'Cannot call add_scratch with (notes or table_description) and description'
-        warning_msg = ("Use of the `notes` or `table_description` argument is deprecated and will be "
-                       "removed in PyNWB 4.0. Use the `description` argument instead.")
-        with self.assertWarnsWith(DeprecationWarning, warning_msg):
-            with self.assertRaisesWith(ValueError, error_msg):
-                self.nwbfile.add_scratch([1, 2, 3, 4], name='test', description='test data', notes='test notes')
-
     def test_add_scratch_container(self):
         data = TimeSeries(name='test_ts', data=[1, 2, 3, 4, 5], unit='unit', timestamps=[1.1, 1.2, 1.3, 1.4, 1.5])
         self.nwbfile.add_scratch(data)
@@ -191,22 +151,6 @@ class TestScratchData(TestCase):
         self.nwbfile.add_scratch(data)
         self.assertIs(self.nwbfile.get_scratch('test', convert=False), data)
         self.assertIs(self.nwbfile.scratch['test'], data)
-    
-    def test_add_scratch_notes_deprecation(self):
-        msg =  ("Use of the `notes` or `table_description` argument is deprecated and will be removed in PyNWB 4.0. "
-                "Use the `description` argument instead.")
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            self.nwbfile.add_scratch(name='test', data=[1, 2, 3, 4, 5], notes='test notes')
-        self.assertEqual(self.nwbfile.scratch['test'].description, 'test notes')    
-
-    def test_add_scratch_table_description_deprecation(self):
-        msg =  ('Use of the `notes` or `table_description` argument is deprecated and will be removed in PyNWB 4.0. '
-                'Use the `description` argument instead.')
-        df = pd.DataFrame(data={'col1': [1, 2, 3, 4], 'col2': ['a', 'b', 'c', 'd']})
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            self.nwbfile.add_scratch(name='test', data=df,
-                                     table_description='test table_description')
-        self.assertEqual(self.nwbfile.scratch['test'].description, 'test table_description')    
 
     def test_get_scratch_list_convert_false(self):
         self.nwbfile.add_scratch([1, 2, 3, 4], name='test', description='test description')

--- a/tests/validation/test_validate.py
+++ b/tests/validation/test_validate.py
@@ -325,22 +325,3 @@ class TestValidateFunction(TestCase):
 
             # remove path from error messages since it will not be included in io outputs
             self.assertEqual(str(e_io.exception), str(e_path.exception))
-
-    def test_validate_paths_deprecation(self):
-        """Test paths argument deprecation warning."""
-
-        # test deprecation warning for 'paths' argument
-        msg = ("The 'paths' argument will be deprecated in PyNWB 4.0 "
-            "Use 'path' instead. To migrate, call this function separately for "
-            "each path instead of passing a list.")
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            results = validate(paths=['tests/back_compat/1.1.2_nwbfile.nwb',
-                                      'tests/back_compat/2.1.0_nwbfile_with_extension.nwb'],)
-        self.assertEqual(results, [])
-
-        # test specifying both 'paths' and 'path' arguments
-        expected_error = "Both 'paths' and 'path' were specified. Please choose only one."
-        with self.assertWarnsWith(DeprecationWarning, msg):
-            with self.assertRaisesWith(ValueError, expected_error):
-                validate(paths=['tests/back_compat/1.0.2_nwbfile.nwb'],
-                         path='tests/back_compat/1.0.2_nwbfile.nwb')


### PR DESCRIPTION
## Motivation

PyNWB 4.0.0 is a major release, so functionality deprecated with a "will be removed in PyNWB 4.0" notice is now removed. See #2210 for the tracked list.

### Removed

- `ProcessingModule.add_container`, `get_container`, `add_data_interface`, `get_data_interface` → use `add` / `get`.
- The `extensions` argument of `get_type_map`, `get_manager`, and `NWBHDF5IO` → load cached namespaces from the file or pass a prebuilt `manager`.
- `ScratchData` `notes` argument and `notes` property → use `description`.
- `NWBFile.add_scratch` `notes` and `table_description` arguments → use `description`.
- `NWBFile` `ic_electrodes` argument → use `icephys_electrodes` (the legacy NWB-1.x reader now maps to `icephys_electrodes`).
- `pynwb.validate` `paths` argument → use `path` and call once per file.

### Changed to read-only

- `NWBFile.icephys_filtering` is now read-only. Use `IntracellularElectrode.filtering` for new files. The legacy `/general/intracellular_ephys/filtering` value still reads from older files; setting it on a new file raises.

### Also

- Inlined the private `_validate_single_file` helper into `validate()`, which became its only caller once the `paths` loop was removed.
- Updated the `extensions.py` and `scratch.py` gallery examples that used `add_container`.
- Added a release PR template checklist item to remove deprecated functionality slated for removal on major releases.

## How to test the behavior?
```
ruff check . && codespell
pytest tests/unit/test_base.py tests/unit/test_scratch.py tests/unit/test_icephys.py \
       tests/unit/test_icephys_metadata_tables.py tests/unit/test_extension.py \
       tests/unit/test_file.py tests/validation/test_validate.py \
       tests/back_compat/test_import_structure.py
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
