### PR TITLE
Allow latest linkml/linkml-runtime and require dandi>=0.76.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## PyNWB 4.0.1 (Unreleased)
 
+### Changed
+- Lifted the `<1.11` cap on the `linkml` and `linkml-runtime` termset extras and bumped the `dandi` docs dependency to `>=0.76.5`. dandi 0.76.5 lifts its `click<8.2` bound ([dandi/dandi-cli#1883](https://github.com/dandi/dandi-cli/pull/1883)), which had conflicted with the `click>=8.2` requirement of linkml 1.11. @rly [#XXXX](https://github.com/NeurodataWithoutBorders/pynwb/pull/XXXX)
+
 ### Fixed
 - Fixed `mock_electrodes` (and `mock_ElectricalSeries`) sizing the auto-created `ElectrodesTable` to a fixed 5 rows while the `DynamicTableRegion` followed `n_electrodes`, which raised an `IndexError` under HDMF 4.x+ for any data with more than 5 channels. The table is now sized to `n_electrodes`. @h-mayorquin [#2214](https://github.com/NeurodataWithoutBorders/pynwb/pull/2214)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## PyNWB 4.0.1 (Unreleased)
 
 ### Changed
-- Lifted the `<1.11` cap on the `linkml` and `linkml-runtime` termset extras and bumped the `dandi` docs dependency to `>=0.76.5`. dandi 0.76.5 lifts its `click<8.2` bound ([dandi/dandi-cli#1883](https://github.com/dandi/dandi-cli/pull/1883)), which had conflicted with the `click>=8.2` requirement of linkml 1.11. @rly [#XXXX](https://github.com/NeurodataWithoutBorders/pynwb/pull/XXXX)
+- Lifted the `<1.11` cap on the `linkml` and `linkml-runtime` termset extras and bumped the `dandi` docs dependency to `>=0.76.5`. dandi 0.76.5 lifts its `click<8.2` bound ([dandi/dandi-cli#1883](https://github.com/dandi/dandi-cli/pull/1883)), which had conflicted with the `click>=8.2` requirement of linkml 1.11. @rly [#2217](https://github.com/NeurodataWithoutBorders/pynwb/pull/2217)
 
 ### Fixed
 - Fixed `mock_electrodes` (and `mock_ElectricalSeries`) sizing the auto-created `ElectrodesTable` to a fixed 5 rows while the `DynamicTableRegion` followed `n_electrodes`, which raised an `IndexError` under HDMF 4.x+ for any data with more than 5 channels. The table is now sized to `n_electrodes`. @h-mayorquin [#2214](https://github.com/NeurodataWithoutBorders/pynwb/pull/2214)

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -19,4 +19,4 @@ dependencies:
   - pip
   - pip:
     - remfile==0.1.13
-    - dandi==0.76.4  # NOTE: dandi is not available on conda for osx-arm64
+    - dandi==0.76.5  # NOTE: dandi is not available on conda for osx-arm64

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,8 @@ zarr = [
     "numcodecs>=0.10.0,<0.16.0",  # numcodecs 0.16.0 is not compatible with zarr<3
 ]
 termset = [
-    # linkml and linkml-runtime 1.11 require click>=8.2, which conflicts with the click<8.2 bound that
-    # dandi imposes when the termset and docs stacks are installed together in the gallery environment.
-    "linkml>=1.5.0,<1.11",
-    "linkml-runtime>=1.5.5,<1.11",
+    "linkml>=1.5.0",
+    "linkml-runtime>=1.5.5",
     "schemasheets>=0.4.0",
     "oaklib>=0.5.12",
 ]
@@ -91,7 +89,7 @@ docs = [
     "dataframe_image>=0.2.3",  # used to render large dataframe as image in the sphinx gallery to improve html display
     "lxml>=4.9.3",  # used by dataframe_image when using the matplotlib backend
     "hdf5plugin>=4.0.0",
-    "dandi>=0.46.6",
+    "dandi>=0.76.5",  # 0.76.5 lifts the click<8.2 bound, allowing linkml/linkml-runtime>=1.11
     "pooch>=1.6.0",
 ]
 


### PR DESCRIPTION
## Motivation

[dandi/dandi-cli#1883](https://github.com/dandi/dandi-cli/pull/1883) has been merged and released in dandi 0.76.5, lifting dandi's `click<8.2` bound. That bound previously conflicted with the `click>=8.2` requirement of linkml 1.11 when the `termset` and `docs` stacks were installed together in the gallery environment, which is why the `linkml`/`linkml-runtime` extras were capped at `<1.11`.

## Changes

- `pyproject.toml`: remove the `<1.11` cap on the `linkml` (`>=1.5.0`) and `linkml-runtime` (`>=1.5.5`) termset extras and drop the obsolete explanatory comment.
- `pyproject.toml`: bump the `dandi` docs dependency from `>=0.46.6` to `>=0.76.5`.
- `environment-ros3.yml`: pin dandi to `0.76.5`.
- `CHANGELOG.md`: add an entry under 4.0.1 (Unreleased).

## Testing

Verified the previously conflicting resolution in a fresh conda env (`python=3.13`) by running the documented docs install, `pip install --group docs ".[zarr,termset]"`:

- Resolves with `dandi 0.76.5`, `linkml 1.11.1`, `linkml-runtime 1.11.1`, and `click 8.4.2` (satisfies linkml 1.11's `click>=8.2`).
- pynwb wheel builds and installs; `pynwb`, `linkml`, `linkml_runtime`, `dandi`, `click` import.
- `pip check` reports no broken requirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)