### PR TITLE
Fix the Units waveforms test fixtures and assert the doubly indexed structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fixed `mock_DeviceModel` defaulting `manufacturer` to `None`. The mock now defaults it to `"manufacturer"`. @HugoFara [#2232](https://github.com/NeurodataWithoutBorders/pynwb/pull/2232)
 - Fixed reading a file whose dates carry a sub-minute UTC offset (e.g. `1900-10-01T00:00:00-05:50:36`). @h-mayorquin [#2230](https://github.com/NeurodataWithoutBorders/pynwb/pull/2230)
 - Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. @bendichter [#2236](https://github.com/NeurodataWithoutBorders/pynwb/pull/2236)
+- Fixed the `Units` waveforms test fixtures, which labelled the dimensions of the 3-D `add_unit` waveforms input as `(num_electrodes, num_spikes, num_samples)` when `add_unit` reads them as `(num_spikes, num_electrodes, num_samples)`, and so encoded a number of spike events that disagreed with the unit's `spike_times`. Added `TestUnitsIO.test_waveforms_structure` asserting `waveforms_index_index`, `waveforms_index`, and the 2-D `waveforms` dataset after a roundtrip. @adityasingh2400 [#2240](https://github.com/NeurodataWithoutBorders/pynwb/pull/2240)
 
 
 ## PyNWB 4.1.0 (July 23, 2026)

--- a/tests/integration/hdf5/test_misc.py
+++ b/tests/integration/hdf5/test_misc.py
@@ -14,40 +14,30 @@ class TestUnitsIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
         """ Return the test Units to read/write """
+        # A 3-D waveforms input to add_unit is ordered (num_spikes, num_electrodes, num_samples).
+        # Dim 0 indexes spike events and becomes waveforms_index_index, dim 1 indexes the electrodes
+        # that observed each spike event and becomes waveforms_index, and dim 2 holds the samples of
+        # each waveform. Every unit below has one waveform per electrode per spike time, so the
+        # number of spike events matches the number of spike_times.
         ut = Units(name='UnitsTest', description='a simple table for testing Units')
         ut.add_unit(spike_times=[0., 1., 2.], obs_intervals=[[0., 1.], [2., 3.]],
                     waveform_mean=[1., 2., 3.], waveform_sd=[4., 5., 6.],
-                    waveforms=[
-                        [  # elec 1
-                            [1, 2, 3],
-                            [1, 2, 3],
-                            [1, 2, 3]
-                        ], [  # elec 2
-                            [1, 2, 3],
-                            [1, 2, 3],
-                            [1, 2, 3]
+                    waveforms=[  # 3 spike times, 2 electrodes, 3 samples
+                        [                # spike 1
+                            [1, 2, 3],   # elec 1, [sample 1, sample 2, sample 3]
+                            [4, 5, 6]    # elec 2
+                        ], [             # spike 2
+                            [7, 8, 9],
+                            [10, 11, 12]
+                        ], [             # spike 3
+                            [13, 14, 15],
+                            [16, 17, 18]
                         ]
                     ])
         ut.add_unit(spike_times=[3., 4., 5.], obs_intervals=[[2., 5.], [6., 7.]],
                     waveform_mean=[1., 2., 3.], waveform_sd=[4., 5., 6.],
-                    waveforms=np.array([
-                        [     # elec 1
-                            [1, 2, 3],  # spike 1, [sample 1, sample 2, sample 3]
-                            [1, 2, 3],  # spike 2
-                            [1, 2, 3],  # spike 3
-                            [1, 2, 3]   # spike 4
-                        ], [  # elec 2
-                            [1, 2, 3],  # spike 1
-                            [1, 2, 3],  # spike 2
-                            [1, 2, 3],  # spike 3
-                            [1, 2, 3]   # spike 4
-                        ], [  # elec 3
-                            [1, 2, 3],  # spike 1
-                            [1, 2, 3],  # spike 2
-                            [1, 2, 3],  # spike 3
-                            [1, 2, 3]   # spike 4
-                        ]
-                    ]))
+                    # 3 spike times, 4 electrodes, 3 samples, continuing the sample values above
+                    waveforms=np.arange(19, 55).reshape(3, 4, 3))
         ut.waveform_rate = 40000.
         ut.resolution = 1/40000
         return ut
@@ -70,6 +60,24 @@ class TestUnitsIO(AcquisitionH5IOMixin, TestCase):
         np.testing.assert_array_equal(received, [[2., 5.], [6., 7.]])
         np.testing.assert_array_equal(ut['obs_intervals'][:], [[[0., 1.], [2., 3.]], [[2., 5.], [6., 7.]]])
 
+    def test_waveforms_structure(self):
+        """ Test the structure of the doubly indexed waveforms column read from file """
+        ut = self.roundtripContainer()
+        waveforms_index_index = ut['waveforms']
+        waveforms_index = waveforms_index_index.target
+        waveforms = waveforms_index.target
+
+        # waveforms_index_index holds the number of spike events of each unit
+        np.testing.assert_array_equal(waveforms_index_index.data[:], [3, 6])
+        # waveforms_index holds the number of waveforms, one per electrode, of each spike event
+        np.testing.assert_array_equal(waveforms_index.data[:], [2, 4, 6, 10, 14, 18])
+        # the waveforms dataset itself is 2-D, (num_waveforms, num_samples)
+        np.testing.assert_array_equal(waveforms.data[:], np.arange(1, 55).reshape(18, 3))
+
+        # unit 0 has 2 electrodes per spike event, unit 1 has 4
+        self.assertEqual([len(spike_event) for spike_event in waveforms_index_index[0]], [2, 2, 2])
+        self.assertEqual([len(spike_event) for spike_event in waveforms_index_index[1]], [4, 4, 4])
+
 
 class TestUnitsWaveformsOnlyIO(AcquisitionH5IOMixin, TestCase):
     """Test roundtripping waveform metadata when only waveforms are present."""
@@ -78,13 +86,14 @@ class TestUnitsWaveformsOnlyIO(AcquisitionH5IOMixin, TestCase):
         ut = Units(name='UnitsWaveformsOnlyTest', description='a simple table for testing Units waveforms')
         ut.add_unit(
             spike_times=[0., 1., 2.],
-            waveforms=[
-                [
-                    [1, 2, 3],
+            waveforms=[  # 3 spike times, 2 electrodes, 3 samples
+                [                # spike 1
+                    [1, 2, 3],   # elec 1, [sample 1, sample 2, sample 3]
+                    [1, 2, 3]    # elec 2
+                ], [             # spike 2
                     [1, 2, 3],
                     [1, 2, 3]
-                ], [
-                    [1, 2, 3],
+                ], [             # spike 3
                     [1, 2, 3],
                     [1, 2, 3]
                 ]
@@ -92,13 +101,14 @@ class TestUnitsWaveformsOnlyIO(AcquisitionH5IOMixin, TestCase):
         )
         ut.add_unit(
             spike_times=[3., 4., 5.],
-            waveforms=np.array([
+            waveforms=np.array([  # 3 spike times, 2 electrodes, 3 samples
                 [
-                    [1, 2, 3],
                     [1, 2, 3],
                     [1, 2, 3]
                 ], [
                     [1, 2, 3],
+                    [1, 2, 3]
+                ], [
                     [1, 2, 3],
                     [1, 2, 3]
                 ]


### PR DESCRIPTION
## Motivation

Addresses the test-fixture half of #2220. I have deliberately left `misc.py` and the `waveforms_desc` docstring alone so this does not conflict with #1936, which is already touching that text.

For the doubly indexed `Units.waveforms` column, `add_unit` interprets a 3-D per-unit input as `(num_spikes, num_electrodes, num_samples)`. Dim 0 becomes `waveforms_index_index`, the spike events of a unit, dim 1 becomes `waveforms_index`, the waveforms of a spike event with one per electrode, and dim 2 is the samples of each waveform. That matches the schema, which says the `waveforms_index` column "indexes which waveforms in this column belong to the same spike event for a given unit, where each waveform was recorded from a different electrode" and the `waveforms_index_index` column "indexes the `waveforms_index` column to indicate which spike events belong to a given unit".

Both `TestUnitsIO` and `TestUnitsWaveformsOnlyIO` label these the other way round, with the outer dimension commented as electrodes and the middle one as spikes. Because of that the fixtures also contradict their own `spike_times`: `TestUnitsIO` declares 3 `spike_times` for each unit but encodes 2 spike events for the first unit and 3 for the second, and `TestUnitsWaveformsOnlyIO` declares 3 `spike_times` per unit but encodes 2 spike events. Neither test asserted anything about the waveforms columns, so nothing caught it.

## Changes

Both fixtures are reordered to `(num_spikes, num_electrodes, num_samples)` so the number of spike events matches the number of `spike_times`, and the comments now describe what `add_unit` actually does. `TestUnitsIO` gets distinct sample values, `1` through `54`, instead of the repeated `[1, 2, 3]` rows, so a transposed or mis-flattened write is detectable rather than looking identical.

A new `test_waveforms_structure` roundtrips the container and asserts `waveforms_index_index`, `waveforms_index`, and the 2-D `waveforms` dataset, plus the per-spike electrode counts. This is the first coverage of the doubly ragged structure of this column.

## How to test the behavior?

Running the new assertions against the old fixture shows the inconsistency directly. The old first unit had 3 `spike_times` but only 2 spike events:

```
>       np.testing.assert_array_equal(waveforms_index_index.data[:], [3, 6])
E       AssertionError:
E       Arrays are not equal
E        [0]: 2 (ACTUAL), 3 (DESIRED)
E        [1]: 5 (ACTUAL), 6 (DESIRED)
E        ACTUAL: array([2, 5], dtype=uint8)
E        DESIRED: array([3, 6])

FAILED tests/integration/hdf5/test_misc.py::TestUnitsIO::test_waveforms_structure
1 failed, 16 deselected
```

With the corrected fixtures:

```
$ pytest tests/integration/hdf5/test_misc.py tests/unit/test_misc.py -q
61 passed, 662 subtests passed in 99.98s
```

The equivalent minimal repro of the ordering, on `dev` and unchanged by this PR:

```python
import numpy as np
from pynwb.misc import Units

u = Units(name='units')
u.add_unit(spike_times=[0.], waveforms=np.arange(1 * 5 * 7).reshape(1, 5, 7))
wf = u['waveforms']
print(np.asarray(wf.target.target.data).shape)  # (5, 7)  -> (num_waveforms, num_samples)
print(list(np.asarray(wf.target.data)))         # [5]     -> 5 electrodes for the 1 spike event
```

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged. This PR covers only part of #2220, so it references the issue without a closing keyword.
