### PR TITLE
Derive ImageSeries.num_samples from timestamps for external-file series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fixed reading a file whose dates carry a sub-minute UTC offset (e.g. `1900-10-01T00:00:00-05:50:36`). @h-mayorquin [#2230](https://github.com/NeurodataWithoutBorders/pynwb/pull/2230)
 - Fixed wide pandas DataFrames in the tutorials spilling out of the content column and into the right margin. @bendichter [#2236](https://github.com/NeurodataWithoutBorders/pynwb/pull/2236)
 - Fixed `set_data_io` being silently ignored on `NWBData` subclasses (`GrayscaleImage`, `RGBImage`, `RGBAImage`, `ExternalImage`, `ImageReferences`, and `ScratchData`), so requested chunking and compression were dropped without warning and the datasets were written uncompressed. @h-mayorquin [#2233](https://github.com/NeurodataWithoutBorders/pynwb/pull/2233)
+- Fixed `ImageSeries.num_samples` returning `None` for an external-file series timed with `timestamps`, which also made `get_starting_time` and `get_duration` return `None` and made `TimeSeriesReferenceVectorData` skip its bounds checks against such a series. It now returns `len(timestamps)`. @rly [#2249](https://github.com/NeurodataWithoutBorders/pynwb/issues/2249)
 - Fixed `TimeSeriesReference.timestamps` returning incorrect times for a `TimeSeries` that has `starting_time` and `rate` instead of `timestamps`. The sample index was multiplied by `rate` instead of divided by it. @h-mayorquin @rly [#2245](https://github.com/NeurodataWithoutBorders/pynwb/pull/2245)
 
 ## PyNWB 4.1.0 (July 23, 2026)

--- a/src/pynwb/image.py
+++ b/src/pynwb/image.py
@@ -36,7 +36,7 @@ from hdmf.utils import (
 )
 
 from . import register_class, CORE_NAMESPACE
-from .base import TimeSeries, Image, Images
+from .base import TimeSeries, Image, Images, _get_num_samples
 from .device import Device
 
 
@@ -248,12 +248,12 @@ class ImageSeries(TimeSeries):
 
     @property
     def num_samples(self):
-        # Overrides TimeSeries.num_samples to return the stored attribute when set, because
-        # external-file series have empty data and len(data) would give 0 instead of the true count.
+        # The data of an external-file series is empty, so its frame count comes from the
+        # num_samples given at construction, and from the length of the timestamps otherwise.
         if self._num_samples is not None:
             return self._num_samples
         if self.external_file is not None:
-            return None
+            return _get_num_samples(self.timestamps)
         return super().num_samples
 
     @property

--- a/tests/unit/test_image.py
+++ b/tests/unit/test_image.py
@@ -388,6 +388,42 @@ class ImageSeriesConstructor(TestCase):
         num_samples_warnings = [x for x in w if 'num_samples' in str(x.message)]
         self.assertEqual(num_samples_warnings, [])
 
+    def test_num_samples_from_timestamps(self):
+        """Test that num_samples comes from the timestamps on an external-file ImageSeries."""
+        iS = ImageSeries(
+            name='test_iS',
+            external_file=['external_file'],
+            format='external',
+            unit='Frames',
+            starting_frame=[0],
+            timestamps=[1.0, 2.0, 3.0],
+        )
+        self.assertEqual(iS.num_samples, 3)
+        self.assertEqual(iS.get_starting_time(), 1.0)
+        self.assertEqual(iS.get_duration(), 2.0)
+
+    def test_num_samples_none_with_rate_construct_mode(self):
+        """Test that num_samples is None on an external-file ImageSeries timed with rate alone.
+
+        Old files written without num_samples carry no frame count that can be recovered.
+        """
+        obj = ImageSeries.__new__(
+            ImageSeries,
+            container_source=None,
+            parent=None,
+            object_id="test",
+            in_construct_mode=True,
+        )
+        obj.__init__(
+            name='test_iS',
+            external_file=['external_file'],
+            format='external',
+            unit='Frames',
+            starting_frame=[0],
+            rate=30.0,
+        )
+        self.assertIsNone(obj.num_samples)
+
     def test_bits_per_pixel_deprecation(self):
         """Test that bits_per_pixel can be set and that a deprecated warning is raised."""
         msg = "bits_per_pixel is deprecated"


### PR DESCRIPTION
Fixes #2249.

`ImageSeries.num_samples` returned `None` as soon as `external_file` was set, which skipped the `len(timestamps)` fallback in `TimeSeries.num_samples`. `get_starting_time` and `get_duration` then returned `None`, and `TimeSeriesReferenceVectorData` and `IntracellularRecordingsTable` skipped their `idx_start`/`count` bounds checks against such a series.

The frame count now comes from the timestamps when they are present. `_get_num_samples(None)` returns `None`, so an external-file series timed with `starting_time`/`rate` and no explicit `num_samples` still reports `None`.

One consequence to be aware of: the `num_samples` dataset is written from this property, so an external-file series timed with `timestamps` now persists a `num_samples` the schema doc describes as unnecessary in that case. #2239 moves the write path onto the explicitly provided value and removes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
