### PR TITLE
Update nwb-schema to 2.11.0 and require HDMF 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Added support for NWB Schema 2.11.0
   - The `unit` attribute of `Units.waveform_mean`, `Units.waveform_sd`, and `Units.waveforms` now has a default value of `"volts"` instead of a fixed value of `"volts"`.
   - `Units.waveform_mean`, `Units.waveform_sd`, and `Units.waveforms` have a new optional `time_before_peak_in_ms` attribute, exposed as the `waveform_time_before_peak_in_ms` argument and field of `Units`. It holds the time, in milliseconds, from the start of each waveform to the spike peak, i.e., the alignment point used during spike sorting. @rly [#2237](https://github.com/NeurodataWithoutBorders/pynwb/pull/2237)
-  - Incorporates HDMF Common Schema 1.10.0, which changes `MeaningsTable.target` from a link to an object-reference attribute. Reading and writing `MeaningsTable` under this layout requires HDMF 6.2.0 or later.
+  - Incorporates HDMF Common Schema 1.10.0, which changes `MeaningsTable.target` from a link to an object-reference attribute.
+- Raised the minimum HDMF requirement to 6.2.0. HDMF 6.2.0 bundles HDMF Common Schema 1.10.0, matching the copy in NWB Schema 2.11.0, and writes the `unit` and `time_before_peak_in_ms` attributes on the `Units` waveform columns correctly. Under HDMF 6.1.0 those attributes fell back to their schema defaults on write. @rly
 
 ### Fixed
 - Fixed `Units.waveform_unit` having no effect on the written file. The `waveform_unit` passed to `Units` is now written to the `waveform_mean`, `waveform_sd`, and `waveforms` columns, and `"volts"` remains the default. PyNWB now also warns when the waveform columns of a file being read carry different `unit` or `sampling_rate` attributes, since only one value per attribute is kept on the `Units` container. @rly [#2162](https://github.com/NeurodataWithoutBorders/pynwb/issues/2162)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 ## PyNWB 4.1.1 (Unreleased)
 
 ### Changed
-- Added support for NWB Schema 2.10.1
+- Added support for NWB Schema 2.11.0
   - The `unit` attribute of `Units.waveform_mean`, `Units.waveform_sd`, and `Units.waveforms` now has a default value of `"volts"` instead of a fixed value of `"volts"`.
   - `Units.waveform_mean`, `Units.waveform_sd`, and `Units.waveforms` have a new optional `time_before_peak_in_ms` attribute, exposed as the `waveform_time_before_peak_in_ms` argument and field of `Units`. It holds the time, in milliseconds, from the start of each waveform to the spike peak, i.e., the alignment point used during spike sorting. @rly [#2237](https://github.com/NeurodataWithoutBorders/pynwb/pull/2237)
+  - Incorporates HDMF Common Schema 1.10.0, which changes `MeaningsTable.target` from a link to an object-reference attribute. Reading and writing `MeaningsTable` under this layout requires HDMF 6.2.0 or later.
 
 ### Fixed
 - Fixed `Units.waveform_unit` having no effect on the written file. The `waveform_unit` passed to `Units` is now written to the `waveform_mean`, `waveform_sd`, and `waveforms` columns, and `"volts"` remains the default. PyNWB now also warns when the waveform columns of a file being read carry different `unit` or `sampling_rate` attributes, since only one value per attribute is kept on the `Units` container. @rly [#2162](https://github.com/NeurodataWithoutBorders/pynwb/issues/2162)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 - Added support for NWB Schema 2.11.0
   - The `unit` attribute of `Units.waveform_mean`, `Units.waveform_sd`, and `Units.waveforms` now has a default value of `"volts"` instead of a fixed value of `"volts"`.
   - `Units.waveform_mean`, `Units.waveform_sd`, and `Units.waveforms` have a new optional `time_before_peak_in_ms` attribute, exposed as the `waveform_time_before_peak_in_ms` argument and field of `Units`. It holds the time, in milliseconds, from the start of each waveform to the spike peak, i.e., the alignment point used during spike sorting. @rly [#2237](https://github.com/NeurodataWithoutBorders/pynwb/pull/2237)
-  - Incorporates HDMF Common Schema 1.10.0, which changes `MeaningsTable.target` from a link to an object-reference attribute.
-- Raised the minimum HDMF requirement to 6.2.0. HDMF 6.2.0 bundles HDMF Common Schema 1.10.0, matching the copy in NWB Schema 2.11.0, and writes the `unit` and `time_before_peak_in_ms` attributes on the `Units` waveform columns correctly. Under HDMF 6.1.0 those attributes fell back to their schema defaults on write. @rly
+  - Incorporates HDMF Common Schema 1.10.0, which changes `MeaningsTable.target` from a link to an object-reference attribute. @rly [#2244](https://github.com/NeurodataWithoutBorders/pynwb/pull/2244)
+- Raised the minimum HDMF requirement to 6.2.0. HDMF 6.2.0 bundles HDMF Common Schema 1.10.0, matching the copy in NWB Schema 2.11.0. @rly [#2244](https://github.com/NeurodataWithoutBorders/pynwb/pull/2244)
 
 ### Fixed
 - Fixed `Units.waveform_unit` having no effect on the written file. The `waveform_unit` passed to `Units` is now written to the `waveform_mean`, `waveform_sd`, and `waveforms` columns, and `"volts"` remains the default. PyNWB now also warns when the waveform columns of a file being read carry different `unit` or `sampling_rate` attributes, since only one value per attribute is kept on the `Units` container. @rly [#2162](https://github.com/NeurodataWithoutBorders/pynwb/issues/2162)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -193,6 +193,7 @@ linkcheck_ignore = [
     r'https://training.incf.org/*',  # temporary ignore until SSL certificate issue is resolved
     r'https://scicrunch.org/*',  # scicrunch.org blocks automated requests with 403
     r'https://app\.readthedocs\.org/projects/pynwb/.*',  # readthedocs blocks CI runner IPs (intermittent 403)
+    r'https://nwb-users\.slack\.com/*',  # Slack returns 403 to unauthenticated requests
 ]
 
 suppress_warnings = ["config.cache"]

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -6,7 +6,7 @@ channels:
 dependencies:
   - python==3.14
   - h5py==3.16.0
-  - hdmf==6.1.0
+  - hdmf==6.2.0
   - matplotlib==3.11.0
   - numpy==2.4.3
   - pandas==2.3.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 dependencies = [
     "h5py>=3.6.0",
-    "hdmf>=6.1.0,<7",
+    "hdmf>=6.2.0,<7",
     "numpy>=1.24.0",
     "pandas>=1.4.0",
     "python-dateutil>=2.8.2",


### PR DESCRIPTION
Updates the `nwb-schema` submodule to the NWB Schema 2.11.0 release candidate and raises the minimum HDMF version to 6.2.0.

Companion to NeurodataWithoutBorders/nwb-schema#710, which covers the "Ensure PyNWB and MatNWB have branches that have passing tests" item on that release checklist.

### Changes

- Pointed `src/pynwb/nwb-schema` at `f7dae71` ("Prepare 2.11.0 release"), which sets the schema version to 2.11.0 and brings in HDMF Common Schema 1.10.0.
- Raised `hdmf` from `>=6.1.0,<7` to `>=6.2.0,<7` in `pyproject.toml`, and pinned `environment-ros3.yml` to `hdmf==6.2.0`.
- Updated the changelog entry to name 2.11.0 and record the `MeaningsTable.target` change and the HDMF floor bump.

### Why HDMF 6.2.0 is required

NWB Schema 2.11.0 carries HDMF Common Schema 1.10.0, which changes `MeaningsTable.target` from a link to an object-reference attribute. HDMF 6.2.0 bundles that same schema version (`e7f84f0`), so the Python-side `MeaningsTable` definition matches. HDMF 6.1.0 bundles 1.9.0 and still treats `target` as a link.

HDMF 6.2.0 also fixes writing the `unit` and `time_before_peak_in_ms` attributes on the `Units` waveform columns. Under 6.1.0 both fell back to their schema defaults on write, so `TestUnitsCustomWaveformUnitIO` and `TestUnitsWaveformTimeBeforePeakIO` failed on `dev` regardless of which schema commit the submodule pointed at.

### Testing

Full suite run locally against schema 2.11.0 with HDMF 6.2.0:

```
848 passed, 15 skipped, 19 warnings, 6768 subtests passed
```

For comparison, the same suite on `dev` with HDMF 6.1.0 gives 8 failed, 844 passed, 6764 subtests passed. All 8 failures are the two waveform test classes described above and are resolved by the HDMF bump.

### Before merging

The submodule points at a commit on the `prepare_2.11.0` branch of nwb-schema, not a tag. Retarget it at the `2.11.0` tag once nwb-schema#710 merges and the tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
