### PR TITLE
Fix `TimeSeriesReference.timestamps` for series that store `starting_time` and `rate`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - Fixed reading a file whose dates carry a sub-minute UTC offset (e.g. `1900-10-01T00:00:00-05:50:36`). @h-mayorquin [#2230](https://github.com/NeurodataWithoutBorders/pynwb/pull/2230)
 - Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. @bendichter [#2236](https://github.com/NeurodataWithoutBorders/pynwb/pull/2236)
 - Fixed `set_data_io` being silently ignored on `NWBData` subclasses (`GrayscaleImage`, `RGBImage`, `RGBAImage`, `ExternalImage`, `ImageReferences`, and `ScratchData`), so requested chunking and compression were dropped without warning and the datasets were written uncompressed. @h-mayorquin [#2233](https://github.com/NeurodataWithoutBorders/pynwb/pull/2233)
-- Fixed `TimeSeriesReference.timestamps` returning incorrect times for a `TimeSeries` that has `starting_time` and `rate` instead of `timestamps`. The sample index was multiplied by `rate` instead of divided by it. @h-mayorquin [#2245](https://github.com/NeurodataWithoutBorders/pynwb/pull/2245)
+- Fixed `TimeSeriesReference.timestamps` returning incorrect times for a `TimeSeries` that has `starting_time` and `rate` instead of `timestamps`. The sample index was multiplied by `rate` instead of divided by it. @h-mayorquin @rly [#2245](https://github.com/NeurodataWithoutBorders/pynwb/pull/2245)
 
 
 ## PyNWB 4.1.0 (July 23, 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed reading a file whose dates carry a sub-minute UTC offset (e.g. `1900-10-01T00:00:00-05:50:36`). @h-mayorquin [#2230](https://github.com/NeurodataWithoutBorders/pynwb/pull/2230)
 - Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. @bendichter [#2236](https://github.com/NeurodataWithoutBorders/pynwb/pull/2236)
 - Fixed `set_data_io` being silently ignored on `NWBData` subclasses (`GrayscaleImage`, `RGBImage`, `RGBAImage`, `ExternalImage`, `ImageReferences`, and `ScratchData`), so requested chunking and compression were dropped without warning and the datasets were written uncompressed. @h-mayorquin [#2233](https://github.com/NeurodataWithoutBorders/pynwb/pull/2233)
+- Fixed `TimeSeriesReference.timestamps` returning incorrect times for a `TimeSeries` that has `starting_time` and `rate` instead of `timestamps`. The sample index was multiplied by `rate` instead of divided by it. @h-mayorquin [#2245](https://github.com/NeurodataWithoutBorders/pynwb/pull/2245)
 
 
 ## PyNWB 4.1.0 (July 23, 2026)

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -676,8 +676,8 @@ class TimeSeriesReference(NamedTuple):
             return self.timeseries.timestamps[self.idx_start: (self.idx_start + self.count)]
         # construct the timestamps from the starting_time and rate
         else:
-            start_time = self.timeseries.rate * self.idx_start + self.timeseries.starting_time
-            return np.arange(0, self.count) * self.timeseries.rate + start_time
+            start_time = self.idx_start / self.timeseries.rate + self.timeseries.starting_time
+            return np.arange(0, self.count) / self.timeseries.rate + start_time
 
     @property
     def data(self):

--- a/src/pynwb/base.py
+++ b/src/pynwb/base.py
@@ -676,8 +676,8 @@ class TimeSeriesReference(NamedTuple):
             return self.timeseries.timestamps[self.idx_start: (self.idx_start + self.count)]
         # construct the timestamps from the starting_time and rate
         else:
-            start_time = self.idx_start / self.timeseries.rate + self.timeseries.starting_time
-            return np.arange(0, self.count) / self.timeseries.rate + start_time
+            sample_indices = self.idx_start + np.arange(self.count)
+            return sample_indices / self.timeseries.rate + self.timeseries.starting_time
 
     @property
     def data(self):

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -949,7 +949,7 @@ class TestTimeSeriesReference(TestCase):
     def test_timestamps_property(self):
         # Timestamps from starting_time and rate
         tsr = TimeSeriesReference(5, 4, self._create_time_series_with_rate())
-        np.testing.assert_array_equal(tsr.timestamps, np.array([5.5, 5.6, 5.7, 5.8]))
+        np.testing.assert_array_equal(tsr.timestamps, np.array([55.0, 65.0, 75.0, 85.0]))
         # Timestamps from timestamps directly
         tsr = TimeSeriesReference(5, 4, self._create_time_series_with_timestamps())
         np.testing.assert_array_equal(tsr.timestamps, np.array([5.0, 6.0, 7.0, 8.0]))

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -856,7 +856,7 @@ class TestTimeSeriesReference(TestCase):
             data=np.arange(10),
             unit="unit",
             starting_time=5.0,
-            rate=0.1,
+            rate=100.0,
         )
         return ts
 
@@ -948,8 +948,11 @@ class TestTimeSeriesReference(TestCase):
 
     def test_timestamps_property(self):
         # Timestamps from starting_time and rate
-        tsr = TimeSeriesReference(5, 4, self._create_time_series_with_rate())
-        np.testing.assert_array_equal(tsr.timestamps, np.array([55.0, 65.0, 75.0, 85.0]))
+        ts = self._create_time_series_with_rate()
+        tsr = TimeSeriesReference(5, 4, ts)
+        np.testing.assert_array_equal(tsr.timestamps, np.array([5.05, 5.06, 5.07, 5.08]))
+        # The reconstructed timestamps are the same values that the referenced TimeSeries reports
+        np.testing.assert_array_equal(tsr.timestamps, ts.get_timestamps()[5:9])
         # Timestamps from timestamps directly
         tsr = TimeSeriesReference(5, 4, self._create_time_series_with_timestamps())
         np.testing.assert_array_equal(tsr.timestamps, np.array([5.0, 6.0, 7.0, 8.0]))


### PR DESCRIPTION
## Motivation

I was reading `TimeSeriesReference` and noticed that its `timestamps` property multiplies the sample index by `rate` where it should divide by it, so every timestamp reconstructed from `starting_time` and `rate` comes back off by a factor of `rate` squared. 

`TimeSeries.get_timestamps` does the right thing:
https://github.com/NeurodataWithoutBorders/pynwb/blob/b3d8d293/src/pynwb/base.py#L373
but they don't match.

I also changed a test that was freezing the old incorrect behavior.

## How to test the behavior?
```python
import numpy as np
from pynwb.base import TimeSeries, TimeSeriesReference

ts = TimeSeries(name="ts", description="d", data=np.arange(1000), unit="V", starting_time=0.0, rate=100.0)
tsr = TimeSeriesReference(100, 4, ts)

print(tsr.timestamps)
print(ts.get_timestamps()[100:104])
```
On `dev` the two lines disagree:
```
[10000. 10100. 10200. 10300.]
[1.   1.01 1.02 1.03]
```
With this PR both print `[1.   1.01 1.02 1.03]`.

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [x] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [x] Have you ensured the PR clearly describes the problem and the solution?
- [x] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [x] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [x] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
