### PR TITLE
Fix NaN handling for TimeIntervals bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 - Added `model` and `serial_number` parameters to `mock_Device`. Passing a `DeviceModel` as `model` together with an `nwbfile` also places that `DeviceModel` in the `NWBFile`, so the link resolves when the file is written. @rly [#2238](https://github.com/NeurodataWithoutBorders/pynwb/pull/2238)
 
 ### Fixed
-- Fixed `FeatureExtraction.times` and `Clustering.peak_over_rms` being copied into a Python list on construction, which was slow for data read from a file. @cboulay [#2253](https://github.com/NeurodataWithoutBorders/pynwb/pull/2253)
+- Fixed `TimeIntervals.get_starting_time` and `get_duration` returning NaN whenever a time column contained NaN values. NaN values are now ignored when calculating the observed interval span. @AtomicGlance [#2212](https://github.com/NeurodataWithoutBorders/pynwb/issues/2212)
+- Fixed `FeatureExtraction.times` and `Clustering.peak_over_rms` being copied into a Python list on construction, which read the backing dataset one element at a time. @cboulay [#2253](https://github.com/NeurodataWithoutBorders/pynwb/pull/2253)
 - Fixed `ElectricalSeries.__init__`, `TimeSeries.get_timestamps`, and `TimeSeries.num_samples` failing on data backed by a zarr array. @rly [#2235](https://github.com/NeurodataWithoutBorders/pynwb/pull/2235)
 - Fixed `TimeSeries.num_samples` returning `None` when the data or timestamps are backed by a `DataChunkIterator` that wraps an array. @rly [#2235](https://github.com/NeurodataWithoutBorders/pynwb/pull/2235)
 - Fixed `Units.waveform_unit` having no effect on the written file. It is now written to the `unit` attribute of the `waveform_mean`, `waveform_sd`, and `waveforms` columns, and still defaults to `"volts"`. Reading a file whose waveform columns carry different `unit` or `sampling_rate` attributes now warns, since `Units` keeps a single value for each. @rly [#2237](https://github.com/NeurodataWithoutBorders/pynwb/pull/2237)

--- a/src/pynwb/epoch.py
+++ b/src/pynwb/epoch.py
@@ -91,30 +91,46 @@ class TimeIntervals(DynamicTable):
         Returns
         -------
         float or None
-            The earliest start time in seconds, or None if the table is empty.
+            The earliest non-NaN start time in seconds, or None if the table is
+            empty or contains no valid start times.
         """
         if len(self) == 0:
             return None
-        # NOTE: Could be optimized to self['start_time'].data[0] if intervals are guaranteed sorted
-        return float(np.min(self['start_time'].data[:]))
+        start_times = np.asarray(self['start_time'].data[:])
+        if np.isnan(start_times).all():
+            return None
+        return float(np.nanmin(start_times))
 
     def get_duration(self):
         """
-        Get the total duration from the earliest start time to the latest stop time.
+        Get the total duration from the earliest start time to the latest known
+        interval boundary.
 
         Returns
         -------
         float or None
-            The duration in seconds, or None if the table is empty.
+            The duration in seconds, or None if the table is empty. If no
+            interval has a valid start time, the duration is NaN.
 
         Notes
         -----
-        The duration represents the time span from the earliest interval start to the
-        latest interval stop, not the sum of individual interval durations.
+        The duration represents the time span from the earliest valid interval
+        start to the latest valid start or stop time, not the sum of individual
+        interval durations. NaN values are ignored. Including valid starts in
+        the upper bound keeps an ongoing interval with a missing stop time from
+        shortening the table's observed span.
         """
         if len(self) == 0:
             return None
-        starting_time = self.get_starting_time()
-        # NOTE: Could be optimized to self['stop_time'].data[-1] if intervals are guaranteed sorted
-        stopping_time = float(np.max(self['stop_time'].data[:]))
+        start_times = np.asarray(self['start_time'].data[:])
+        stop_times = np.asarray(self['stop_time'].data[:])
+
+        valid_starts = start_times[~np.isnan(start_times)]
+        if valid_starts.size == 0:
+            return float('nan')
+
+        valid_stops = stop_times[~np.isnan(stop_times)]
+        starting_time = float(np.nanmin(valid_starts))
+        known_boundaries = np.concatenate((valid_starts, valid_stops))
+        stopping_time = float(np.nanmax(known_boundaries))
         return stopping_time - starting_time

--- a/tests/unit/test_epoch.py
+++ b/tests/unit/test_epoch.py
@@ -217,6 +217,21 @@ class TimeIntervalsTest(TestCase):
         ti = TimeIntervals(name='ti_name')
         self.assertIsNone(ti.get_starting_time())
 
+    def test_get_starting_time_ignores_nan(self):
+        """Test get_starting_time ignores NaN start times"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=np.nan, stop_time=1.0)
+        ti.add_interval(start_time=2.0, stop_time=3.0)
+        ti.add_interval(start_time=1.0, stop_time=2.0)
+        self.assertEqual(ti.get_starting_time(), 1.0)
+
+    def test_get_starting_time_all_nan(self):
+        """Test get_starting_time returns None when all starts are NaN"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=np.nan, stop_time=1.0)
+        ti.add_interval(start_time=np.nan, stop_time=2.0)
+        self.assertIsNone(ti.get_starting_time())
+
     def test_get_starting_time_single_interval(self):
         """Test get_starting_time with single interval"""
         ti = TimeIntervals(name='ti_name')
@@ -236,6 +251,27 @@ class TimeIntervalsTest(TestCase):
         """Test get_duration returns None for empty table"""
         ti = TimeIntervals(name='ti_name')
         self.assertIsNone(ti.get_duration())
+
+    def test_get_duration_ignores_nan_stop_and_uses_later_start(self):
+        """Test get_duration includes a later start when its stop is NaN"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=0.0, stop_time=1.0)
+        ti.add_interval(start_time=2.0, stop_time=np.nan)
+        self.assertEqual(ti.get_duration(), 2.0)
+
+    def test_get_duration_all_nan_stops_uses_start_span(self):
+        """Test get_duration falls back to the span of valid starts"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=2.0, stop_time=np.nan)
+        ti.add_interval(start_time=5.0, stop_time=np.nan)
+        self.assertEqual(ti.get_duration(), 3.0)
+
+    def test_get_duration_all_nan_starts_returns_nan(self):
+        """Test get_duration returns NaN when no valid start exists"""
+        ti = TimeIntervals(name='ti_name')
+        ti.add_interval(start_time=np.nan, stop_time=1.0)
+        ti.add_interval(start_time=np.nan, stop_time=np.nan)
+        self.assertTrue(np.isnan(ti.get_duration()))
 
     def test_get_duration_single_interval(self):
         """Test get_duration with single interval"""


### PR DESCRIPTION
Fixes #2212

## What changed

- Ignore NaN start times in TimeIntervals.get_starting_time.
- Calculate duration from the earliest valid start to the latest known start or stop boundary, so an ongoing interval with a missing stop does not shorten the observed span.
- Return None for an empty table and NaN when no valid start time exists.
- Add regression coverage for mixed and all-NaN inputs and document the behavior in the upcoming changelog.

## Testing

- `python -m pytest tests/unit/test_epoch.py -q` — 26 passed
- `ruff check src/pynwb/epoch.py tests/unit/test_epoch.py` — passed
- The broader unit suite reports 594 passed and 2 skipped; its only failures are the existing typemap-cache tests, which require the missing NWB schema submodule in this partial checkout.