### PR TITLE
Illustrate usage of add_ref_container in HERD tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Raised the minimum HDMF requirement to 6.2.0. HDMF 6.2.0 bundles HDMF Common Schema 1.10.0, matching the copy in NWB Schema 2.11.0. @rly [#2244](https://github.com/NeurodataWithoutBorders/pynwb/pull/2244)
 
 ### Added
-- Added a section to the "How to Configure Term Validations" tutorial showing how to populate a `HERD` from the fields that a loaded type configuration wraps with a `TermSetWrapper`. It covers `HERD.add_ref_container` to walk an `NWBFile` and add a reference for every wrapped field, `HERD.to_dataframe` to inspect the result, and `HERD.add_ref_termset` to add a reference for a single field. @oruebel [#2251](https://github.com/NeurodataWithoutBorders/pynwb/pull/2251)
+- Added a section to the "How to Configure Term Validations" tutorial showing how to populate a `HERD` from the fields that a loaded type configuration wraps with a `TermSetWrapper`. @oruebel [#2251](https://github.com/NeurodataWithoutBorders/pynwb/pull/2251)
 
 ### Fixed
 - Fixed `Units.waveform_unit` having no effect on the written file. The `waveform_unit` passed to `Units` is now written to the `waveform_mean`, `waveform_sd`, and `waveforms` columns, and `"volts"` remains the default. PyNWB now also warns when the waveform columns of a file being read carry different `unit` or `sampling_rate` attributes, since only one value per attribute is kept on the `Units` container. @rly [#2162](https://github.com/NeurodataWithoutBorders/pynwb/issues/2162)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - Incorporates HDMF Common Schema 1.10.0, which changes `MeaningsTable.target` from a link to an object-reference attribute. @rly [#2244](https://github.com/NeurodataWithoutBorders/pynwb/pull/2244)
 - Raised the minimum HDMF requirement to 6.2.0. HDMF 6.2.0 bundles HDMF Common Schema 1.10.0, matching the copy in NWB Schema 2.11.0. @rly [#2244](https://github.com/NeurodataWithoutBorders/pynwb/pull/2244)
 
+### Added
+- Added a section to the "How to Configure Term Validations" tutorial showing how to populate a `HERD` from the fields that a loaded type configuration wraps with a `TermSetWrapper`. It covers `HERD.add_ref_container` to walk an `NWBFile` and add a reference for every wrapped field, `HERD.to_dataframe` to inspect the result, and `HERD.add_ref_termset` to add a reference for a single field. @oruebel [#2251](https://github.com/NeurodataWithoutBorders/pynwb/pull/2251)
+
 ### Fixed
 - Fixed `Units.waveform_unit` having no effect on the written file. The `waveform_unit` passed to `Units` is now written to the `waveform_mean`, `waveform_sd`, and `waveforms` columns, and `"volts"` remains the default. PyNWB now also warns when the waveform columns of a file being read carry different `unit` or `sampling_rate` attributes, since only one value per attribute is kept on the `Units` container. @rly [#2162](https://github.com/NeurodataWithoutBorders/pynwb/issues/2162)
 - Fixed `mock_DeviceModel` defaulting `manufacturer` to `None`. The mock now defaults it to `"manufacturer"`. @HugoFara [#2232](https://github.com/NeurodataWithoutBorders/pynwb/pull/2232)

--- a/docs/gallery/general/plot_configurator.py
+++ b/docs/gallery/general/plot_configurator.py
@@ -112,6 +112,47 @@ nwbfile.subject = subject
 # current configuration.
 config = get_loaded_type_config()
 
+####################################
+# How to populate HERD from TermSet-wrapped fields
+# -------------------------------------------------
+# Since ``experimenter`` and ``species`` are validated against a
+# :py:class:`~hdmf.term_set.TermSet`, PyNWB can automatically populate a
+# :py:class:`~pynwb.resources.HERD` (HDMF External Resources Data Structure) with references
+# derived from those :py:class:`~hdmf.term_set.TermSetWrapper` fields, without having to manually
+# specify the ``entity_id`` and ``entity_uri`` for each value.
+#
+# Use :py:meth:`~pynwb.file.NWBFile.get_external_resources` to get (or create) the file's HERD,
+# then call :py:meth:`~hdmf.common.resources.HERD.add_ref_container` on the ``NWBFile``. This walks
+# through all of the objects contained in the file, finds every field wrapped with a
+# :py:class:`~hdmf.term_set.TermSetWrapper`, looks up the matching entity in the associated
+# :py:class:`~hdmf.term_set.TermSet`, and adds the corresponding reference to HERD automatically.
+
+herd = nwbfile.get_external_resources()
+herd.add_ref_container(root_container=nwbfile)
+
+####################################
+# Inspect the populated HERD
+# --------------------------
+# :py:meth:`~hdmf.common.resources.HERD.to_dataframe` flattens the interlinked HERD tables into a
+# single :py:class:`~pandas.DataFrame`, showing one row per (object, key, entity) reference. Note
+# that both the ``experimenter`` reference on the ``NWBFile`` and the ``species`` reference on the
+# ``Subject`` were added automatically.
+herd.to_dataframe()
+
+####################################
+# If instead you only want to add a reference for a single, specific field rather than searching
+# the whole file, use :py:meth:`~hdmf.common.resources.HERD.add_ref_termset` directly on that
+# field, e.g.:
+#
+# .. code-block:: python
+#
+#     herd.add_ref_termset(
+#         container=subject,
+#         attribute="species",
+#         termset=subject.fields["species"].termset,
+#         key=subject.fields["species"].value,
+#     )
+
 ######################################
 # How to unload the Configuration file
 # ------------------------------------


### PR DESCRIPTION
## Motivation

The PyNWB tutorials currently don't show usage of `add_ref_container` for populating `HERD` when a term set configuration is used. 

## Checklist

- [x] Did you update CHANGELOG.md with your changes?
- [X] Have you checked our [Contributing](https://github.com/NeurodataWithoutBorders/pynwb/blob/dev/docs/CONTRIBUTING.rst) document?
- [X] Have you ensured the PR clearly describes the problem and the solution?
- [X] Is your contribution compliant with our coding style? This can be checked running `ruff check . && codespell` from the source directory.
- [X] Have you checked to ensure that there aren't other open [Pull Requests](https://github.com/NeurodataWithoutBorders/pynwb/pulls) for the same change?
- [X] Have you included the relevant issue number using "Fix #XXX" notation where XXX is the issue number? By including "Fix #XXX" you allow GitHub to close issue #XXX when the PR is merged.
