### PR TITLE
Fix `NWBData` shadowing the data attribute it inherits from `Data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PyNWB Changelog
 
+## PyNWB 4.1.1 (Unreleased)
+
+### Fixed
+- Fixed `set_data_io` being silently ignored on `NWBData` subclasses (`GrayscaleImage`, `RGBImage`, `RGBAImage`, `ExternalImage`, `ImageReferences`, and `ScratchData`), so requested chunking and compression were dropped without warning and the datasets were written uncompressed. `NWBData` declared its own data storage and `data` property, shadowing the ones inherited from `hdmf.container.Data`, so the inherited `set_data_io` wrapped the parent's attribute while `.data` kept reading the child's. `NWBData` now uses the inherited storage, which also makes `.data` reflect `transform`, `append`, and `extend`, and return the value coerced by `Data.__init__` (a `pandas.Series` passed as `data` now reads back as the `ndarray` that is actually written). @h-mayorquin [#2233](https://github.com/NeurodataWithoutBorders/pynwb/pull/2233)
+
 ## PyNWB 4.1.0 (July 23, 2026)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 - Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. @bendichter [#2236](https://github.com/NeurodataWithoutBorders/pynwb/pull/2236)
-- Fixed `set_data_io` being silently ignored on `NWBData` subclasses (`GrayscaleImage`, `RGBImage`, `RGBAImage`, `ExternalImage`, `ImageReferences`, and `ScratchData`), so requested chunking and compression were dropped without warning and the datasets were written uncompressed. `NWBData` declared its own data storage and `data` property, shadowing the ones inherited from `hdmf.container.Data`, so the inherited `set_data_io` wrapped the parent's attribute while `.data` kept reading the child's. `NWBData` now uses the inherited storage, which also makes `.data` reflect `transform`, `append`, and `extend`, and return the value coerced by `Data.__init__` (a `pandas.Series` passed as `data` now reads back as the `ndarray` that is actually written). @h-mayorquin [#2233](https://github.com/NeurodataWithoutBorders/pynwb/pull/2233)
+- Fixed `set_data_io` being silently ignored on `NWBData` subclasses (`GrayscaleImage`, `RGBImage`, `RGBAImage`, `ExternalImage`, `ImageReferences`, and `ScratchData`), so requested chunking and compression were dropped without warning and the datasets were written uncompressed. @h-mayorquin [#2233](https://github.com/NeurodataWithoutBorders/pynwb/pull/2233)
 
 
 ## PyNWB 4.1.0 (July 23, 2026)

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -1,7 +1,5 @@
 from warnings import warn
 
-import numpy as np
-
 from hdmf import Container, Data
 from hdmf.container import AbstractContainer, MultiContainerInterface as hdmf_MultiContainerInterface, Table
 from hdmf.common import DynamicTable, DynamicTableRegion  # noqa: F401
@@ -102,32 +100,6 @@ class NWBData(NWBMixin, Data):
             allow_positional=AllowPositional.WARNING,)
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-    def __getitem__(self, args):
-        if isinstance(self.data, (tuple, list)) and isinstance(args, (tuple, list)):
-            return [self.data[i] for i in args]
-        return self.data[args]
-
-    def append(self, arg):
-        """
-        Append a single element to the data
-
-        Note: The arg to append should be 1 dimension less than the data.
-        For example, if the data is a 2D array, arg should be a 1D array.
-        Appending to scalar data is not supported. To append multiple
-        elements, use extend.
-        """
-        if not isinstance(self.data, (list, np.ndarray)):
-            raise ValueError("NWBData cannot append to object of type '%s'" % type(self.data))
-        super().append(arg)
-
-    def extend(self, arg):
-        """
-        Extend the data with multiple elements.
-        """
-        if not isinstance(self.data, (list, np.ndarray)):
-            raise ValueError("NWBData cannot extend object of type '%s'" % type(self.data))
-        super().extend(arg)
 
 
 @register_class('ScratchData', CORE_NAMESPACE)

--- a/src/pynwb/core.py
+++ b/src/pynwb/core.py
@@ -102,16 +102,6 @@ class NWBData(NWBMixin, Data):
             allow_positional=AllowPositional.WARNING,)
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.__data = kwargs['data']
-
-    @property
-    def data(self):
-        """The data managed by this object"""
-        return self.__data
-
-    def __len__(self):
-        """Size of the data. Same as len(self.data)"""
-        return len(self.__data)
 
     def __getitem__(self, args):
         if isinstance(self.data, (tuple, list)) and isinstance(args, (tuple, list)):
@@ -127,25 +117,17 @@ class NWBData(NWBMixin, Data):
         Appending to scalar data is not supported. To append multiple
         elements, use extend.
         """
-        if isinstance(self.data, list):
-            self.data.append(arg)
-        elif isinstance(self.data, np.ndarray):
-            self.__data = np.concatenate((self.__data, [arg]))
-        else:
-            msg = "NWBData cannot append to object of type '%s'" % type(self.__data)
-            raise ValueError(msg)
+        if not isinstance(self.data, (list, np.ndarray)):
+            raise ValueError("NWBData cannot append to object of type '%s'" % type(self.data))
+        super().append(arg)
 
     def extend(self, arg):
         """
         Extend the data with multiple elements.
         """
-        if isinstance(self.data, list):
-            self.data.extend(arg)
-        elif isinstance(self.data, np.ndarray):
-            self.__data = np.concatenate((self.__data, arg))
-        else:
-            msg = "NWBData cannot extend object of type '%s'" % type(self.__data)
-            raise ValueError(msg)
+        if not isinstance(self.data, (list, np.ndarray)):
+            raise ValueError("NWBData cannot extend object of type '%s'" % type(self.data))
+        super().extend(arg)
 
 
 @register_class('ScratchData', CORE_NAMESPACE)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -2,10 +2,11 @@ from datetime import datetime
 from dateutil.tz import tzlocal
 
 import numpy as np
+from hdmf.backends.hdf5 import H5DataIO
 from hdmf.utils import docval
 
 from pynwb import NWBFile, TimeSeries, available_namespaces
-from pynwb.core import NWBContainer, NWBData
+from pynwb.core import NWBContainer, NWBData, ScratchData
 from pynwb.testing import TestCase
 
 
@@ -99,7 +100,24 @@ class TestNWBData(TestCase):
         obj = NWBData(name="obj1", data=1)
         with self.assertRaises(ValueError):
             obj.extend(2)
-    
+
+    def test_set_data_io_visible_through_data(self):
+        """set_data_io is inherited from Data, so its wrapping must be visible on NWBData.data.
+
+        NWBData used to declare its own data storage, which shadowed the parent's, so the DataIO
+        was applied to the parent attribute and then never read back. See #2233.
+        """
+        obj = MyNWBData("obj1", data=np.array([1, 2, 3]))
+        obj.set_data_io(H5DataIO, dict(compression="gzip"))
+        self.assertIsInstance(obj.data, H5DataIO)
+        self.assertEqual(obj.data.io_settings["compression"], "gzip")
+
+    def test_set_data_io_visible_through_data_on_scratch_data(self):
+        """The shadow was on NWBData, so every subclass was affected, not only the image types."""
+        obj = ScratchData(name="obj1", data=np.array([1, 2, 3]), description="test")
+        obj.set_data_io(H5DataIO, dict(compression="gzip"))
+        self.assertIsInstance(obj.data, H5DataIO)
+
     def test_slicing_list_with_list(self):
         obj = MyNWBData("obj1", data=[[1, 2, 3], [4, 5, 6]])
         self.assertEqual(obj[[1,]], [[4, 5, 6]])


### PR DESCRIPTION
## Motivation

I found this while [trying to get neuroconv's default chunking and gzip compression](https://github.com/catalystneuro/neuroconv/pull/1835) to apply to `GrayscaleImage` datasets, and discovering that it silently did nothing. `NWBData` re-declares `self.__data` in its `__init__` and overrides the `data` property to read it, which shadows the storage it inherits from `hdmf.container.Data`. The inherited `set_data_io` writes the parent's attribute while `.data` reads the child's, so the `DataIO` wrapping is applied and then never seen again, and the dataset is written uncompressed with nothing warning you. This affects every `NWBData` subclass, so `ScratchData`, `ImageReferences`, `ExternalImage` and the image types, and the same shadow leaves `transform`, `append`, and `extend` operating on a different attribute than the parent thinks it is holding.

The fix is to let the parent own the storage. The private attribute and the `data` property go, `__len__` was a duplicate of hdmf's so it goes with them, and `append` and `extend` become a type guard that delegates to `super()`, which keeps the existing error message for scalar data.

Two behavior changes worth a reviewer's attention. `Data.__init__` runs `coerce_pandas_data` before storing while `NWBData` stashed the raw argument, so `.data` now returns the coerced value, meaning a `pandas.Series` passed as `data` reads back as the `ndarray` that was always the thing actually written to the file. And because `append` and `extend` now go through hdmf's `append_data` and `extend_data`, appending an array to ndarray-backed data concatenates instead of raising `ValueError: all the input arrays must have same number of dimensions`. That is the reproduction in #727, which this improves but does not close, since the list and ndarray cases still diverge. The existing test suite passes without modification.

## How to test the behavior?

```python
import numpy as np
from hdmf.backends.hdf5 import H5DataIO
from pynwb.image import GrayscaleImage

image = GrayscaleImage(name="image", data=np.zeros((4, 4)))
image.set_data_io(H5DataIO, dict(compression="gzip"))

# before: <class 'numpy.ndarray'>, the H5DataIO is stranded on the parent attribute
# after:  <class 'hdmf.backends.hdf5.h5_utils.H5DataIO'>
print(type(image.data))
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [ ] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
