### PR TITLE
Keep wide DataFrames in the tutorials inside the content column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # PyNWB Changelog
 
+## PyNWB 4.2.0 (Upcoming)
+
+### Fixed
+- Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. Sphinx-gallery emits DataFrame output as a raw HTML table, which the theme's responsive table wrapper does not apply to, so a table wider than the content column overflowed with no way to scroll it. The output container now scrolls horizontally and cells stay on one line, which also keeps the columns aligned with their headers. The `Linking to External Resources (HERD)` tutorial was the most affected. @bendichter
+
+
 ## PyNWB 4.1.0 (July 23, 2026)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## PyNWB 4.2.0 (Upcoming)
 
 ### Fixed
-- Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. Sphinx-gallery emits DataFrame output as a raw HTML table, which the theme's responsive table wrapper does not apply to, so a table wider than the content column overflowed with no way to scroll it. The output container now scrolls horizontally and cells stay on one line, which also keeps the columns aligned with their headers. The `Linking to External Resources (HERD)` tutorial was the most affected. @bendichter
+- Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. @bendichter [#2236](https://github.com/NeurodataWithoutBorders/pynwb/pull/2236)
 
 
 ## PyNWB 4.1.0 (July 23, 2026)

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -26,3 +26,26 @@ button.copybtn {
     border: none;
     background: none;
 }
+
+/* Pandas DataFrames in sphinx-gallery output.
+
+   Sphinx-gallery emits the DataFrame as a raw HTML table that no responsive wrapper
+   applies to, so a table wider than the content column spills into the right margin
+   instead of scrolling. Scroll the container, and let each cell keep to one line so
+   the columns line up with their headers. Pandas already caps cell text at
+   display.max_colwidth, which bounds how wide the table can get. */
+.rendered_html {
+    overflow-x: auto;
+}
+
+.rendered_html table.dataframe {
+    table-layout: auto;
+    width: auto;
+    margin-left: 0;
+    margin-right: 0;
+}
+
+.rendered_html table.dataframe th,
+.rendered_html table.dataframe td {
+    white-space: nowrap;
+}


### PR DESCRIPTION
## Motivation

Wide pandas DataFrames in the tutorials render past the right edge of the content column, with no way to scroll them. The `Linking to External Resources (HERD)` tutorial is the most visible case, since `herd.to_dataframe()` has twelve columns, but any sufficiently wide DataFrame in the gallery has the same problem.

Sphinx-gallery emits DataFrame output as a raw HTML `<table class="dataframe">` inside a plain `<div class="output_subarea ... rendered_html">`. The RTD theme's responsive table wrapper (`.wy-table-responsive`, which is what normally supplies `overflow-x`) is only applied to docutils tables, so it never wraps this one. On the built HERD page the table wants about 1100px inside a container of about 700px, and the container's `overflow-x` computes to `visible`, so the table simply draws outside the content box. Sphinx-gallery's own `table-layout: fixed` rule compounds it by breaking each object ID across four lines and pulling the columns away from their headers.

## How to test the behavior

Build the docs and open `tutorials/general/plot_external_resources.html`, or limit the gallery to the one example:

```
python -m sphinx -b html -D sphinx_gallery_conf.filename_pattern=plot_external_resources docs/source docs/_build/html
```

Scroll to the `Inspect the HERD` section.

## Before

![before](https://raw.githubusercontent.com/bendichter/pynwb/pr-assets/dataframe-table-css/herd_before.png)

## After

![after](https://raw.githubusercontent.com/bendichter/pynwb/pr-assets/dataframe-table-css/herd_after.png)

## The change

Three rules in `docs/source/_static/css/custom.css`:

- `.rendered_html` gets `overflow-x: auto`, so the output container scrolls instead of spilling. This only adds a scrollbar when the content actually overflows, so narrow output is unaffected.
- `table.dataframe` goes back to `table-layout: auto` with `width: auto` and no auto margins, which sizes columns to their content and left-aligns the table with the surrounding text instead of centering it.
- Cells are kept to a single line, so each row reads across cleanly and the columns line up with their headers. Pandas already truncates cell text at `display.max_colwidth`, which bounds how wide the table can get.

I checked the result at both a 1440px and a 760px viewport, and on the narrow single-column tables in the same tutorial (`herd.keys.to_dataframe()`), which now sit left-aligned with the body text rather than floating in the center.

## Checklist

- [x] Did you update `CHANGELOG.md` with your changes?
- [ ] Does the PR clearly describe the problem and the solution?
- [ ] Have you reviewed our `Contributing Guide`?
- [ ] Does the PR use "Fix #XXX" notation to tell GitHub to close the corresponding issue upon merge of the PR?

## A separate note

`docs/source/_static/theme_overrides.css` is an earlier attempt at this same problem. It sets `overflow: visible !important` on `.wy-table-responsive`, which would defeat scrolling, but it is not listed in `html_css_files` in `conf.py` and so is never loaded. It had no effect on this bug either way. I left it alone here, but it looks like dead code worth deleting separately.
