### PR TITLE
Raise FileNotFoundError for missing files in read_nwb and _get_backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed `mock_electrodes` (and `mock_ElectricalSeries`) sizing the auto-created `ElectrodesTable` to a fixed 5 rows while the `DynamicTableRegion` followed `n_electrodes`, which raised an `IndexError` under HDMF 4.x+ for any data with more than 5 channels. The table is now sized to `n_electrodes`. @h-mayorquin [#2214](https://github.com/NeurodataWithoutBorders/pynwb/pull/2214)
+- Fixed `read_nwb` and `_get_backend` reporting a nonexistent path as an unrecognized backend (and, without hdmf-zarr installed, suggesting `pip install hdmf-zarr`). A missing file now raises a `FileNotFoundError`. @rly [#2221](https://github.com/NeurodataWithoutBorders/pynwb/issues/2221)
 
 
 ## PyNWB 4.0.0 (June 29, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Fixed `mock_electrodes` (and `mock_ElectricalSeries`) sizing the auto-created `ElectrodesTable` to a fixed 5 rows while the `DynamicTableRegion` followed `n_electrodes`, which raised an `IndexError` under HDMF 4.x+ for any data with more than 5 channels. The table is now sized to `n_electrodes`. @h-mayorquin [#2214](https://github.com/NeurodataWithoutBorders/pynwb/pull/2214)
-- Fixed `read_nwb` and `_get_backend` reporting a nonexistent path as an unrecognized backend (and, without hdmf-zarr installed, suggesting `pip install hdmf-zarr`). A missing file now raises a `FileNotFoundError`. @rly [#2221](https://github.com/NeurodataWithoutBorders/pynwb/issues/2221)
+- Fixed `read_nwb` and `_get_backend` reporting a nonexistent path as an unrecognized backend (and, without hdmf-zarr installed, suggesting `pip install hdmf-zarr`). A missing file now raises a `FileNotFoundError`. @rly [#2222](https://github.com/NeurodataWithoutBorders/pynwb/pull/2222)
 
 
 ## PyNWB 4.0.0 (June 29, 2026)

--- a/src/pynwb/__init__.py
+++ b/src/pynwb/__init__.py
@@ -346,6 +346,9 @@ def _get_backend(path: str, method: str = None):
     if method == "ros3":
         return NWBHDF5IO  # TODO - add additional conditions for other streaming methods
 
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Could not find the file '{path}'.")
+
     try:
         from hdmf_zarr import NWBZarrIO
         backend_io_classes = [NWBHDF5IO, NWBZarrIO]
@@ -574,6 +577,8 @@ def read_nwb(**kwargs):
     """
 
     path = popargs('path', kwargs)
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Could not find the file '{path}'.")
     # HDF5 is always available so we try that first
     backend_is_hdf5 = NWBHDF5IO.can_read(path=path)
     if backend_is_hdf5:

--- a/tests/integration/io/test_read.py
+++ b/tests/integration/io/test_read.py
@@ -44,6 +44,13 @@ class TestReadNWBMethod(TestCase):
             self.assertContainerEqual(read_nwbfile, self.nwbfile)
             read_nwbfile.get_read_io().close()
 
+    def test_read_missing_file(self):
+        """Test attempting to read a file that does not exist."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "does_not_exist.nwb"
+            with self.assertRaisesWith(FileNotFoundError, f"Could not find the file '{path}'."):
+                read_nwb(path=path)
+
     def test_read_zarr_without_hdmf_zarr(self):
         """Test attempting to read a Zarr file without hdmf_zarr installed."""
         if HAVE_NWBZarrIO:

--- a/tests/integration/utils/test_io_utils.py
+++ b/tests/integration/utils/test_io_utils.py
@@ -76,9 +76,19 @@ class TestGetNWBBackend(TestCase):
     def tearDown(self):
         remove_test_file(self.hdf5_path)
 
-    def test_get_backend_invalid_file(self):
-        with self.assertRaises(ValueError):
+    def test_get_backend_missing_file(self):
+        with self.assertRaises(FileNotFoundError):
             _get_backend('not_a_file.nwb')
+
+    def test_get_backend_invalid_file(self):
+        invalid_path = "test_pynwb_invalid_backend.nwb"
+        with open(invalid_path, "w") as f:
+            f.write("this is not an NWB file")
+        try:
+            with self.assertRaises(ValueError):
+                _get_backend(invalid_path)
+        finally:
+            remove_test_file(invalid_path)
 
     def test_get_backend_HDF5(self):
         backend_io = _get_backend(self.hdf5_path)


### PR DESCRIPTION
## Motivation

Fixes #2221.

`read_nwb` (and `_get_backend`) reported a nonexistent path as an unrecognized backend rather than a missing file. Because `NWBHDF5IO.can_read` returns `False` for any path where `os.path.isfile()` is `False`, a missing file was indistinguishable from "exists but not HDF5" and fell into the Zarr branch:

- Without hdmf-zarr installed, the user was told to `pip install hdmf-zarr`, which has nothing to do with a typo'd filename.
- With hdmf-zarr installed, the message conflated "file not found" with "not valid NWB."

## Changes

- `read_nwb` and `_get_backend` now check `os.path.exists(path)` up front and raise `FileNotFoundError: Could not find the file '<path>'.` before backend detection. The hdmf-zarr hint remains for files that exist but no installed backend can read.
- Split the old `test_get_backend_invalid_file` (which passed a *missing* file) into `test_get_backend_missing_file` (`FileNotFoundError`) and a genuine `test_get_backend_invalid_file` using an existing-but-invalid file (`ValueError`).
- Added `test_read_missing_file` for `read_nwb`.
- Added a CHANGELOG entry.

## Checklist

- [x] Tests added/updated
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)