### PR TITLE
Accept num_samples in OpticalSeries, OnePhotonSeries, and TwoPhotonSeries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed reading a file whose dates carry a sub-minute UTC offset (e.g. `1900-10-01T00:00:00-05:50:36`). @h-mayorquin [#2230](https://github.com/NeurodataWithoutBorders/pynwb/pull/2230)
 - Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. @bendichter [#2236](https://github.com/NeurodataWithoutBorders/pynwb/pull/2236)
 - Fixed `set_data_io` being silently ignored on `NWBData` subclasses (`GrayscaleImage`, `RGBImage`, `RGBAImage`, `ExternalImage`, `ImageReferences`, and `ScratchData`), so requested chunking and compression were dropped without warning and the datasets were written uncompressed. @h-mayorquin [#2233](https://github.com/NeurodataWithoutBorders/pynwb/pull/2233)
+- Fixed `OpticalSeries`, `OnePhotonSeries`, and `TwoPhotonSeries` not accepting `num_samples`, which made them impossible to construct with `format="external"` and `rate`, because that configuration requires `num_samples`. @rly [#2247](https://github.com/NeurodataWithoutBorders/pynwb/issues/2247)
 - Fixed `TimeSeriesReference.timestamps` returning incorrect times for a `TimeSeries` that has `starting_time` and `rate` instead of `timestamps`. The sample index was multiplied by `rate` instead of divided by it. @h-mayorquin @rly [#2245](https://github.com/NeurodataWithoutBorders/pynwb/pull/2245)
 
 ## PyNWB 4.1.0 (July 23, 2026)

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -416,9 +416,9 @@ class OpticalSeries(ImageSeries):
                      'dimension must be length 3 and represents the RGB value for color images. Either data or '
                      'external_file must be specified, but not both.'),
              'default': None},
-            *get_docval(ImageSeries.__init__, 'unit', 'format', 'external_file', 'starting_frame', 'bits_per_pixel',
-                        'dimension', 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate', 'comments',
-                        'description', 'control', 'control_description', 'device', 'offset'),
+            *get_docval(ImageSeries.__init__, 'unit', 'format', 'external_file', 'starting_frame', 'num_samples',
+                        'bits_per_pixel', 'dimension', 'resolution', 'conversion', 'timestamps', 'starting_time',
+                        'rate', 'comments', 'description', 'control', 'control_description', 'device', 'offset'),
             allow_positional=AllowPositional.WARNING,)
     def __init__(self, **kwargs):
         distance, field_of_view, orientation = popargs('distance', 'field_of_view', 'orientation', kwargs)

--- a/src/pynwb/ophys.py
+++ b/src/pynwb/ophys.py
@@ -207,6 +207,7 @@ class OnePhotonSeries(ImageSeries):
             ImageSeries.__init__,
             "external_file",
             "starting_frame",
+            "num_samples",
             "bits_per_pixel",
             "dimension",
             "resolution",
@@ -258,7 +259,7 @@ class TwoPhotonSeries(ImageSeries):
              'doc': 'Lines imaged per second. This is also stored in /general/optophysiology but is kept '
                     'here as it is useful information for analysis, and so good to be stored w/ the actual data.',
              'default': None},
-            *get_docval(ImageSeries.__init__, 'external_file', 'starting_frame', 'bits_per_pixel',
+            *get_docval(ImageSeries.__init__, 'external_file', 'starting_frame', 'num_samples', 'bits_per_pixel',
                         'dimension', 'resolution', 'conversion', 'timestamps', 'starting_time', 'rate',
                         'comments', 'description', 'control', 'control_description', 'device', 'offset'),
             allow_positional=AllowPositional.WARNING,)

--- a/tests/integration/hdf5/test_image.py
+++ b/tests/integration/hdf5/test_image.py
@@ -132,3 +132,31 @@ class TestOpticalSeriesOptionalFieldsIO(NWBH5IOMixin, TestCase):
         self.assertIsNone(self.optical_series.distance)
         self.assertIsNone(self.optical_series.field_of_view)
         self.assertIsNone(self.optical_series.orientation)
+
+
+class TestOpticalSeriesWithNumSamplesIO(NWBH5IOMixin, TestCase):
+    """Roundtrip test for OpticalSeries with num_samples (external file + rate timing)."""
+
+    def setUpContainer(self):
+        self.dev1 = Device(name='dev1')
+        self.optical_series = OpticalSeries(
+            name='OpticalSeries',
+            distance=8.,
+            field_of_view=(4., 5.),
+            orientation='upper left',
+            unit='m',
+            external_file=['external_file'],
+            starting_frame=[0],
+            format='external',
+            rate=30.0,
+            num_samples=900,
+            device=self.dev1,
+        )
+        return self.optical_series
+
+    def addContainer(self, nwbfile):
+        nwbfile.add_device(self.dev1)
+        nwbfile.add_stimulus(self.optical_series)
+
+    def getContainer(self, nwbfile):
+        return nwbfile.stimulus['OpticalSeries']

--- a/tests/integration/hdf5/test_ophys.py
+++ b/tests/integration/hdf5/test_ophys.py
@@ -167,6 +167,28 @@ class TestOnePhotonSeriesIO(AcquisitionH5IOMixin, TestCase):
         nwbfile.add_acquisition(self.container)
 
 
+class TestOnePhotonSeriesWithNumSamplesIO(AcquisitionH5IOMixin, TestCase):
+    """Roundtrip test for OnePhotonSeries with num_samples (external file + rate timing)."""
+
+    def setUpContainer(self):
+        self.device, self.optical_channel, self.imaging_plane = make_imaging_plane()
+        return OnePhotonSeries(
+            name='test_1ps_num_samples',
+            imaging_plane=self.imaging_plane,
+            unit='image_unit',
+            external_file=['external_file'],
+            starting_frame=[0],
+            format='external',
+            rate=30.0,
+            num_samples=900,
+        )
+
+    def addContainer(self, nwbfile):
+        nwbfile.add_device(self.device)
+        nwbfile.add_imaging_plane(self.imaging_plane)
+        nwbfile.add_acquisition(self.container)
+
+
 class TestTwoPhotonSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def setUpContainer(self):
@@ -191,6 +213,29 @@ class TestTwoPhotonSeriesIO(AcquisitionH5IOMixin, TestCase):
 
     def addContainer(self, nwbfile):
         """ Add the test TwoPhotonSeries as an acquisition and add Device and ImagingPlane to the given NWBFile """
+        nwbfile.add_device(self.device)
+        nwbfile.add_imaging_plane(self.imaging_plane)
+        nwbfile.add_acquisition(self.container)
+
+
+class TestTwoPhotonSeriesWithNumSamplesIO(AcquisitionH5IOMixin, TestCase):
+    """Roundtrip test for TwoPhotonSeries with num_samples (external file + rate timing)."""
+
+    def setUpContainer(self):
+        self.device, self.optical_channel, self.imaging_plane = make_imaging_plane()
+        return TwoPhotonSeries(
+            name='test_2ps_num_samples',
+            imaging_plane=self.imaging_plane,
+            unit='image_unit',
+            external_file=['external_file'],
+            starting_frame=[0],
+            format='external',
+            field_of_view=[2.0, 2.0, 5.0],
+            rate=30.0,
+            num_samples=900,
+        )
+
+    def addContainer(self, nwbfile):
         nwbfile.add_device(self.device)
         nwbfile.add_imaging_plane(self.imaging_plane)
         nwbfile.add_acquisition(self.container)

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -582,6 +582,23 @@ class OpticalSeriesConstructor(TestCase):
         self.assertIsNone(ts.field_of_view)
         self.assertIsNone(ts.orientation)
 
+    def test_num_samples(self):
+        """Test that num_samples can be set on an external-file OpticalSeries timed with rate."""
+        ts = OpticalSeries(
+            name='test_ts',
+            unit='unit',
+            distance=1.0,
+            field_of_view=[4, 5],
+            orientation='orientation',
+            external_file=['external_file'],
+            starting_frame=[0],
+            format='external',
+            rate=30.0,
+            num_samples=900,
+        )
+        self.assertEqual(ts.num_samples, 900)
+
+
 class TestImageSubtypes(TestCase):
 
     def test_grayscale_image(self):

--- a/tests/unit/test_ophys.py
+++ b/tests/unit/test_ophys.py
@@ -293,6 +293,21 @@ class OnePhotonSeriesConstructor(TestCase):
         self.assertEqual(one_photon_series.format, "external")
         self.assertIsNone(one_photon_series.dimension)
 
+    def test_num_samples(self):
+        """Test that num_samples can be set on an external-file OnePhotonSeries timed with rate."""
+        ip = create_imaging_plane()
+        one_photon_series = OnePhotonSeries(
+            name="test_one_photon_series",
+            unit="unit",
+            imaging_plane=ip,
+            external_file=["external_file"],
+            starting_frame=[0],
+            format="external",
+            rate=30.0,
+            num_samples=900,
+        )
+        self.assertEqual(one_photon_series.num_samples, 900)
+
     def test_negative_binning_assertion(self):
         ip = create_imaging_plane()
 
@@ -333,6 +348,21 @@ class TwoPhotonSeriesConstructor(TestCase):
         self.assertEqual(tPS.starting_frame, [0])
         self.assertEqual(tPS.format, 'external')
         self.assertIsNone(tPS.dimension)
+
+    def test_num_samples(self):
+        """Test that num_samples can be set on an external-file TwoPhotonSeries timed with rate."""
+        ip = create_imaging_plane()
+        tPS = TwoPhotonSeries(
+            name='test_tPS',
+            unit='unit',
+            imaging_plane=ip,
+            external_file=['external_file'],
+            starting_frame=[0],
+            format='external',
+            rate=30.0,
+            num_samples=900,
+        )
+        self.assertEqual(tPS.num_samples, 900)
 
 
 class MotionCorrectionConstructor(TestCase):


### PR DESCRIPTION
Fixes #2247.

`OpticalSeries`, `OnePhotonSeries`, and `TwoPhotonSeries` build their docvals by enumerating the inherited `ImageSeries` arguments by name, and `num_samples` was not added to those lists when it was introduced in #2194. Since `ImageSeries.__init__` raises when `format='external'` and `rate` is used for timing without `num_samples`, the three types were impossible to construct in that configuration.

Adds `num_samples` to the three argument lists, plus construction and roundtrip tests for each type. All three new unit tests and all six new roundtrip tests fail without the source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
