### PR TITLE
Return ObjectMapper.NO_OVERRIDE from override functions instead of None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## PyNWB 4.0.1 (Unreleased)
 
 ### Changed
+- Updated `ObjectMapper` `constructor_arg` and `object_attr` override functions to return the `hdmf.build.ObjectMapper.NO_OVERRIDE` sentinel instead of `None` to signal "no override". In HDMF, returning `None` from an override function to signal "no override" is deprecated and, in HDMF 8.0, will set the constructor argument or attribute to `None`. Requires a version of HDMF that provides `ObjectMapper.NO_OVERRIDE` (see [hdmf-dev/hdmf#1167](https://github.com/hdmf-dev/hdmf/pull/1167)). @rly [#XXXX](https://github.com/NeurodataWithoutBorders/pynwb/pull/XXXX)
 - Lifted the `<1.11` cap on the `linkml` and `linkml-runtime` termset extras and bumped the `dandi` docs dependency to `>=0.76.5`. dandi 0.76.5 lifts its `click<8.2` bound ([dandi/dandi-cli#1883](https://github.com/dandi/dandi-cli/pull/1883)), which had conflicted with the `click>=8.2` requirement of linkml 1.11. @rly [#2217](https://github.com/NeurodataWithoutBorders/pynwb/pull/2217)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## PyNWB 4.0.1 (Unreleased)
 
 ### Changed
-- Updated `ObjectMapper` `constructor_arg` and `object_attr` override functions to return the `hdmf.build.ObjectMapper.NO_OVERRIDE` sentinel instead of `None` to signal "no override". In HDMF, returning `None` from an override function to signal "no override" is deprecated and, in HDMF 8.0, will set the constructor argument or attribute to `None`. Requires a version of HDMF that provides `ObjectMapper.NO_OVERRIDE` (see [hdmf-dev/hdmf#1167](https://github.com/hdmf-dev/hdmf/pull/1167)). @rly [#2224](https://github.com/NeurodataWithoutBorders/pynwb/pull/2224)
+- Updated `ObjectMapper` `constructor_arg` and `object_attr` override functions to return the `hdmf.build.ObjectMapper.NO_OVERRIDE` sentinel instead of `None` to signal "no override". HDMF 6.2.0 deprecates returning `None` from an override function to signal "no override" (in HDMF 8.0 a `None` return will set the constructor argument or attribute to `None`, dropping data), and emits a `DeprecationWarning` when it happens (see [hdmf-dev/hdmf#1167](https://github.com/hdmf-dev/hdmf/pull/1167)). PyNWB resolves the sentinel via `getattr`, so it degrades to `None` on HDMF < 6.2.0 and keeps working with the existing `hdmf>=6.1.0` requirement without bumping the minimum version. @rly [#2224](https://github.com/NeurodataWithoutBorders/pynwb/pull/2224)
 - Lifted the `<1.11` cap on the `linkml` and `linkml-runtime` termset extras and bumped the `dandi` docs dependency to `>=0.76.5`. dandi 0.76.5 lifts its `click<8.2` bound ([dandi/dandi-cli#1883](https://github.com/dandi/dandi-cli/pull/1883)), which had conflicted with the `click>=8.2` requirement of linkml 1.11. @rly [#2217](https://github.com/NeurodataWithoutBorders/pynwb/pull/2217)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## PyNWB 4.0.1 (Unreleased)
 
 ### Changed
-- Updated `ObjectMapper` `constructor_arg` and `object_attr` override functions to return the `hdmf.build.ObjectMapper.NO_OVERRIDE` sentinel instead of `None` to signal "no override". In HDMF, returning `None` from an override function to signal "no override" is deprecated and, in HDMF 8.0, will set the constructor argument or attribute to `None`. Requires a version of HDMF that provides `ObjectMapper.NO_OVERRIDE` (see [hdmf-dev/hdmf#1167](https://github.com/hdmf-dev/hdmf/pull/1167)). @rly [#XXXX](https://github.com/NeurodataWithoutBorders/pynwb/pull/XXXX)
+- Updated `ObjectMapper` `constructor_arg` and `object_attr` override functions to return the `hdmf.build.ObjectMapper.NO_OVERRIDE` sentinel instead of `None` to signal "no override". In HDMF, returning `None` from an override function to signal "no override" is deprecated and, in HDMF 8.0, will set the constructor argument or attribute to `None`. Requires a version of HDMF that provides `ObjectMapper.NO_OVERRIDE` (see [hdmf-dev/hdmf#1167](https://github.com/hdmf-dev/hdmf/pull/1167)). @rly [#2224](https://github.com/NeurodataWithoutBorders/pynwb/pull/2224)
 - Lifted the `<1.11` cap on the `linkml` and `linkml-runtime` termset extras and bumped the `dandi` docs dependency to `>=0.76.5`. dandi 0.76.5 lifts its `click<8.2` bound ([dandi/dandi-cli#1883](https://github.com/dandi/dandi-cli/pull/1883)), which had conflicted with the `click>=8.2` requirement of linkml 1.11. @rly [#2217](https://github.com/NeurodataWithoutBorders/pynwb/pull/2217)
 
 ### Added

--- a/src/pynwb/io/device.py
+++ b/src/pynwb/io/device.py
@@ -95,7 +95,7 @@ class DeviceMapper(NWBContainerMapper):
 
             return model
 
-        return None
+        return self.NO_OVERRIDE
 
 
     def __new_container__(self, cls, container_source, parent, object_id, **kwargs):

--- a/src/pynwb/io/device.py
+++ b/src/pynwb/io/device.py
@@ -3,6 +3,7 @@ from warnings import warn
 from .. import register_map
 from ..device import Device, DeviceModel
 from .core import NWBContainerMapper
+from .utils import NO_OVERRIDE
 
 def _name_has_invalid_chars(name):
     """Return True if ``name`` contains a character that is not allowed in an NWB object name."""
@@ -95,7 +96,7 @@ class DeviceMapper(NWBContainerMapper):
 
             return model
 
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE
 
 
     def __new_container__(self, cls, container_source, parent, object_id, **kwargs):

--- a/src/pynwb/io/epoch.py
+++ b/src/pynwb/io/epoch.py
@@ -3,6 +3,7 @@ from hdmf.common.table import VectorData
 from hdmf.common.io.table import DynamicTableMap
 
 from .. import register_map
+from .utils import NO_OVERRIDE
 from pynwb.epoch import TimeIntervals
 from pynwb.base import TimeSeriesReferenceVectorData
 
@@ -47,4 +48,4 @@ class TimeIntervalsMap(DynamicTableMap):
             # overwrite the columns constructor argument
             return columns
         # do not override
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE

--- a/src/pynwb/io/epoch.py
+++ b/src/pynwb/io/epoch.py
@@ -47,4 +47,4 @@ class TimeIntervalsMap(DynamicTableMap):
             # overwrite the columns constructor argument
             return columns
         # do not override
-        return None
+        return self.NO_OVERRIDE

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -7,7 +7,7 @@ from hdmf.utils import docval, get_docval
 from .. import register_map
 from ..file import NWBFile, Subject
 from ..core import ScratchData
-from .utils import get_nwb_version
+from .utils import get_nwb_version, NO_OVERRIDE
 
 
 @register_map(NWBFile)
@@ -290,7 +290,7 @@ class NWBFileMap(ObjectMapper):
         Then it was changed to be a 1-D array of strings. This mapping function is necessary
         for writing a valid 'experimenter' array if it is a string in the NWBFile container.
         """
-        ret = self.NO_OVERRIDE
+        ret = NO_OVERRIDE
         if isinstance(container.experimenter, str):
             ret = (container.experimenter,)
         return ret
@@ -325,7 +325,7 @@ class NWBFileMap(ObjectMapper):
         Then it was changed to be a 1-D array of strings. This mapping function is necessary
         for writing a valid 'related_publications' array if it is a string in the NWBFile container.
         """
-        ret = self.NO_OVERRIDE
+        ret = NO_OVERRIDE
         if isinstance(container.related_publications, str):
             ret = (container.related_publications,)
         return ret

--- a/src/pynwb/io/file.py
+++ b/src/pynwb/io/file.py
@@ -290,7 +290,7 @@ class NWBFileMap(ObjectMapper):
         Then it was changed to be a 1-D array of strings. This mapping function is necessary
         for writing a valid 'experimenter' array if it is a string in the NWBFile container.
         """
-        ret = None
+        ret = self.NO_OVERRIDE
         if isinstance(container.experimenter, str):
             ret = (container.experimenter,)
         return ret
@@ -325,7 +325,7 @@ class NWBFileMap(ObjectMapper):
         Then it was changed to be a 1-D array of strings. This mapping function is necessary
         for writing a valid 'related_publications' array if it is a string in the NWBFile container.
         """
-        ret = None
+        ret = self.NO_OVERRIDE
         if isinstance(container.related_publications, str):
             ret = (container.related_publications,)
         return ret

--- a/src/pynwb/io/utils.py
+++ b/src/pynwb/io/utils.py
@@ -1,7 +1,14 @@
 import re
 from typing import Tuple
 
-from hdmf.build import Builder
+from hdmf.build import Builder, ObjectMapper
+
+# Value an override function returns to signal "no override". HDMF >= 6.2.0 provides the
+# ObjectMapper.NO_OVERRIDE sentinel; older HDMF uses a None return. getattr resolves to whichever
+# the installed HDMF supports.
+# TODO: return ObjectMapper.NO_OVERRIDE directly and remove this shim once the minimum required HDMF
+# version is >= 6.2.0.
+NO_OVERRIDE = getattr(ObjectMapper, "NO_OVERRIDE", None)
 
 
 def get_nwb_version(builder: Builder, include_prerelease=False) -> Tuple[int, ...]:

--- a/src/pynwb/legacy/io/base.py
+++ b/src/pynwb/legacy/io/base.py
@@ -1,6 +1,7 @@
 from pynwb.base import TimeSeries, ProcessingModule
 
 from .. import ObjectMapper, register_map
+from pynwb.io.utils import NO_OVERRIDE
 
 legacy_TimeSeries_missing_time_info_name_list = ('natural_movie_one_image_stack',
                                                  'natural_movie_two_image_stack',
@@ -56,11 +57,11 @@ class TimeSeriesMap(ObjectMapper):
         builder = args[0]
         if builder.name in legacy_TimeSeries_missing_time_info_name_list:
             return -1.0
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE
 
     @ObjectMapper.constructor_arg('rate')
     def carg_rate(self, *args):
         builder = args[0]
         if builder.name in legacy_TimeSeries_missing_time_info_name_list:
             return -1.0
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE

--- a/src/pynwb/legacy/io/base.py
+++ b/src/pynwb/legacy/io/base.py
@@ -56,9 +56,11 @@ class TimeSeriesMap(ObjectMapper):
         builder = args[0]
         if builder.name in legacy_TimeSeries_missing_time_info_name_list:
             return -1.0
+        return self.NO_OVERRIDE
 
     @ObjectMapper.constructor_arg('rate')
     def carg_rate(self, *args):
         builder = args[0]
         if builder.name in legacy_TimeSeries_missing_time_info_name_list:
             return -1.0
+        return self.NO_OVERRIDE

--- a/src/pynwb/legacy/io/behavior.py
+++ b/src/pynwb/legacy/io/behavior.py
@@ -2,6 +2,7 @@ from pynwb.behavior import BehavioralTimeSeries, PupilTracking
 from pynwb.image import IndexSeries
 
 from .. import ObjectMapper, register_map
+from pynwb.io.utils import NO_OVERRIDE
 
 
 @register_map(BehavioralTimeSeries)
@@ -20,7 +21,7 @@ class BehavioralTimeSeriesMap(ObjectMapper):
                 for x in value:
                     if not isinstance(x, IndexSeries):
                         return x
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE
 
 
 @register_map(PupilTracking)
@@ -39,4 +40,4 @@ class PupilTrackingMap(ObjectMapper):
                 for x in value:
                     if not isinstance(x, IndexSeries):
                         return x
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE

--- a/src/pynwb/legacy/io/behavior.py
+++ b/src/pynwb/legacy/io/behavior.py
@@ -20,6 +20,7 @@ class BehavioralTimeSeriesMap(ObjectMapper):
                 for x in value:
                     if not isinstance(x, IndexSeries):
                         return x
+        return self.NO_OVERRIDE
 
 
 @register_map(PupilTracking)
@@ -38,3 +39,4 @@ class PupilTrackingMap(ObjectMapper):
                 for x in value:
                     if not isinstance(x, IndexSeries):
                         return x
+        return self.NO_OVERRIDE

--- a/src/pynwb/legacy/io/image.py
+++ b/src/pynwb/legacy/io/image.py
@@ -13,3 +13,4 @@ class ImageSeriesMap(ObjectMapper):
         builder = args[0]
         if builder.name in ('corrected',):
             return np.array([-1.])
+        return self.NO_OVERRIDE

--- a/src/pynwb/legacy/io/image.py
+++ b/src/pynwb/legacy/io/image.py
@@ -3,6 +3,7 @@ import numpy as np
 from pynwb.image import ImageSeries
 
 from .. import ObjectMapper, register_map
+from pynwb.io.utils import NO_OVERRIDE
 
 
 @register_map(ImageSeries)
@@ -13,4 +14,4 @@ class ImageSeriesMap(ObjectMapper):
         builder = args[0]
         if builder.name in ('corrected',):
             return np.array([-1.])
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE

--- a/src/pynwb/legacy/io/ophys.py
+++ b/src/pynwb/legacy/io/ophys.py
@@ -40,6 +40,7 @@ class TwoPhotonSeriesMap(ObjectMapper):
         builder = args[0]
         if builder.name in ('2p_image_series',):
             return np.array([-1.])
+        return self.NO_OVERRIDE
 
     @ObjectMapper.constructor_arg('unit')
     def carg_unit(self, *args):

--- a/src/pynwb/legacy/io/ophys.py
+++ b/src/pynwb/legacy/io/ophys.py
@@ -3,6 +3,7 @@ import numpy as np
 from pynwb.ophys import PlaneSegmentation, TwoPhotonSeries
 
 from .. import ObjectMapper, register_map
+from pynwb.io.utils import NO_OVERRIDE
 
 
 @register_map(PlaneSegmentation)
@@ -40,7 +41,7 @@ class TwoPhotonSeriesMap(ObjectMapper):
         builder = args[0]
         if builder.name in ('2p_image_series',):
             return np.array([-1.])
-        return self.NO_OVERRIDE
+        return NO_OVERRIDE
 
     @ObjectMapper.constructor_arg('unit')
     def carg_unit(self, *args):


### PR DESCRIPTION
## Motivation

Depends on [hdmf-dev/hdmf#1167](https://github.com/hdmf-dev/hdmf/pull/1167).

That HDMF PR adds `ObjectMapper.NO_OVERRIDE`, a sentinel that a `constructor_arg` / `object_attr` override function returns to fall through to the value built from the file or read from the container. HDMF 6.2.0 deprecates the previous convention of returning `None` for that purpose: returning `None` still falls through, but emits a `DeprecationWarning` when doing so actually changes the result, and in HDMF 8.0 a `None` return will set the constructor argument or attribute to `None`, which would drop data.

Several PyNWB override functions use the old `None`-means-no-override idiom, so they emit the new warning against HDMF 6.2.0 and would break under HDMF 8.0. `trials`/`epochs`/`invalid_times` reads from schema >= 2.5 fire it on every read, so downstream tools that treat warnings as errors (e.g. [dandi-cli](https://github.com/dandi/dandi-cli/actions/runs/29777728823/job/88471108820)) fail once HDMF 6.2.0 is installed against a current PyNWB.

## Changes

Migrates the affected override functions to return a `NO_OVERRIDE` sentinel instead of `None`. The sentinel is defined once in `src/pynwb/io/utils.py` and resolved with `getattr`:

```python
NO_OVERRIDE = getattr(ObjectMapper, "NO_OVERRIDE", None)
```

This resolves to `ObjectMapper.NO_OVERRIDE` on HDMF >= 6.2.0 (no warning) and to `None` on older HDMF (where the sentinel and the warning do not exist, so `None` is still the correct signal). The override functions therefore work on both, so **the minimum HDMF version stays at `>=6.1.0`, no floor bump**, and this can be released before HDMF 6.2.0 to close the gap for tools that treat warnings as errors.

Active mappers:
- `io/epoch.py` `TimeIntervalsMap.columns_carg` (highest impact: fires on every `trials`/`epochs`/`invalid_times` read from schema >= 2.5)
- `io/device.py` `DeviceMapper.model_carg`
- `io/file.py` `NWBFileMap.experimenter_obj_attr` and `publication_obj_attr`

Legacy NWB 1.x mappers (`pynwb.legacy`):
- `legacy/io/base.py` `carg_starting_time`, `carg_rate`
- `legacy/io/ophys.py` and `legacy/io/image.py` `carg_data`
- `legacy/io/behavior.py` `carg_time_series` (Behavioral + PupilTracking)

Override functions that return `None` only when the target field is absent (so the fall-through value is also `None`) are left as-is; they neither warn nor change behavior in HDMF 8.0.

## Verification

- New HDMF (with `NO_OVERRIDE`): full HDF5 integration + unit suite passes with `DeprecationWarning` promoted to an error, including `trials`/`experimenter`/`related_publications` roundtrips. Reverting this change reproduces the warning on `trials`/`epochs` roundtrips.
- Old HDMF (6.1.0, no `NO_OVERRIDE`): the shim resolves to `None`, preserving current behavior.

## Note for downstream consumers

This fix protects code that upgrades to the PyNWB release containing it. It cannot change the already-released PyNWB 4.0.0, whose `hdmf<7` pin will still pull HDMF 6.2.0 and warn. Tools such as dandi-cli should require the fixed PyNWB release (`pynwb>=4.0.1`).

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our [Contributing Guide](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst)?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the relevant issue numbered XXX when the PR is merged?
