### PR TITLE
Fix PyPI upload rejecting metadata 2.5 and gate it in CI

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/release.md
@@ -6,6 +6,12 @@ Prepare for release of PyNWB [version]
   versions in `environment-ros3.yml` to the latest as needed. The `zarr` and `numcodecs` upper bounds in the
   `zarr` extra track hdmf-zarr's own bounds. Check hdmf-zarr's requirements before touching them rather than
   raising them to the latest release.
+- [ ] Update the actions referenced in `.github/workflows/` to their latest releases. `pypa/gh-action-pypi-publish`
+  validates the distributions with the `twine` and `packaging` versions it bundles, and an outdated release rejects
+  metadata that current build backends emit. Set the `twine` pin in the "Check distribution metadata" steps to the
+  version in the action's
+  [`requirements/runtime.txt`](https://github.com/pypa/gh-action-pypi-publish/blob/release/v1/requirements/runtime.txt)
+  (the `release/v1` branch tracks the latest v1 release).
 - [ ] Major releases: Remove the deprecated functionality slated for removal in this version.
 - [ ] Check legal file dates and information in `Legal.txt`, `license.txt`, `README.rst`, `docs/source/conf.py`,
   and any other locations as needed

--- a/.github/workflows/deploy_release.yml
+++ b/.github/workflows/deploy_release.yml
@@ -42,6 +42,13 @@ jobs:
           tox -e build
           ls -1 dist
 
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload below apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
+
       - name: Test installation from a wheel
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
@@ -56,7 +63,10 @@ jobs:
         # Publishes to PyPI via OIDC trusted publishing. The pynwb project on PyPI must have a trusted
         # publisher configured for the NeurodataWithoutBorders/pynwb repository, the deploy_release.yml
         # workflow, and the pypi environment.
-        uses: pypa/gh-action-pypi-publish@v1.14.1
+        # This action validates the distributions with the twine and packaging versions pinned in its
+        # requirements/runtime.txt. When bumping it, set the twine pin in the "Check distribution
+        # metadata" steps of this workflow, run_tests.yml, and run_all_tests.yml to match.
+        uses: pypa/gh-action-pypi-publish@v1.14.2
         with:
           skip-existing: true
 

--- a/.github/workflows/run_all_tests.yml
+++ b/.github/workflows/run_all_tests.yml
@@ -73,6 +73,13 @@ jobs:
           tox -e build
           ls -1 dist
 
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload in deploy_release.yml apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
+
       - name: Test installation from a wheel
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
@@ -166,6 +173,13 @@ jobs:
         run: |
           tox -e build
           ls -1 dist
+
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload in deploy_release.yml apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
 
       - name: Test installation from a wheel
         run: |

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -55,6 +55,13 @@ jobs:
           tox -e build
           ls -1 dist
 
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload in deploy_release.yml apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
+
       - name: Test installation from a wheel
         run: |
           tox -e wheelinstall --recreate --installpkg dist/*-none-any.whl
@@ -145,6 +152,13 @@ jobs:
         run: |
           tox -e build
           ls -1 dist
+
+      - name: Check distribution metadata
+        # twine is pinned to the version bundled in pypa/gh-action-pypi-publish so that this check
+        # and the upload in deploy_release.yml apply the same metadata validation.
+        run: |
+          python -m pip install twine==7.0.0
+          python -m twine check --strict dist/*
 
       - name: Test installation from a wheel
         run: |

--- a/environment-ros3.yml
+++ b/environment-ros3.yml
@@ -12,6 +12,10 @@ dependencies:
   - hdmf==6.2.0
   - matplotlib==3.11.1
   - numpy==2.5.2
+  # Supplies a prebuilt numcodecs for the conda-forge python, which cannot compile the sdist. PyPI
+  # has no wheel for this python within the numcodecs bound of the zarr extra, so keep this version
+  # inside that bound (see pyproject.toml).
+  - numcodecs==0.15.1
   - pandas==3.0.5
   - python-dateutil==2.9.0.post0
   - setuptools


### PR DESCRIPTION
The 4.2.0 tag build never published. hatchling 1.32.0 emits `Metadata-Version: 2.5` by default, and `pypa/gh-action-pypi-publish@v1.14.1` pins twine 6.1.0 / packaging 25.0, which only recognize metadata up to 2.4. The upload failed with `InvalidDistribution` ([log](https://github.com/NeurodataWithoutBorders/pynwb/actions/runs/33671348841/job/100385448887)). v1.14.2 pins twine 7.0.0 / packaging 26.2. Upstream context: pypa/twine#1327.

`deploy_release.yml` only runs on a tag, so nothing in PR CI built a distribution and checked its metadata. This adds a `Check distribution metadata` step next to each build step, pinned to the twine the publish action bundles so the gate matches the upload.

Also pins `numcodecs==0.15.1` in `environment-ros3.yml`, unrelated to the above. numcodecs publishes no cp314 wheel within the bound the `zarr` extra sets, so pip compiled the sdist inside the conda environment, where the conda-forge python's CFLAGS reach gcc as an unrecognized `-partition=none`. conda-forge has a prebuilt 0.15.1 for python 3.14 on linux-64.

The `4.2.0` tag has been deleted from origin so the release can be re-cut once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)