### PR TITLE
Fix TimeIntervals.get_duration/get_starting_time NaN propagation (Fix #2212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - Fixed `mock_electrodes` (and `mock_ElectricalSeries`) sizing the auto-created `ElectrodesTable` to a fixed 5 rows while the `DynamicTableRegion` followed `n_electrodes`, which raised an `IndexError` under HDMF 4.x+ for any data with more than 5 channels. The table is now sized to `n_electrodes`. @h-mayorquin [#2214](https://github.com/NeurodataWithoutBorders/pynwb/pull/2214)
+- Fixed `TimeIntervals.get_starting_time()` and `get_duration()` returning `NaN` when the table contains NaN start/stop times (e.g. ongoing/unbounded intervals). NaN entries are now ignored via `np.nanmin`/`np.nanmax`. `get_starting_time()` returns `None` when the table is empty or all start times are NaN. `get_duration()` returns `None` for an empty table, `NaN` when all start times are NaN, and falls back to the span of the start times when all stop times are NaN. @Leonard013 [#2212](https://github.com/NeurodataWithoutBorders/pynwb/issues/2212)
 
 
 ## PyNWB 4.0.0 (June 29, 2026)

--- a/src/pynwb/epoch.py
+++ b/src/pynwb/epoch.py
@@ -88,15 +88,21 @@ class TimeIntervals(DynamicTable):
         """
         Get the earliest start time across all intervals in this TimeIntervals table.
 
+        NaN start times are ignored.
+
         Returns
         -------
         float or None
-            The earliest start time in seconds, or None if the table is empty.
+            The earliest non-NaN start time in seconds, or None if the table is
+            empty or all start times are NaN.
         """
         if len(self) == 0:
             return None
+        start_time = np.asarray(self['start_time'].data[:], dtype=float)
+        if np.all(np.isnan(start_time)):
+            return None
         # NOTE: Could be optimized to self['start_time'].data[0] if intervals are guaranteed sorted
-        return float(np.min(self['start_time'].data[:]))
+        return float(np.nanmin(start_time))
 
     def get_duration(self):
         """
@@ -105,16 +111,28 @@ class TimeIntervals(DynamicTable):
         Returns
         -------
         float or None
-            The duration in seconds, or None if the table is empty.
+            The duration in seconds, or None if the table is empty. Returns NaN if
+            all start times are NaN (the earliest start is undefined). If all stop
+            times are NaN but valid start times exist, the duration falls back to
+            the span of the start times (latest start minus earliest start).
 
         Notes
         -----
         The duration represents the time span from the earliest interval start to the
-        latest interval stop, not the sum of individual interval durations.
+        latest interval stop, not the sum of individual interval durations. NaN
+        start/stop times (e.g. for ongoing/unbounded intervals) are ignored.
         """
         if len(self) == 0:
             return None
         starting_time = self.get_starting_time()
+        if starting_time is None:
+            # all start times are NaN, so the earliest start is undefined
+            return float("nan")
+        stop_time = np.asarray(self['stop_time'].data[:], dtype=float)
+        if np.all(np.isnan(stop_time)):
+            # no valid stop times: fall back to the span of the start times
+            start_time = np.asarray(self['start_time'].data[:], dtype=float)
+            return float(np.nanmax(start_time)) - starting_time
         # NOTE: Could be optimized to self['stop_time'].data[-1] if intervals are guaranteed sorted
-        stopping_time = float(np.max(self['stop_time'].data[:]))
+        stopping_time = float(np.nanmax(stop_time))
         return stopping_time - starting_time

--- a/tests/unit/test_epoch.py
+++ b/tests/unit/test_epoch.py
@@ -243,3 +243,70 @@ class TimeIntervalsTest(TestCase):
         ti.add_interval(start_time=5.0, stop_time=10.0)
         # Duration: 10.0 - 5.0 = 5.0
         self.assertEqual(ti.get_duration(), 5.0)
+
+    def test_get_starting_time_ignores_nan(self):
+        """Test get_starting_time ignores NaN start times (#2212)"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=np.nan, stop_time=5.0)
+        ti.add_interval(start_time=2.0, stop_time=7.0)
+        ti.add_interval(start_time=8.0, stop_time=np.nan)
+        self.assertEqual(ti.get_starting_time(), 2.0)
+
+    def test_get_starting_time_all_nan(self):
+        """Test get_starting_time returns None when all start times are NaN (#2212)"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=np.nan, stop_time=5.0)
+        ti.add_interval(start_time=np.nan, stop_time=9.0)
+        self.assertIsNone(ti.get_starting_time())
+
+    def test_get_duration_ignores_nan_stop(self):
+        """Test get_duration ignores a NaN stop time (#2212 issue example)"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=0.0, stop_time=1.0)
+        ti.add_interval(start_time=2.0, stop_time=np.nan)  # ongoing interval
+        # nanmax(stop_time)=1.0, nanmin(start_time)=0.0 -> 1.0
+        self.assertEqual(ti.get_duration(), 1.0)
+
+    def test_get_duration_ignores_nan_stop_among_valid(self):
+        """Test get_duration ignores a NaN stop among valid stop times (#2212)"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=2.0, stop_time=5.0)
+        ti.add_interval(start_time=7.0, stop_time=np.nan)
+        ti.add_interval(start_time=12.0, stop_time=18.0)
+        # nanmax(stop_time)=18.0, nanmin(start_time)=2.0 -> 16.0
+        self.assertEqual(ti.get_duration(), 16.0)
+
+    def test_get_duration_all_stop_nan(self):
+        """Test get_duration falls back to the span of starts when all stops are NaN (#2212)"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=2.0, stop_time=np.nan)
+        ti.add_interval(start_time=9.0, stop_time=np.nan)
+        # all stop times NaN, valid starts -> span of starts: 9.0 - 2.0 = 7.0
+        self.assertEqual(ti.get_duration(), 7.0)
+
+    def test_get_duration_all_nan(self):
+        """Test get_duration returns NaN when all start and stop times are NaN (#2212)"""
+        import warnings
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=np.nan, stop_time=np.nan)
+        ti.add_interval(start_time=np.nan, stop_time=np.nan)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)  # must not emit an all-NaN warning
+            duration = ti.get_duration()
+        self.assertTrue(np.isnan(duration))
+
+    def test_get_duration_all_start_nan_valid_stops(self):
+        """Test get_duration returns NaN when all starts are NaN even with valid stops (#2212).
+
+        This case is not covered by the issue's explicit spec bullets. The earliest
+        start is undefined (get_starting_time returns None here), so the duration is
+        NaN for consistency.
+        """
+        import warnings
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=np.nan, stop_time=5.0)
+        ti.add_interval(start_time=np.nan, stop_time=9.0)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)  # must not emit an all-NaN warning
+            duration = ti.get_duration()
+        self.assertTrue(np.isnan(duration))


### PR DESCRIPTION
## Motivation

`TimeIntervals.get_duration` (added in #2146) uses `np.max` on `stop_time`, and
`get_starting_time` uses `np.min` on `start_time`. Both propagate `NaN`. Start/stop
times are allowed to be `NaN` (e.g. ongoing/unbounded intervals), so both methods
returned `NaN` whenever any relevant value was `NaN`. Fixes #2212 (bug, priority: high).

## What changed

`src/pynwb/epoch.py`:

- `get_starting_time()` now uses `np.nanmin` and returns `None` if the table is empty
  **or all start times are NaN**.
- `get_duration()` now uses `np.nanmin`/`np.nanmax`, implementing the issue's spec bullets:
  - Empty table → `None`.
  - All start times AND all stop times NaN → `NaN`.
  - All stop times NaN but valid start times exist → span of the start times
    (`nanmax(start) − nanmin(start)`).
  - Otherwise → `nanmax(stop) − nanmin(start)`.
- All-NaN slices are **guarded** (early `None`/`NaN` returns) so `np.nanmin`/`np.nanmax`
  are never called on an all-NaN array → **no numpy `RuntimeWarning`** is emitted.
- Non-NaN behavior is unchanged (`nanmin`/`nanmax` == `min`/`max` when there are no NaNs).

`tests/unit/test_epoch.py`: 7 regression tests (table below).
`CHANGELOG.md`: entry under `## PyNWB 4.0.1 (Unreleased)` → `### Fixed`.

## How to test

```python
import numpy as np
from pynwb.epoch import TimeIntervals

ti = TimeIntervals(name="intervals")
ti.add_interval(start_time=0.0, stop_time=1.0)
ti.add_interval(start_time=2.0, stop_time=np.nan)  # ongoing interval
print(ti.get_starting_time())  # 0.0
print(ti.get_duration())       # 1.0  (was: nan)
```

`python -m pytest tests/unit/test_epoch.py -q` → 28 passed (21 existing + 7 new).
Full `tests/unit` → 568 passed, 3 skipped. `ruff` + `codespell` clean.

## ⚠️ Clarification: the issue's inline "expected 2.0" is a typo; the spec value is 1.0

The reproduction snippet in the issue body has an inline comment
`# -> nan, expected 2.0 (latest valid stop is 1.0; here all-NaN-stop fallback not triggered)`.
The "2.0" contradicts the issue's own **Expected behavior** bullets and the parenthetical
that follows it. Per the bullets, `get_duration` ignores NaN via `nanmin`/`nanmax`:
`nanmax([1.0, NaN]) = 1.0`, `nanmin([0.0, 2.0]) = 0.0`, so duration = `1.0`. The
"all stop times NaN" fallback is not triggered because a valid stop (`1.0`) exists. This PR
implements **1.0** (the authoritative bullet-spec value). Flagging in case you'd like to
confirm.

## ⚠️ One case is not covered by the spec bullets (flagged for review)

**All start times NaN, but valid stop times exist** — e.g. `add(NaN, 5.0)` + `add(NaN, 9.0)`.
The spec bullets cover "all start AND all stop NaN" and "all stop NaN, valid starts", but not
this. Since the earliest start is undefined here (`get_starting_time()` returns `None` per the
spec), I chose the consistent behavior: `get_duration()` returns `NaN` (mirrors the "all start
& stop NaN → NaN" rule — duration is undefined when the start reference is undefined). Covered
by `test_get_duration_all_start_nan_valid_stops`. **Please confirm** `NaN` is acceptable here
(alternatives: raise, or return `None`).

## Regression tests added

| Test | Scenario | Asserts |
|---|---|---|
| `test_get_starting_time_ignores_nan` | NaN among valid starts | `2.0` |
| `test_get_starting_time_all_nan` | all starts NaN | `None` |
| `test_get_duration_ignores_nan_stop` | issue example add(0,1)+add(2,NaN) | `1.0` (not 2.0) |
| `test_get_duration_ignores_nan_stop_among_valid` | NaN stop among valid | `16.0` |
| `test_get_duration_all_stop_nan` | all stops NaN, valid starts | `7.0` (span of starts) |
| `test_get_duration_all_nan` | all start+stop NaN | `NaN`, no RuntimeWarning |
| `test_get_duration_all_start_nan_valid_stops` | UNSPEC: all starts NaN, valid stops | `NaN`, no RuntimeWarning |

## Checklist

- [x] Updated CHANGELOG.md
- [x] Checked Contributing document
- [x] PR describes problem and solution
- [x] `ruff check` and `codespell` pass on changed files
