### PR TITLE
Use the gh CLI and PyPI trusted publishing for releases

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -22,8 +22,10 @@ Prepare for release of PyNWB [version]
 
 ### After merging:
 1. Create release by following steps in `docs/source/make_a_release.rst` or use alias `git pypi-release [tag]` if set up
-2. After the CI bot creates the new release (wait ~10 min), update the release notes on the
-   [GitHub releases page](https://github.com/NeurodataWithoutBorders/pynwb/releases) with the changelog
+2. After the CI bot creates the new release (wait ~10 min), check the release notes on the
+   [GitHub releases page](https://github.com/NeurodataWithoutBorders/pynwb/releases). The workflow fills them
+   from this version's section of `CHANGELOG.md`, and falls back to auto-generated notes if that section is
+   empty or its heading does not match the tag.
 3. Check that the readthedocs "stable" build runs and succeeds
 4. Either monitor [conda-forge/pynwb-feedstock](https://github.com/conda-forge/pynwb-feedstock) for the
    regro-cf-autotick-bot bot to create a PR updating the version of HDMF to the latest PyPI release, usually within

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -47,9 +47,8 @@ jobs:
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
 
       - name: Test installation from a source distribution
-        # The source distribution is uploaded to PyPI and attached to the GitHub release, so it is
-        # installed here from a clean environment. --recreate is required: pip skips an install whose
-        # version is already present.
+        # The source distribution is uploaded to PyPI and attached to the GitHub release. --recreate
+        # gives it a fresh environment, so its dependencies are resolved and installed from scratch.
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
 

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -8,10 +8,17 @@ jobs:
   deploy-release:
     name: Deploy release from tag
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pynwb
+    permissions:
+      id-token: write  # mint the OIDC token for PyPI trusted publishing
+      contents: write  # create the GitHub release
     steps:
       - name: Checkout repo with submodules
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           submodules: 'recursive'
           fetch-depth: 0  # tags are required for versioneer to determine the version
 
@@ -40,15 +47,37 @@ jobs:
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
 
       - name: Upload wheel and source distributions to PyPI
-        run: |
-          python -m pip install twine
-          ls -1 dist
-          # twine upload --repository-url https://test.pypi.org/legacy/ -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
-          twine upload -u ${{ secrets.BOT_PYPI_USER }} -p ${{ secrets.BOT_PYPI_PASSWORD }} --skip-existing dist/*
+        # Publishes to PyPI via OIDC trusted publishing. The pynwb project on PyPI must have a trusted
+        # publisher configured for the NeurodataWithoutBorders/pynwb repository, the deploy_release.yml
+        # workflow, and the pypi environment.
+        uses: pypa/gh-action-pypi-publish@v1.14.1
+        with:
+          skip-existing: true
 
       - name: Publish wheel and source distributions as a GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          python -m pip install "githubrelease>=1.5.9"
-          githubrelease --github-token ${{ secrets.BOT_GITHUB_TOKEN }} release NeurodataWithoutBorders/pynwb \
-            create ${{ github.ref_name }} --name ${{ github.ref_name }} \
-            --publish dist/*
+          # Use this version's CHANGELOG.md section as the release notes, falling back to
+          # auto-generated notes if no matching section with content is found (e.g. a heading/tag mismatch).
+          awk -v hdr="## PyNWB ${GITHUB_REF_NAME}" '
+            index($0, hdr) == 1 { f = 1; next }
+            f && /^## / { exit }
+            f { print }
+          ' CHANGELOG.md > release_notes.md
+          if grep -q '[^[:space:]]' release_notes.md; then
+            notes_args=(--notes-file release_notes.md)
+          else
+            echo "No release notes found in CHANGELOG.md for ${GITHUB_REF_NAME}; using auto-generated notes."
+            notes_args=(--generate-notes)
+          fi
+          # Create the release, or upload the artifacts to it if a re-run finds it already exists,
+          # so the step can be re-run safely.
+          if gh release view "${GITHUB_REF_NAME}" --repo NeurodataWithoutBorders/pynwb > /dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" dist/* --repo NeurodataWithoutBorders/pynwb --clobber
+          else
+            gh release create "${GITHUB_REF_NAME}" dist/* \
+              --repo NeurodataWithoutBorders/pynwb \
+              --title "${GITHUB_REF_NAME}" \
+              "${notes_args[@]}"
+          fi

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -46,6 +46,13 @@ jobs:
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
 
+      - name: Test installation from a source distribution
+        # The source distribution is uploaded to PyPI and attached to the GitHub release, so it is
+        # installed here from a clean environment. --recreate is required: pip skips an install whose
+        # version is already present.
+        run: |
+          tox -e wheelinstall --recreate --installpkg dist/*.tar.gz
+
       - name: Upload wheel and source distributions to PyPI
         # Publishes to PyPI via OIDC trusted publishing. The pynwb project on PyPI must have a trusted
         # publisher configured for the NeurodataWithoutBorders/pynwb repository, the deploy_release.yml

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -80,11 +80,11 @@ jobs:
           fi
           # Create the release, or upload the artifacts to it if a re-run finds it already exists,
           # so the step can be re-run safely.
-          if gh release view "${GITHUB_REF_NAME}" --repo NeurodataWithoutBorders/pynwb > /dev/null 2>&1; then
-            gh release upload "${GITHUB_REF_NAME}" dist/* --repo NeurodataWithoutBorders/pynwb --clobber
+          if gh release view "${GITHUB_REF_NAME}" --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" dist/* --repo "$GITHUB_REPOSITORY" --clobber
           else
             gh release create "${GITHUB_REF_NAME}" dist/* \
-              --repo NeurodataWithoutBorders/pynwb \
+              --repo "$GITHUB_REPOSITORY" \
               --title "${GITHUB_REF_NAME}" \
               "${notes_args[@]}"
           fi

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -3,9 +3,8 @@ on:
   push:
     branches:
       - dev
-    tags-ignore:  # exclude tags created by "ci_addons publish_github_release"
+    tags-ignore:  # exclude the rolling tag that the deploy-dev job moves to each dev commit
       - 'latest'
-      - 'latest-tmp'
   pull_request:
 
 concurrency:
@@ -238,32 +237,33 @@ jobs:
     needs: [run-tests, run-gallery-tests, run-tests-on-conda, run-ros3-tests, run-gallery-ros3-tests]
     if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # create the "latest" pre-release and move its tag
     steps:
-      - name: Checkout repo with submodules
-        uses: actions/checkout@v7
-        with:
-          submodules: 'recursive'
-          fetch-depth: 0  # tags are required for versioneer to determine the version
-
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.14'
-
       - name: Download wheel and source distributions from artifact
         uses: actions/download-artifact@v8
         with:
           name: distributions
           path: dist
 
-      - name: Publish wheel and source distributions as a GitHub release
+      - name: Publish wheel and source distributions as a GitHub pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install scikit-ci-addons
-          ci_addons publish_github_release NeurodataWithoutBorders/pynwb  \
-              --prerelease-packages "dist/*" \
-              --prerelease-sha $GITHUB_SHA \
-              --prerelease-packages-clear-pattern "*" \
-              --prerelease-packages-keep-pattern "*dev<COMMIT_DISTANCE>*" \
-              --token ${{ secrets.BOT_GITHUB_TOKEN }} \
-              --re-upload
+          ls -1 dist
+          # The "latest" pre-release is a rolling pointer to the tip of dev, holding only the
+          # distributions built from that commit. Delete it and its tag, then recreate both, so
+          # that the tag, the target commit, and the attached artifacts stay consistent.
+          if gh release view latest --repo "$REPO" > /dev/null 2>&1; then
+            gh release delete latest --repo "$REPO" --yes --cleanup-tag
+          fi
+          # A tag can outlive its release if a previous run was interrupted between the two deletes.
+          gh api --silent -X DELETE "repos/$REPO/git/refs/tags/latest" 2> /dev/null || true
+
+          gh release create latest dist/* \
+            --repo "$REPO" \
+            --target "$GITHUB_SHA" \
+            --title "Latest" \
+            --prerelease \
+            --notes "Pre-release build of the dev branch at commit $GITHUB_SHA."

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -249,20 +249,19 @@ jobs:
       - name: Publish wheel and source distributions as a GitHub pre-release
         env:
           GH_TOKEN: ${{ github.token }}
-          REPO: ${{ github.repository }}
         run: |
           ls -1 dist
           # The "latest" pre-release is a rolling pointer to the tip of dev, holding only the
           # distributions built from that commit. Delete it and its tag, then recreate both, so
           # that the tag, the target commit, and the attached artifacts stay consistent.
-          if gh release view latest --repo "$REPO" > /dev/null 2>&1; then
-            gh release delete latest --repo "$REPO" --yes --cleanup-tag
+          if gh release view latest --repo "$GITHUB_REPOSITORY" > /dev/null 2>&1; then
+            gh release delete latest --repo "$GITHUB_REPOSITORY" --yes --cleanup-tag
           fi
           # A tag can outlive its release if a previous run was interrupted between the two deletes.
-          gh api --silent -X DELETE "repos/$REPO/git/refs/tags/latest" 2> /dev/null || true
+          gh api --silent -X DELETE "repos/$GITHUB_REPOSITORY/git/refs/tags/latest" 2> /dev/null || true
 
           gh release create latest dist/* \
-            --repo "$REPO" \
+            --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "Latest" \
             --prerelease \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Fixed
 - Fixed `mock_electrodes` (and `mock_ElectricalSeries`) sizing the auto-created `ElectrodesTable` to a fixed 5 rows while the `DynamicTableRegion` followed `n_electrodes`, which raised an `IndexError` under HDMF 4.x+ for any data with more than 5 channels. The table is now sized to `n_electrodes`. @h-mayorquin [#2214](https://github.com/NeurodataWithoutBorders/pynwb/pull/2214)
 - Fixed `read_nwb` and `_get_backend` reporting a nonexistent path as an unrecognized backend (and, without hdmf-zarr installed, suggesting `pip install hdmf-zarr`). A missing file now raises a `FileNotFoundError`. @rly [#2222](https://github.com/NeurodataWithoutBorders/pynwb/pull/2222)
+- Fixed the `Deploy pre-release from dev` CI job, which failed with a `404` from the GitHub API because `scikit-ci-addons` resolved the `latest` tag to one of two duplicate draft releases it had itself created. Both release paths now use the `gh` CLI. @rly [#2225](https://github.com/NeurodataWithoutBorders/pynwb/pull/2225)
 
 
 ## PyNWB 4.0.0 (June 29, 2026)

--- a/docs/source/make_a_release.rst
+++ b/docs/source/make_a_release.rst
@@ -128,22 +128,21 @@ Publish release on PyPI: Step-by-step
 
   .. important::
 
-      This will trigger the "Deploy release" GitHub Actions workflow which will automatically
-      upload the wheels and source distribution to both the  `PyNWB PyPI project page`_ and a
-      new :pynwb:`GitHub release <releases>` using the nwb-bot account.
+      This will trigger the "Deploy release" GitHub Actions workflow, which uploads the wheel and
+      source distribution to the `PyNWB PyPI project page`_ via PyPI trusted publishing and creates
+      a new :pynwb:`GitHub release <releases>` as the github-actions bot.
 
 
 7. Check the status of the builds on :pynwb:`GitHub Actions <actions>`.
 
 
 8. Once the builds are completed, check that the distributions are available on `PyNWB PyPI project page`_ and that
-   a new :pynwb:`GitHub release <releases>` was created.
+   a new :pynwb:`GitHub release <releases>` was created. The workflow fills the release notes from this version's
+   section of ``CHANGELOG.md``, so check that they match. If the section was empty or its heading did not match the
+   tag, the workflow falls back to auto-generated notes, which should be replaced by hand.
 
 
-9. Copy the release notes from ``CHANGELOG.md`` to the newly created :pynwb:`GitHub release <releases>`.
-
-
-10. Create a clean testing environment to test the installation.
+9. Create a clean testing environment to test the installation.
 
   On bash/zsh:
 
@@ -155,7 +154,7 @@ Publish release on PyPI: Step-by-step
   On other shells, see the `Python instructions for creating a virtual environment`_.
 
 
-11. Test the installation:
+10. Test the installation:
 
   .. code::
 
@@ -163,7 +162,7 @@ Publish release on PyPI: Step-by-step
       python -c "import pynwb; print(pynwb.__version__)"
 
 
-12. Cleanup
+11. Cleanup
 
   On bash/zsh:
 

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -76,7 +76,7 @@ Versioning and Releasing
 PyNWB uses versioneer_ for versioning source and wheel distributions. Versioneer creates a semi-unique release
 name for the wheels that are created. It requires a version control system (git in PyNWB's case) to generate a release
 name. After all the tests pass, GitHub Actions creates both a wheel (\*.whl) and source distribution (\*.tar.gz) for
-Python 3 and uploads them back to GitHub as a :pynwb:`releases`. Pushing to "dev" attaches them to the rolling "latest"
+Python 3 and uploads them back to GitHub as a :pynwb:`GitHub release <releases>`. Pushing to "dev" attaches them to the rolling "latest"
 pre-release; pushing a MAJOR.MINOR.PATCH tag attaches them to a release for that tag and uploads them to PyPI.
 Versioneer makes it possible to get the source distribution from GitHub
 and create wheels directly without having to use a version control system because it hardcodes versions in the source

--- a/docs/source/software_process.rst
+++ b/docs/source/software_process.rst
@@ -75,15 +75,17 @@ Versioning and Releasing
 
 PyNWB uses versioneer_ for versioning source and wheel distributions. Versioneer creates a semi-unique release
 name for the wheels that are created. It requires a version control system (git in PyNWB's case) to generate a release
-name. After all the tests pass, CircleCI creates both a wheel (\*.whl) and source distribution (\*.tar.gz) for Python 3
-and uploads them back to GitHub as a :pynwb:`releases`. Versioneer makes it possible to get the source distribution from GitHub
+name. After all the tests pass, GitHub Actions creates both a wheel (\*.whl) and source distribution (\*.tar.gz) for
+Python 3 and uploads them back to GitHub as a :pynwb:`releases`. Pushing to "dev" attaches them to the rolling "latest"
+pre-release; pushing a MAJOR.MINOR.PATCH tag attaches them to a release for that tag and uploads them to PyPI.
+Versioneer makes it possible to get the source distribution from GitHub
 and create wheels directly without having to use a version control system because it hardcodes versions in the source
 distribution.
 
 It is important to note that GitHub automatically generates source code archives in .zip and .tar.gz formats and
 attaches those files to all releases as an asset. These files currently do not contain the submodules within PyNWB and
 thus do not serve as a complete installation. For a complete source code archive, use the source distribution generated
-by CircleCI, typically named `pynwb-{version}.tar.gz`.
+by GitHub Actions, typically named `pynwb-{version}.tar.gz`.
 
 .. _versioneer: https://github.com/python-versioneer/python-versioneer
 


### PR DESCRIPTION
## Motivation

The `Deploy pre-release from dev` job [failed](https://github.com/NeurodataWithoutBorders/pynwb/actions/runs/29794565105/job/88525067854) with `404 Client Error` from the GitHub API.

`scikit-ci-addons` (last released 2019) drives `githubrelease` (last released 2022), which resolves a tag to the **first** release with a matching `tag_name` and moves the rolling `latest` tag through a non-atomic rename dance. That had left two draft releases tagged `latest`: the run uploaded assets to one, then tried to edit the other and 404'd. Since the failing call was the first half of a `draft=True` → `draft=False` bounce, the public `latest` pre-release page was left empty and `refs/tags/latest` deleted, plus a stray `refs/tags/latest-tmp-tmp`. The duplicate release and stray tag have been deleted manually; this PR keeps them from coming back.

## What changed

Release paths only. Mirrors hdmf-dev/hdmf#1517 and the release parts of hdmf-dev/hdmf#1518.

**`run_tests.yml` (`deploy-dev`)** — `ci_addons publish_github_release` → `gh release`. The `latest` release and tag are deleted and recreated on each dev push, so the tag, target commit, and artifacts always agree; duplicates cannot accumulate. Authenticates with `GITHUB_TOKEN` (`contents: write`) instead of `BOT_GITHUB_TOKEN`. Dropped the checkout and `setup-python` steps (nothing reads the tree or runs Python) and the obsolete `latest-tmp` from `tags-ignore`.

**`deploy_release.yml`** — `twine` with a long-lived password on the command line → `pypa/gh-action-pypi-publish` with OIDC trusted publishing. `githubrelease` → `gh release`, idempotent on re-run, with notes taken from the version's `CHANGELOG.md` section (falling back to `--generate-notes`). Added a source-distribution install test, which was missing. `persist-credentials: false` on checkout.

Not included from hdmf-dev/hdmf#1518: SHA pinning, composite action, zizmor, dependabot, repo-wide `permissions`.

**Docs** — `make_a_release.rst` and the release PR template drop the now-automatic "copy the release notes" step and the "nwb-bot account" note. `software_process.rst` credited **CircleCI** with building and uploading the distributions; there is no CircleCI config in this repo (pre-existing staleness, fixed while auditing the release docs).

## ⚠️ Required before the next tagged release

Trusted publishing needs one-time setup that cannot be done from the repo:

- PyPI → `pynwb` → Settings → Publishing → add a GitHub publisher: owner `NeurodataWithoutBorders`, repo `pynwb`, workflow `deploy_release.yml`, environment `pypi`.
- Create a `pypi` repository environment (Settings → Environments).

Afterwards `BOT_PYPI_USER` / `BOT_PYPI_PASSWORD` can be removed. `BOT_GITHUB_TOKEN` is no longer used by either release path.

## Notes

- Releases will be authored by `github-actions[bot]` rather than the bot PAT account. Nothing triggers on `release:` events, and `GITHUB_TOKEN`-created tags do not start workflow runs.
- The first `dev` push after merge deletes the leftover draft release and publishes a clean `latest` with a real tag, restoring the public pre-release page.

## How to test the behavior?

```
Cannot be fully exercised without a dev push / tag push plus the PyPI trusted publisher.

Verified locally:
- all workflows parse as YAML; both release shell blocks pass `bash -n`
- both tox install steps run against real artifacts: `tox -e build` then wheelinstall
  from the wheel and from the .tar.gz (the sdist run rebuilds via hatchling, confirming
  --recreate makes it a real install rather than a no-op)
- the awk notes extraction against the real CHANGELOG.md: 4.0.0 -> 46 lines, 3.1.3 -> 15
  (prefix matching handles the date suffix in the heading), 9.9.9 -> --generate-notes
- every gh flag used confirmed present in the gh CLI
- sphinx `-W` linkcheck and the Read the Docs build pass on the docs changes
```

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [x] Does the PR clearly describe the problem and the solution?
- [x] Have you reviewed our Contributing Guide?
- [ ] Does the PR use "Fix #XXX" notation? (no associated issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
