### PR TITLE
Fix stale NWBFile.objects cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Fixed
 - Fixed `FeatureExtraction.times` and `Clustering.peak_over_rms` being copied into a Python list on construction, which was slow for data read from a file. @cboulay [#2253](https://github.com/NeurodataWithoutBorders/pynwb/pull/2253)
+- Fixed `NWBFile.objects` becoming stale after containers were added to or removed from the file, including mutations made through nested containers. The object mapping is now rebuilt whenever it is accessed. @AtomicGlance [#2242](https://github.com/NeurodataWithoutBorders/pynwb/issues/2242)
 - Fixed `ElectricalSeries.__init__`, `TimeSeries.get_timestamps`, and `TimeSeries.num_samples` failing on data backed by a zarr array. @rly [#2235](https://github.com/NeurodataWithoutBorders/pynwb/pull/2235)
 - Fixed `TimeSeries.num_samples` returning `None` when the data or timestamps are backed by a `DataChunkIterator` that wraps an array. @rly [#2235](https://github.com/NeurodataWithoutBorders/pynwb/pull/2235)
 - Fixed `Units.waveform_unit` having no effect on the written file. It is now written to the `unit` attribute of the `waveform_mean`, `waveform_sd`, and `waveforms` columns, and still defaults to `"volts"`. Reading a file whose waveform columns carry different `unit` or `sampling_rate` attributes now warns, since `Units` keeps a single value for each. @rly [#2237](https://github.com/NeurodataWithoutBorders/pynwb/pull/2237)

--- a/src/pynwb/file.py
+++ b/src/pynwb/file.py
@@ -586,8 +586,10 @@ class NWBFile(MultiContainerInterface, HERDManager):
 
     @property
     def objects(self):
-        if self.__obj is None:
-            self.all_children()
+        # Containers can be added to or removed from nested parents without
+        # notifying the NWBFile, so a cached mapping cannot be invalidated
+        # reliably. Rebuild it to keep this view in sync with the file.
+        self.all_children()
         return self.__obj
 
     @property

--- a/tests/unit/test_file.py
+++ b/tests/unit/test_file.py
@@ -444,6 +444,33 @@ class NWBFileTest(TestCase):
         self.assertIn(device, children)
         self.assertIn(elecgrp, children)
 
+    def test_objects_updated_after_adding_container(self):
+        ts = TimeSeries(name='added', data=[0, 1], unit='grams', timestamps=[0.0, 1.0])
+        self.nwbfile.objects
+
+        self.nwbfile.add_acquisition(ts)
+
+        self.assertIs(self.nwbfile.objects[ts.object_id], ts)
+
+    def test_objects_updated_after_removing_container(self):
+        ts = TimeSeries(name='removed', data=[0, 1], unit='grams', timestamps=[0.0, 1.0])
+        self.nwbfile.add_acquisition(ts)
+        self.nwbfile.objects
+
+        del self.nwbfile.acquisition[ts.name]
+        ts.reset_parent()
+
+        self.assertNotIn(ts.object_id, self.nwbfile.objects)
+
+    def test_objects_updated_after_adding_nested_container(self):
+        module = self.nwbfile.create_processing_module(name='behavior', description='')
+        self.nwbfile.objects
+        ts = TimeSeries(name='nested', data=[0, 1], unit='grams', timestamps=[0.0, 1.0])
+
+        module.add(ts)
+
+        self.assertIs(self.nwbfile.objects[ts.object_id], ts)
+
     def test_fail_if_source_script_file_name_without_source_script(self):
         with self.assertRaises(ValueError):
             # <-- source_script_file_name without source_script is not allowed


### PR DESCRIPTION
## Motivation

`NWBFile.objects` is populated on first access but is not refreshed when containers are added to or removed from the file. This leaves callers with a stale object mapping, including when a nested `ProcessingModule` is modified. A stale mapping can cause downstream writers and integrations to miss newly added containers.

## How to test the behavior?

The object mapping is now rebuilt each time `NWBFile.objects` is accessed. Regression tests cover direct additions, removals, and additions through a nested processing module, while preserving the existing object instances.

## Checklist

- [x] Updated `CHANGELOG.md`.
- [x] The PR clearly describes the problem and the solution.
- [x] The relevant issue is linked with `Fix #2242`.
- [x] `ruff check src/pynwb/file.py tests/unit/test_file.py` passes.
- [x] `PYTHONPATH=src python -m pytest tests/unit/test_file.py -q` passes (63 tests).
